### PR TITLE
Update fullcolor apps icons with new icons

### DIFF
--- a/icons/src/fullcolor/default/apps/calendar-app.svg
+++ b/icons/src/fullcolor/default/apps/calendar-app.svg
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="calendar-app.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="152.0926"
-     inkscape:cy="62.914244"
-     inkscape:current-layer="layer4"
+     inkscape:zoom="2"
+     inkscape:cx="357.5"
+     inkscape:cy="169.5"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -91,306 +92,142 @@
   </sodipodi:namedview>
   <defs
      id="defs3">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1686"
-       x1="319.99991"
-       y1="108.00015"
-       x2="367.99991"
-       y2="108.00015"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000119)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1688"
-       x1="320.00003"
-       y1="164.00002"
-       x2="352.00003"
-       y2="164.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00002,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1690"
-       x1="319.9993"
-       y1="211.99928"
-       x2="343.9993"
-       y2="211.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1692"
-       x1="320.00031"
-       y1="252.00034"
-       x2="336.00031"
-       y2="252.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1694"
-       x1="38.309559"
-       y1="270.69043"
-       x2="263.99759"
-       y2="267.99701"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,151.9973,155.9997)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1692-6"
-       x1="321.00031"
-       y1="244.00034"
-       x2="335.00031"
-       y2="244.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1690-9"
-       x1="320.9993"
-       y1="199.99928"
-       x2="342.9993"
-       y2="199.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1688-4"
-       x1="322"
-       y1="148.00002"
-       x2="350"
-       y2="148.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00001,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1686-0"
-       x1="321.99991"
-       y1="84.000153"
-       x2="365.99991"
-       y2="84.000153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000125)" />
     <filter
        inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
-       id="filter58449"
-       x="-0.047999425"
-       width="1.0959988"
-       y="-0.048000575"
-       height="1.0960012">
+       id="filter864"
+       x="-0.017910021"
+       width="1.03582"
+       y="-0.019350594"
+       height="1.0387012">
       <feGaussianBlur
          inkscape:collect="always"
-         stdDeviation="4.4800539"
-         id="feGaussianBlur58451" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58492"
-       x="-0.011999856"
-       width="1.0239997"
-       y="-0.012000144"
-       height="1.0240003">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1200135"
-         id="feGaussianBlur58494" />
+         stdDeviation="1.1358682"
+         id="feGaussianBlur866" />
     </filter>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient4338-7">
+       xlink:href="#linearGradient912"
+       id="linearGradient1112"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9291366,0,0,1.0010862,26.132962,-5.7087808)"
+       x1="132.29164"
+       y1="48.291653"
+       x2="132.29164"
+       y2="122.37498" />
+    <linearGradient
+       id="linearGradient912"
+       inkscape:collect="always">
       <stop
-         style="stop-color:#2b898f;stop-opacity:1"
+         id="stop908"
          offset="0"
-         id="stop4340-2" />
+         style="stop-color:#f85015;stop-opacity:1" />
       <stop
-         style="stop-color:#5bdbc1;stop-opacity:1"
+         id="stop910"
          offset="1"
-         id="stop4342-6" />
+         style="stop-color:#ee3009;stop-opacity:1" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient1002"
+       xlink:href="#linearGradient940"
+       id="linearGradient894"
+       x1="137.58331"
+       y1="117.08331"
+       x2="137.58331"
+       y2="334.04166"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.078125,0,0,0.08680555,320.16668,61.777783)"
-       x1="16"
-       y1="304"
-       x2="16"
-       y2="208" />
+       gradientTransform="matrix(0.9291366,0,0,1.0010861,26.132962,-5.7087738)" />
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4245">
+       id="linearGradient940">
       <stop
-         style="stop-color:#d9d9d9;stop-opacity:1"
+         id="stop936"
          offset="0"
-         id="stop4247" />
+         style="stop-color:#f6f7f7;stop-opacity:1" />
       <stop
-         style="stop-color:#ececec;stop-opacity:1"
+         id="stop938"
          offset="1"
-         id="stop4249" />
+         style="stop-color:#dce7f0;stop-opacity:1" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient21969"
+       xlink:href="#linearGradient912"
+       id="linearGradient573"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.046875,0,0,0.05208333,319.5,134.66668)"
-       x1="16"
-       y1="304"
-       x2="16"
-       y2="208" />
+       gradientTransform="matrix(0.19080483,0,0,0.2055802,318.1523,50.791947)"
+       x1="132.29164"
+       y1="48.291653"
+       x2="132.29164"
+       y2="122.37498" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient998"
+       xlink:href="#linearGradient940"
+       id="linearGradient575"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.046875,0,0,0.05208333,321.5,134.66668)"
-       x1="16"
-       y1="304"
-       x2="16"
-       y2="208" />
+       gradientTransform="matrix(0.19080483,0,0,0.20558018,318.1523,50.791949)"
+       x1="137.58331"
+       y1="117.08331"
+       x2="137.58331"
+       y2="334.04166" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient985"
+       xlink:href="#linearGradient912"
+       id="linearGradient585"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.03125,0,0,0.03472222,320.66667,235.11111)"
-       x1="16"
-       y1="304"
-       x2="16"
-       y2="208" />
+       gradientTransform="matrix(0.12443793,0,0,0.13407404,319.14281,126.34257)"
+       x1="132.29164"
+       y1="48.291653"
+       x2="132.29164"
+       y2="122.37498" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient21975"
+       xlink:href="#linearGradient940"
+       id="linearGradient587"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.03125,0,0,0.03472222,320.66667,191.11111)"
-       x1="16"
-       y1="304"
-       x2="16"
-       y2="208" />
+       gradientTransform="matrix(0.12443793,0,0,0.13407403,319.14281,126.34257)"
+       x1="137.58331"
+       y1="117.08331"
+       x2="137.58331"
+       y2="334.04166" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient4251-3"
-       x1="16"
-       y1="304"
-       x2="16"
-       y2="208"
+       xlink:href="#linearGradient912"
+       id="linearGradient597"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.03125,0,0,0.03472222,320.66667,191.11111)" />
+       gradientTransform="matrix(0.09540241,0,0,0.1027901,319.07615,183.39597)"
+       x1="132.29164"
+       y1="48.291653"
+       x2="132.29164"
+       y2="122.37498" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient4251"
-       x1="16"
-       y1="304"
-       x2="16"
-       y2="208"
+       xlink:href="#linearGradient940"
+       id="linearGradient599"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.375,0,0,0.41666666,16,49.333349)" />
+       gradientTransform="matrix(0.09540241,0,0,0.10279009,319.07615,183.39597)"
+       x1="137.58331"
+       y1="117.08331"
+       x2="137.58331"
+       y2="334.04166" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient21961"
+       xlink:href="#linearGradient912"
+       id="linearGradient609"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.375,0,0,0.41666666,32.0576,49.333349)"
-       x1="16"
-       y1="304"
-       x2="16"
-       y2="208" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter967"
-       x="-0.0071999999"
-       width="1.0144"
-       y="-0.035999998"
-       height="1.072">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.44"
-         id="feGaussianBlur969" />
-    </filter>
+       gradientTransform="matrix(0.06221897,0,0,0.06703702,319.57142,233.17127)"
+       x1="132.29164"
+       y1="48.291653"
+       x2="132.29164"
+       y2="122.37498" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4262"
-       id="linearGradient4268"
-       x1="0"
-       y1="258"
-       x2="0"
-       y2="208"
+       xlink:href="#linearGradient940"
+       id="linearGradient611"
        gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect"
-       gradientTransform="matrix(1,0,0,0.83333335,0,42.999994)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4262">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4264" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4266" />
-    </linearGradient>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4277"
-       x="-0.02775"
-       width="1.0555"
-       y="-0.1776"
-       height="1.3552001">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="5.92"
-         id="feGaussianBlur4279" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4262"
-       id="linearGradient26575"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.83333335,0,42.999994)"
-       x1="0"
-       y1="258"
-       x2="0"
-       y2="208"
-       spreadMethod="reflect" />
+       gradientTransform="matrix(0.06221897,0,0,0.06703702,319.57142,233.17127)"
+       x1="137.58331"
+       y1="117.08331"
+       x2="137.58331"
+       y2="334.04166" />
   </defs>
   <metadata
      id="metadata4">
@@ -402,13 +239,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -490,7 +327,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">calendar-app</tspan></text>
+           id="tspan924">calendar-app</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -525,322 +362,154 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
+      <rect
+         rx="10.592156"
+         y="45.681343"
+         x="41.374649"
+         height="220.63727"
+         width="221.25064"
+         id="rect1383"
+         style="display:inline;fill:url(#linearGradient894);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:20.0908;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         style="display:inline;fill:url(#linearGradient1112);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:20.0908;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new"
+         d="m 51.966652,45.681336 c -5.86805,0 -10.592,5.089743 -10.592,11.412193 V 111.50171 H 262.62535 V 57.093529 c 0,-6.32245 -4.72395,-11.412193 -10.59202,-11.412193 z m 70.279718,17.642873 c 2.35081,0 4.47114,0.43037 6.36098,1.29124 1.90522,0.86083 3.51849,2.09414 4.83985,3.69993 1.32137,1.60576 2.33544,3.55091 3.0422,5.83543 0.72206,2.28449 1.08321,4.85043 1.08321,7.69778 0,2.84738 -0.36115,5.41332 -1.08321,7.69782 -0.70678,2.28449 -1.72083,4.22965 -3.0422,5.83542 -1.32136,1.58922 -2.93463,2.81426 -4.83985,3.67509 -1.88984,0.86083 -4.01017,1.291261 -6.36098,1.291241 -2.35076,0 -4.47876,-0.430371 -6.384,-1.291241 -1.88985,-0.86083 -3.49544,-2.08587 -4.8168,-3.67509 -1.32135,-1.60577 -2.34312,-3.55091 -3.06524,-5.83542 -0.70678,-2.2845 -1.06015,-4.85044 -1.06015,-7.69782 0,-2.84735 0.35343,-5.41329 1.06015,-7.69778 0.722,-2.28452 1.74389,-4.22967 3.06524,-5.83543 1.32136,-1.60579 2.92695,-2.8391 4.8168,-3.69993 1.90524,-0.86083 4.03324,-1.29124 6.384,-1.29124 z m 34.22473,0 c 1.81302,0 3.49546,0.2897 5.04727,0.8691 1.56719,0.56277 2.95768,1.36575 4.17151,2.40866 1.21378,1.02638 2.21249,2.27624 2.9961,3.74959 0.79895,1.45678 1.32904,3.07913 1.59024,4.86699 h -4.19456 c -0.26111,-1.17535 -0.69131,-2.23484 -1.29061,-3.17845 -0.5838,-0.96013 -1.29832,-1.7796 -2.14339,-2.45834 -0.82968,-0.6787 -1.77461,-1.20018 -2.83476,-1.56436 -1.0448,-0.38068 -2.15871,-0.5711 -3.3418,-0.5711 -1.62866,0 -3.10368,0.33938 -4.42502,1.0181 -1.32137,0.6787 -2.45066,1.64716 -3.3879,2.9053 -0.92186,1.25813 -1.63632,2.77286 -2.14335,4.54419 -0.50701,1.75476 -0.76056,3.72475 -0.76056,5.90993 0,2.20174 0.24589,4.18826 0.73743,5.95957 0.50693,1.77133 1.22917,3.28606 2.16642,4.5442 0.93724,1.24159 2.06653,2.20174 3.3879,2.88048 1.32134,0.6787 2.80403,1.0181 4.44805,1.0181 1.21382,0 2.34314,-0.14894 3.38792,-0.44694 1.04478,-0.31442 1.97434,-0.76977 2.78868,-1.36573 0.81432,-0.5959 1.50572,-1.31608 2.07422,-2.16036 0.5838,-0.86081 1.02942,-1.83753 1.33671,-2.93012 h 4.19456 c -0.76822,3.5592 -2.33544,6.29069 -4.70158,8.19443 -2.36615,1.88722 -5.40066,2.830811 -9.10354,2.830811 -2.28934,0 -4.36356,-0.430371 -6.22268,-1.291241 -1.84376,-0.87739 -3.41863,-2.11898 -4.72461,-3.72477 -1.29063,-1.60574 -2.28934,-3.55091 -2.99612,-5.83541 -0.69131,-2.28453 -1.0371,-4.84216 -1.0371,-7.67299 0,-2.81424 0.35341,-5.35534 1.06015,-7.62329 0.70678,-2.2845 1.71315,-4.22965 3.01915,-5.83543 1.30599,-1.62233 2.88087,-2.86394 4.72463,-3.72475 1.84373,-0.87737 3.90261,-1.31608 6.17658,-1.31608 z m 15.02661,0.59597 h 25.58209 v 4.02271 h -10.71682 v 31.80934 h -4.14844 v -31.8093 h -10.71683 z m -49.25134,3.5261 c -1.70546,0 -3.24192,0.33938 -4.60937,1.0181 -1.35209,0.66213 -2.51212,1.62233 -3.48009,2.88046 -0.95261,1.24159 -1.6901,2.7563 -2.21251,4.54419 -0.50701,1.77131 -0.76056,3.75786 -0.76056,5.95958 0,2.20175 0.25353,4.18827 0.76056,5.9596 0.52245,1.77131 1.2599,3.28606 2.21251,4.54419 0.96797,1.24157 2.128,2.20173 3.48009,2.88045 1.36745,0.66213 2.90391,0.99328 4.60937,0.99328 1.70549,0 3.23427,-0.33107 4.58635,-0.99328 1.36748,-0.6787 2.5275,-1.63888 3.48009,-2.88045 0.96798,-1.25813 1.70549,-2.77288 2.21251,-4.54421 0.52237,-1.77131 0.78359,-3.75783 0.78359,-5.95958 0,-2.20172 -0.2611,-4.18827 -0.78359,-5.9596 -0.50692,-1.78787 -1.24453,-3.30258 -2.21251,-4.54417 -0.95259,-1.25813 -2.11261,-2.21829 -3.48009,-2.88046 -1.35208,-0.67878 -2.88086,-1.01812 -4.58635,-1.0181 z"
+         id="rect1110" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.99981;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;filter:url(#filter864);enable-background:new"
+         id="rect932"
+         width="235.95665"
+         height="218.39064"
+         x="17.48835"
+         y="52.338001"
+         rx="11.29619"
+         transform="matrix(0.91649794,0,0,0.98746878,27.845072,-3.5091118)" />
+      <rect
+         rx="2.175175"
+         y="61.345276"
+         x="321.28229"
+         height="45.309441"
+         width="45.435398"
+         id="rect565"
+         style="display:inline;fill:url(#linearGradient575);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.12579;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         style="display:inline;fill:url(#linearGradient573);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.12579;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new"
+         d="m 323.45744,61.345274 c -1.20505,0 -2.17515,1.045215 -2.17515,2.343576 V 74.861958 H 366.7177 V 63.68885 c 0,-1.298361 -0.97009,-2.343576 -2.17514,-2.343576 z m 14.43244,3.62309 c 0.48275,0 0.91818,0.08838 1.30627,0.265166 0.39125,0.176777 0.72255,0.430046 0.9939,0.759807 0.27135,0.329754 0.4796,0.729204 0.62474,1.198347 0.14828,0.469136 0.22244,0.99607 0.22244,1.580794 0,0.58473 -0.0742,1.111664 -0.22244,1.580802 -0.14515,0.469137 -0.35339,0.868589 -0.62474,1.198346 -0.27135,0.326357 -0.60265,0.577928 -0.9939,0.754705 -0.38809,0.176778 -0.82352,0.26517 -1.30627,0.265166 -0.48275,0 -0.91975,-0.08838 -1.311,-0.265166 -0.3881,-0.176777 -0.71782,-0.428348 -0.98917,-0.754705 -0.27134,-0.329757 -0.48117,-0.729205 -0.62946,-1.198346 -0.14515,-0.469138 -0.21771,-0.996072 -0.21771,-1.580802 0,-0.584724 0.0726,-1.111658 0.21771,-1.580794 0.14826,-0.469143 0.35812,-0.868593 0.62946,-1.198347 0.27135,-0.329761 0.60107,-0.58303 0.98917,-0.759807 0.39125,-0.176778 0.82825,-0.265166 1.311,-0.265166 z m 7.02829,0 c 0.37232,0 0.71782,0.05949 1.03649,0.178476 0.32184,0.115569 0.60738,0.280467 0.85665,0.494636 0.24926,0.210774 0.45435,0.467442 0.61527,0.770005 0.16407,0.29916 0.27293,0.632321 0.32657,0.999471 h -0.86138 c -0.0536,-0.241367 -0.14197,-0.45894 -0.26504,-0.652717 -0.11989,-0.19717 -0.26662,-0.365454 -0.44016,-0.504838 -0.17038,-0.139376 -0.36443,-0.246466 -0.58214,-0.321253 -0.21455,-0.07818 -0.4433,-0.117279 -0.68626,-0.117279 -0.33446,0 -0.63736,0.06969 -0.90871,0.209074 -0.27135,0.139376 -0.50326,0.338256 -0.69573,0.596624 -0.18931,0.258366 -0.33603,0.569427 -0.44015,0.933182 -0.10412,0.360352 -0.15619,0.764904 -0.15619,1.213646 0,0.452143 0.0505,0.860089 0.15144,1.223841 0.1041,0.363755 0.25242,0.674815 0.44489,0.933184 0.19247,0.254969 0.42438,0.452143 0.69573,0.591527 0.27135,0.139376 0.57583,0.209074 0.91344,0.209074 0.24926,0 0.48118,-0.03059 0.69573,-0.09178 0.21455,-0.06457 0.40545,-0.158077 0.57268,-0.280462 0.16722,-0.122372 0.30921,-0.270266 0.42595,-0.443645 0.11989,-0.176774 0.2114,-0.37735 0.27451,-0.601721 h 0.86138 c -0.15776,0.730907 -0.4796,1.291838 -0.9655,1.682784 -0.48591,0.387554 -1.10907,0.581328 -1.86948,0.581328 -0.47013,0 -0.89609,-0.08838 -1.27787,-0.265166 -0.37863,-0.180178 -0.70204,-0.435148 -0.97024,-0.764908 -0.26504,-0.32975 -0.47013,-0.729205 -0.61527,-1.198343 -0.14197,-0.469145 -0.21298,-0.994372 -0.21298,-1.575704 0,-0.577924 0.0726,-1.099757 0.21771,-1.565497 0.14515,-0.469138 0.35181,-0.868588 0.62001,-1.198347 0.26819,-0.333157 0.5916,-0.58813 0.97023,-0.764904 0.37863,-0.180174 0.80143,-0.270266 1.26841,-0.270266 z m 3.08582,0.122387 h 5.25347 v 0.826092 h -2.20078 v 6.532275 h -0.85191 v -6.532267 h -2.20078 z m -10.11411,0.72411 c -0.35023,0 -0.66575,0.06969 -0.94657,0.209074 -0.27766,0.135973 -0.51588,0.333157 -0.71466,0.591523 -0.19563,0.254969 -0.34707,0.566026 -0.45435,0.933182 -0.10412,0.363751 -0.15619,0.771703 -0.15619,1.223842 0,0.452145 0.0521,0.860091 0.15619,1.223847 0.10728,0.363751 0.25872,0.674815 0.45435,0.933181 0.19878,0.254966 0.437,0.452141 0.71466,0.591521 0.28082,0.135974 0.59634,0.203978 0.94657,0.203978 0.35023,0 0.66418,-0.06799 0.94184,-0.203978 0.28082,-0.139375 0.51904,-0.336555 0.71466,-0.591521 0.19878,-0.258366 0.35023,-0.56943 0.45435,-0.933186 0.10728,-0.363751 0.16092,-0.771697 0.16092,-1.223842 0,-0.452139 -0.0536,-0.860091 -0.16092,-1.223846 -0.1041,-0.367152 -0.25557,-0.678209 -0.45435,-0.933178 -0.19562,-0.258366 -0.43384,-0.455542 -0.71466,-0.591523 -0.27766,-0.139392 -0.59161,-0.209078 -0.94184,-0.209074 z"
+         id="path567" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.99981;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;filter:url(#filter864);enable-background:new"
+         id="rect569"
+         width="235.95665"
+         height="218.39064"
+         x="17.48835"
+         y="52.338001"
+         rx="11.29619"
+         transform="matrix(0.1882094,0,0,0.20278377,318.5039,51.243664)" />
+      <rect
+         rx="1.4185923"
+         y="133.22519"
+         x="321.18411"
+         height="29.549635"
+         width="29.631781"
+         id="rect577"
+         style="display:inline;fill:url(#linearGradient587);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.69073;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.12858,237.00001 c -3.74357,0 -4.14638,0.30899 -4.12803,3.32331 v 4.17669 4.17668 c -0.0183,3.01433 0.38446,3.32332 4.12803,3.32332 h 7.74335 c 3.7436,0 4.12805,-0.30895 4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 -0.38446,-3.32331 -4.12805,-3.32331 z"
-         id="path918-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         style="display:inline;fill:url(#linearGradient585);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.69073;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new"
+         d="m 322.60268,133.22518 c -0.7859,0 -1.41858,0.68166 -1.41858,1.52842 v 7.28681 h 29.63179 v -7.28681 c 0,-0.84676 -0.63267,-1.52842 -1.41857,-1.52842 z m 9.41246,2.36288 c 0.31484,0 0.59881,0.0576 0.85191,0.17294 0.25517,0.11529 0.47123,0.28046 0.6482,0.49552 0.17697,0.21506 0.31278,0.47557 0.40744,0.78153 0.0967,0.30596 0.14507,0.64961 0.14507,1.03096 0,0.38134 -0.0484,0.72499 -0.14507,1.03095 -0.0947,0.30596 -0.23047,0.56648 -0.40744,0.78153 -0.17697,0.21285 -0.39303,0.37691 -0.6482,0.4922 -0.2531,0.11529 -0.53707,0.17294 -0.85191,0.17294 -0.31484,0 -0.59984,-0.0576 -0.855,-0.17294 -0.25311,-0.11529 -0.46814,-0.27935 -0.64511,-0.4922 -0.17696,-0.21505 -0.31381,-0.47556 -0.41052,-0.78153 -0.0947,-0.30596 -0.14198,-0.64961 -0.14198,-1.03095 0,-0.38135 0.0473,-0.725 0.14198,-1.03096 0.0967,-0.30596 0.23356,-0.56647 0.41052,-0.78153 0.17697,-0.21506 0.392,-0.38023 0.64511,-0.49552 0.25516,-0.11529 0.54016,-0.17294 0.855,-0.17294 z m 4.58367,0 c 0.24281,0 0.46814,0.0388 0.67597,0.1164 0.20989,0.0754 0.39612,0.18291 0.55868,0.32259 0.16256,0.13746 0.29632,0.30485 0.40127,0.50218 0.107,0.1951 0.17799,0.41238 0.21298,0.65183 h -0.56177 c -0.035,-0.15742 -0.0926,-0.29931 -0.17286,-0.42569 -0.0782,-0.12859 -0.17388,-0.23834 -0.28706,-0.32924 -0.11111,-0.0909 -0.23767,-0.16074 -0.37965,-0.20952 -0.13993,-0.051 -0.28911,-0.0765 -0.44756,-0.0765 -0.21813,0 -0.41567,0.0455 -0.59264,0.13636 -0.17697,0.0909 -0.32821,0.2206 -0.45374,0.3891 -0.12346,0.1685 -0.21915,0.37137 -0.28705,0.6086 -0.0679,0.23501 -0.10186,0.49885 -0.10186,0.7915 0,0.29488 0.0329,0.56093 0.0988,0.79816 0.0679,0.23723 0.16462,0.4401 0.29015,0.6086 0.12552,0.16628 0.27677,0.29488 0.45373,0.38578 0.17697,0.0909 0.37554,0.13635 0.59572,0.13635 0.16257,0 0.31382,-0.02 0.45374,-0.0599 0.13993,-0.0421 0.26443,-0.10309 0.37349,-0.18291 0.10906,-0.0798 0.20166,-0.17626 0.27779,-0.28933 0.0782,-0.11529 0.13787,-0.2461 0.17903,-0.39243 h 0.56177 c -0.10289,0.47668 -0.31278,0.8425 -0.62967,1.09747 -0.3169,0.25275 -0.72331,0.37913 -1.21923,0.37913 -0.30661,0 -0.58441,-0.0576 -0.83339,-0.17294 -0.24694,-0.11751 -0.45786,-0.28379 -0.63277,-0.49885 -0.17285,-0.21506 -0.30661,-0.47557 -0.40126,-0.78153 -0.0926,-0.30596 -0.1389,-0.6485 -0.1389,-1.02763 0,-0.37691 0.0473,-0.71723 0.14198,-1.02098 0.0947,-0.30596 0.22944,-0.56647 0.40436,-0.78153 0.1749,-0.21728 0.38582,-0.38356 0.63276,-0.49885 0.24693,-0.1175 0.52267,-0.17626 0.82722,-0.17626 z m 2.01249,0.0798 h 3.42617 v 0.53876 h -1.43529 v 4.26018 h -0.55559 v -4.26018 h -1.43529 z m -6.59616,0.47225 c -0.22841,0 -0.43419,0.0454 -0.61733,0.13635 -0.18108,0.0887 -0.33644,0.21728 -0.46608,0.38578 -0.12759,0.16628 -0.22635,0.36914 -0.29632,0.60859 -0.0679,0.23723 -0.10186,0.50329 -0.10186,0.79816 0,0.29488 0.034,0.56093 0.10186,0.79816 0.07,0.23723 0.16873,0.4401 0.29632,0.6086 0.12964,0.16628 0.285,0.29487 0.46608,0.38577 0.18314,0.0887 0.38892,0.13303 0.61733,0.13303 0.22841,0 0.43316,-0.0443 0.61424,-0.13303 0.18315,-0.0909 0.33851,-0.21949 0.46609,-0.38577 0.12963,-0.1685 0.22841,-0.37137 0.29631,-0.6086 0.07,-0.23723 0.10495,-0.50328 0.10495,-0.79816 0,-0.29487 -0.035,-0.56093 -0.10495,-0.79816 -0.0679,-0.23945 -0.16668,-0.44231 -0.29631,-0.60859 -0.12758,-0.1685 -0.28294,-0.2971 -0.46609,-0.38578 -0.18108,-0.0909 -0.38583,-0.13635 -0.61424,-0.13635 z"
+         id="path579" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.99981;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;filter:url(#filter864);enable-background:new"
+         id="rect581"
+         width="235.95665"
+         height="218.39064"
+         x="17.48835"
+         y="52.338001"
+         rx="11.29619"
+         transform="matrix(0.12274526,0,0,0.13225028,319.37211,126.63717)" />
+      <rect
+         rx="1.0875875"
+         y="188.67264"
+         x="320.64114"
+         height="22.65472"
+         width="22.717699"
+         id="rect589"
+         style="display:inline;fill:url(#linearGradient599);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.06289;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 326.45275,189.00048 c -1.2321,0 -2.21668,0.0221 -3.06999,0.14144 -0.85332,0.11937 -1.62809,0.35533 -2.21066,0.83967 -0.58256,0.48436 -0.86983,1.13381 -1.01188,1.84587 -0.14202,0.71207 -0.16501,1.53239 -0.15897,2.56202 v 7.61066 4.6143 c -0.006,1.02762 0.0171,1.84735 0.15897,2.55843 0.14203,0.71208 0.42931,1.36152 1.01188,1.84587 0.58258,0.48434 1.35734,0.7203 2.21066,0.83967 0.85331,0.11936 1.83789,0.14144 3.06999,0.14144 h 11.09542 c 1.2321,0 2.21381,-0.022 3.0657,-0.14144 0.85187,-0.11947 1.62795,-0.35683 2.2085,-0.84146 0.58057,-0.48464 0.86451,-1.13152 1.00758,-1.84228 0.14307,-0.71077 0.16972,-1.5314 0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 -0.0266,-1.84946 -0.16972,-2.56023 -0.14307,-0.71076 -0.42701,-1.35765 -1.00758,-1.84228 -0.58055,-0.48464 -1.35661,-0.722 -2.2085,-0.84147 -0.8519,-0.11947 -1.83359,-0.14144 -3.0657,-0.14144 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         style="display:inline;fill:url(#linearGradient597);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.06289;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new"
+         d="m 321.72872,188.67264 c -0.60252,0 -1.08758,0.5226 -1.08758,1.17179 v 5.58655 h 22.71771 v -5.58655 c 0,-0.64919 -0.48505,-1.17179 -1.08757,-1.17179 z m 7.21622,1.81154 c 0.24138,0 0.45909,0.0442 0.65313,0.13259 0.19563,0.0884 0.36128,0.21502 0.49696,0.37989 0.13567,0.16488 0.23979,0.36461 0.31237,0.59918 0.0741,0.23457 0.11122,0.49803 0.11122,0.7904 0,0.29236 -0.0371,0.55583 -0.11122,0.7904 -0.0726,0.23456 -0.1767,0.4343 -0.31237,0.59917 -0.13568,0.16318 -0.30133,0.28896 -0.49696,0.37735 -0.19404,0.0884 -0.41175,0.13259 -0.65313,0.13259 -0.24138,0 -0.45988,-0.0442 -0.6555,-0.13259 -0.19405,-0.0884 -0.35891,-0.21417 -0.49458,-0.37735 -0.13567,-0.16487 -0.24059,-0.3646 -0.31474,-0.59917 -0.0726,-0.23457 -0.10885,-0.49804 -0.10885,-0.7904 0,-0.29237 0.0363,-0.55583 0.10885,-0.7904 0.0741,-0.23457 0.17907,-0.4343 0.31474,-0.59918 0.13567,-0.16487 0.30053,-0.2915 0.49458,-0.37989 0.19562,-0.0884 0.41412,-0.13259 0.6555,-0.13259 z m 3.51415,0 c 0.18615,0 0.35891,0.0297 0.51824,0.0892 0.16092,0.0578 0.30369,0.14023 0.42832,0.24732 0.12463,0.10538 0.22718,0.23372 0.30764,0.385 0.082,0.14958 0.13646,0.31616 0.16329,0.49974 h -0.43069 c -0.0268,-0.12069 -0.071,-0.22947 -0.13253,-0.32636 -0.06,-0.0986 -0.13331,-0.18273 -0.22008,-0.25242 -0.0852,-0.0697 -0.18221,-0.12323 -0.29106,-0.16063 -0.10728,-0.0391 -0.22165,-0.0587 -0.34313,-0.0587 -0.16723,0 -0.31868,0.0349 -0.45436,0.10454 -0.13568,0.0697 -0.25163,0.16913 -0.34787,0.29831 -0.0947,0.12918 -0.16801,0.28472 -0.22007,0.46659 -0.052,0.18018 -0.0781,0.38245 -0.0781,0.60682 0,0.22607 0.0252,0.43005 0.0758,0.61192 0.052,0.18188 0.1262,0.33741 0.22244,0.4666 0.0962,0.12748 0.21219,0.22607 0.34786,0.29576 0.13568,0.0697 0.28792,0.10454 0.45672,0.10454 0.12464,0 0.2406,-0.0153 0.34787,-0.0459 0.10728,-0.0323 0.20273,-0.079 0.28634,-0.14023 0.0836,-0.0612 0.15461,-0.13513 0.21297,-0.22182 0.06,-0.0884 0.10571,-0.18868 0.13726,-0.30086 h 0.43069 c -0.0789,0.36545 -0.2398,0.64592 -0.48275,0.84139 -0.24295,0.19378 -0.55453,0.29067 -0.93474,0.29067 -0.23507,0 -0.44805,-0.0442 -0.63893,-0.13259 -0.18932,-0.0901 -0.35103,-0.21757 -0.48512,-0.38245 -0.13252,-0.16488 -0.23507,-0.3646 -0.30764,-0.59917 -0.071,-0.23457 -0.10649,-0.49719 -0.10649,-0.78785 0,-0.28897 0.0363,-0.54988 0.10885,-0.78275 0.0726,-0.23457 0.17591,-0.4343 0.31001,-0.59918 0.13409,-0.16658 0.2958,-0.29406 0.48512,-0.38245 0.18931,-0.0901 0.40071,-0.13513 0.6342,-0.13513 z m 1.54291,0.0612 h 2.62673 v 0.41305 h -1.10039 v 3.26614 h -0.42595 v -3.26614 H 334.002 Z m -5.05706,0.36206 c -0.17511,0 -0.33288,0.0348 -0.47329,0.10453 -0.13882,0.068 -0.25793,0.16658 -0.35732,0.29577 -0.0978,0.12748 -0.17354,0.283 -0.22718,0.46658 -0.0521,0.18188 -0.0781,0.38586 -0.0781,0.61193 0,0.22607 0.0261,0.43004 0.0781,0.61192 0.0537,0.18187 0.12936,0.33741 0.22718,0.46659 0.0994,0.12748 0.2185,0.22607 0.35732,0.29576 0.14041,0.068 0.29818,0.10199 0.47329,0.10199 0.17512,0 0.33209,-0.034 0.47092,-0.10199 0.14041,-0.0697 0.25952,-0.16828 0.35733,-0.29576 0.0994,-0.12918 0.17512,-0.28472 0.22718,-0.46659 0.0537,-0.18188 0.0805,-0.38585 0.0805,-0.61192 0,-0.22607 -0.0268,-0.43005 -0.0805,-0.61193 -0.0521,-0.18358 -0.12779,-0.3391 -0.22718,-0.46658 -0.0978,-0.12919 -0.21692,-0.22778 -0.35733,-0.29577 -0.13883,-0.0697 -0.2958,-0.10453 -0.47092,-0.10453 z"
+         id="path591" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.99981;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;filter:url(#filter864);enable-background:new"
+         id="rect593"
+         width="235.95665"
+         height="218.39064"
+         x="17.48835"
+         y="52.338001"
+         rx="11.29619"
+         transform="matrix(0.0941047,0,0,0.10139188,319.25195,183.62183)" />
+      <rect
+         rx="0.70929623"
+         y="236.61258"
+         x="320.59204"
+         height="14.774818"
+         width="14.815891"
+         id="rect601"
+         style="display:inline;fill:url(#linearGradient611);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.34536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 329.30094,134 c -1.63949,0 -2.94082,0.0308 -4.04505,0.19141 -1.10422,0.16064 -2.06697,0.4726 -2.78308,1.09179 -0.71611,0.61919 -1.0805,1.45612 -1.26421,2.41407 -0.18374,0.95795 -0.21537,2.08705 -0.20733,3.51171 V 149 v 7.79688 c -0.009,1.42131 0.0239,2.5495 0.20733,3.50585 0.18371,0.95796 0.5481,1.79488 1.26421,2.41407 0.71611,0.61919 1.67886,0.93115 2.78308,1.09179 1.10423,0.16065 2.40556,0.19141 4.04505,0.19141 h 13.40164 c 1.63949,0 2.93835,-0.0307 4.04054,-0.19141 1.10219,-0.16075 2.06274,-0.47425 2.77633,-1.09375 0.71357,-0.6195 1.07457,-1.45363 1.25969,-2.41015 C 350.96429,159.34816 351,158.22066 351,156.79688 V 149 141.20312 c 0,-1.42378 -0.0358,-2.55128 -0.22086,-3.50781 -0.18512,-0.95653 -0.54612,-1.79065 -1.25969,-2.41015 -0.71359,-0.61951 -1.67414,-0.933 -2.77633,-1.09375 C 345.64093,134.03065 344.34207,134 342.70258,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 333.65776,62 c -2.6221,0 -4.68675,0.05009 -6.38561,0.286735 -1.69887,0.236639 -3.08904,0.680503 -4.10735,1.523515 -1.0183,0.843013 -1.55577,1.996072 -1.83828,3.406406 -0.28252,1.410336 -0.33767,3.127346 -0.32482,5.308412 v 12.474816 12.480783 c -0.0127,2.177715 0.0426,3.893853 0.32482,5.302673 0.28251,1.41034 0.81998,2.5634 1.83828,3.40641 1.01831,0.84301 2.40848,1.28688 4.10735,1.52351 1.69888,0.23665 3.76351,0.28674 6.38561,0.28674 h 20.68618 c 2.62213,0 4.68568,-0.05 6.38104,-0.28674 1.69534,-0.23674 3.08126,-0.6821 4.09581,-1.52542 1.01457,-0.84331 1.54885,-1.99555 1.83367,-3.4045 C 366.93929,101.37441 367,99.660878 367,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0608,-3.893733 -0.34554,-5.302677 -0.28482,-1.408942 -0.81911,-2.561177 -1.83368,-3.404494 -1.01455,-0.843317 -2.40047,-1.288685 -4.09582,-1.525427 C 359.02962,62.049992 356.96605,62 354.34394,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500049 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 v 12.75157 12.75181 c -0.0527,8.842031 1.82291,9.748381 11.83407,9.748381 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.748381 v -12.75181 -12.75157 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1694);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 225.07297,43.999694 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.006466 73.00648 c 0.17299,35.36812 -3.62489,38.99353 -38.92162,38.99353 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 155.99969 82.993224 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 326.17688,188.49945 c -5.14666,0 -5.70043,0.43262 -5.67521,4.65309 v 5.84793 7.84761 c -0.0253,4.22046 0.52855,4.65307 5.67521,4.65307 h 11.64568 c 5.14665,0 5.67521,-0.43255 5.67521,-4.65307 v -7.84761 -5.84793 c 0,-4.22051 -0.52857,-4.65309 -5.67522,-4.65309 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.4056,236.50001 c -3.47604,0 -3.85006,0.30899 -3.83302,3.32331 v 4.17669 4.17668 c -0.017,3.01433 0.35698,3.32332 3.83302,3.32332 h 7.18996 c 3.47605,0 3.83303,-0.30895 3.83303,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.35699,-3.32331 -3.83303,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         style="display:inline;fill:url(#linearGradient609);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.34536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new"
+         d="m 321.30136,236.61258 c -0.39295,0 -0.70929,0.34083 -0.70929,0.76421 v 3.6434 h 14.8159 v -3.6434 c 0,-0.42338 -0.31634,-0.76421 -0.70929,-0.76421 z m 4.70623,1.18144 c 0.15742,0 0.29941,0.0288 0.42595,0.0865 0.12759,0.0576 0.23562,0.14023 0.32411,0.24776 0.0885,0.10753 0.15638,0.23778 0.20372,0.39077 0.0483,0.15298 0.0725,0.3248 0.0725,0.51547 0,0.19067 -0.0242,0.3625 -0.0725,0.51548 -0.0473,0.15298 -0.11524,0.28324 -0.20372,0.39076 -0.0885,0.10643 -0.19652,0.18846 -0.32411,0.2461 -0.12654,0.0577 -0.26853,0.0865 -0.42595,0.0865 -0.15742,0 -0.29992,-0.0288 -0.4275,-0.0865 -0.12655,-0.0576 -0.23407,-0.13967 -0.32255,-0.2461 -0.0885,-0.10752 -0.15691,-0.23778 -0.20527,-0.39076 -0.0473,-0.15298 -0.071,-0.32481 -0.071,-0.51548 0,-0.19067 0.0237,-0.36249 0.071,-0.51547 0.0483,-0.15299 0.11679,-0.28324 0.20527,-0.39077 0.0885,-0.10753 0.196,-0.19011 0.32255,-0.24776 0.12758,-0.0577 0.27008,-0.0865 0.4275,-0.0865 z m 2.29184,0 c 0.1214,0 0.23407,0.0194 0.33798,0.0582 0.10495,0.0377 0.19806,0.0915 0.27934,0.1613 0.0813,0.0687 0.14816,0.15243 0.20063,0.25109 0.0535,0.0976 0.089,0.20619 0.1065,0.32591 h -0.28089 c -0.0175,-0.0787 -0.0463,-0.14965 -0.0864,-0.21284 -0.0391,-0.0643 -0.0869,-0.11917 -0.14353,-0.16462 -0.0556,-0.0455 -0.11883,-0.0804 -0.18982,-0.10476 -0.07,-0.0255 -0.14456,-0.0383 -0.22378,-0.0383 -0.10907,0 -0.20784,0.0228 -0.29632,0.0682 -0.0885,0.0454 -0.16411,0.1103 -0.22688,0.19455 -0.0618,0.0842 -0.10957,0.18568 -0.14352,0.30429 -0.0339,0.11751 -0.0509,0.24943 -0.0509,0.39576 0,0.14743 0.0164,0.28046 0.0494,0.39907 0.0339,0.11862 0.0823,0.22005 0.14507,0.30431 0.0627,0.0831 0.13838,0.14743 0.22686,0.19288 0.0885,0.0455 0.18778,0.0682 0.29787,0.0682 0.0813,0 0.15691,-0.01 0.22687,-0.0299 0.07,-0.0211 0.13221,-0.0515 0.18674,-0.0915 0.0545,-0.0399 0.10083,-0.0881 0.13889,-0.14466 0.0391,-0.0576 0.0689,-0.12305 0.0895,-0.19621 h 0.28089 c -0.0515,0.23833 -0.1564,0.42125 -0.31484,0.54873 -0.15845,0.12638 -0.36165,0.18957 -0.60961,0.18957 -0.15331,0 -0.29221,-0.0288 -0.4167,-0.0865 -0.12347,-0.0588 -0.22893,-0.14189 -0.31638,-0.24942 -0.0864,-0.10753 -0.15331,-0.23778 -0.20063,-0.39076 -0.0463,-0.15298 -0.0695,-0.32426 -0.0695,-0.51382 0,-0.18846 0.0237,-0.35862 0.071,-0.51049 0.0473,-0.15298 0.11473,-0.28324 0.20218,-0.39077 0.0874,-0.10864 0.19292,-0.19178 0.31639,-0.24942 0.12346,-0.0588 0.26133,-0.0881 0.41361,-0.0881 z m 1.00624,0.0399 h 1.71309 v 0.26938 h -0.71765 v 2.13009 h -0.27779 v -2.13009 h -0.71765 z m -3.29808,0.23613 c -0.1142,0 -0.2171,0.0227 -0.30867,0.0682 -0.0905,0.0444 -0.16821,0.10864 -0.23303,0.19289 -0.0638,0.0831 -0.11318,0.18457 -0.14816,0.3043 -0.034,0.11861 -0.0509,0.25164 -0.0509,0.39908 0,0.14744 0.017,0.28046 0.0509,0.39908 0.035,0.11861 0.0844,0.22005 0.14816,0.3043 0.0648,0.0831 0.1425,0.14743 0.23303,0.19288 0.0916,0.0444 0.19447,0.0665 0.30867,0.0665 0.11421,0 0.21658,-0.0222 0.30712,-0.0665 0.0916,-0.0454 0.16925,-0.10974 0.23304,-0.19288 0.0648,-0.0842 0.11421,-0.18569 0.14816,-0.3043 0.035,-0.11862 0.0525,-0.25164 0.0525,-0.39908 0,-0.14744 -0.0175,-0.28047 -0.0525,-0.39908 -0.034,-0.11973 -0.0833,-0.22116 -0.14816,-0.3043 -0.0638,-0.0842 -0.14147,-0.14855 -0.23304,-0.19289 -0.0905,-0.0455 -0.19291,-0.0682 -0.30712,-0.0682 z"
+         id="path603" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.99981;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;filter:url(#filter864);enable-background:new"
+         id="rect605"
+         width="235.95665"
+         height="218.39064"
+         x="17.48835"
+         y="52.338001"
+         rx="11.29619"
+         transform="matrix(0.06137263,0,0,0.06612514,319.68607,233.31857)" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms and folds"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#linearGradient26575);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:48;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter4277);enable-background:accumulate"
-         d="m 16,210 v 96 h 16 v -96 z"
-         transform="matrix(0.5,0,0,0.5,32,28.000013)"
-         id="path21959"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#linearGradient4268);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:48;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter4277);enable-background:accumulate"
-         d="m 480,210 v 96 h 16 v -96 z"
-         transform="matrix(0.5,0,0,0.5,16,28.000013)"
-         id="path4258"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:48;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter967);enable-background:accumulate"
-         d="m 16,210 v 96 h 16 v -96 z"
-         transform="matrix(0.5,0,0,0.5,32.0576,28.000013)"
-         id="path21955"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:48;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter967);enable-background:accumulate"
-         d="m 480,210 v 96 h 16 v -96 z"
-         transform="matrix(0.5,0,0,0.5,16,28.000013)"
-         id="path965"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient21961);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:24;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 40.0576,132.00002 V 180 h 8 v -47.99998 z"
-         id="path21951"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient4251);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:24;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 256,132.00002 V 180 h 8 v -47.99998 z"
-         id="rect4243"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:24;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 40.0576,132.00002 v 1 h 8 v -1 z"
-         id="path21947"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:24;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 256,132.00002 v 1 h 8 v -1 z"
-         id="path4344"
-         inkscape:connector-curvature="0" />
-      <path
-         style="font-style:normal;font-weight:normal;font-size:149.37759399px;line-height:1000%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:3.73443985px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-         d="m 111.4375,156.00002 c -1.56471,1.54321 -3.10185,3.06848 -4.80664,4.70508 -2.98755,2.88796 -6.1258,5.87575 -9.412109,8.96289 -3.18672,3.08714 -6.1237,6.42273 -8.8125,10.00779 -2.589211,3.58506 -4.730881,7.41897 -6.423831,11.50195 -1.69294,3.98341 -2.53906,8.3156 -2.53906,12.9961 v 2.53906 c 0.0996,0.49793 0.14844,0.84771 0.14844,1.04688 h 59.60351 v -8.51563 H 90.347661 v -0.29883 c 0,-2.39004 0.54714,-4.77988 1.64257,-7.16992 1.19503,-2.48963 2.73875,-4.97912 4.63086,-7.46875 1.99171,-2.58921 4.184179,-5.12756 6.574219,-7.61719 2.48963,-2.58921 5.02798,-5.12949 7.61719,-7.61912 3.08714,-2.98755 6.12378,-5.97534 9.11133,-8.96289 1.34823,-1.34823 2.616,-2.71863 3.82226,-4.10742 z m 65.05469,0 c -1.28646,0.84619 -2.54527,1.762 -3.76953,2.76367 -2.09129,1.69295 -3.98284,3.68415 -5.67578,5.97461 -1.59337,2.19087 -2.88892,4.73118 -3.88477,7.61914 -0.99585,2.78836 -1.49414,5.92466 -1.49414,9.41014 0,4.08299 0.74841,7.86804 2.24219,11.35351 1.59336,3.3859 3.78388,6.37173 6.57226,8.96094 2.88797,2.48963 6.27439,4.43198 10.1582,5.82617 3.98341,1.39419 8.41331,2.0918 13.29297,2.0918 4.87967,0 9.31152,-0.74646 13.29493,-2.24023 3.9834,-1.3942 7.36982,-3.33655 10.1582,-5.82618 2.78838,-2.58921 4.93005,-5.67665 6.42383,-9.26171 1.59336,-3.58507 2.38867,-7.51863 2.38867,-11.80079 0,-4.97925 -1.44407,-9.71005 -4.33203,-14.19138 -2.63061,-4.22777 -7.14674,-7.78144 -13.5,-10.67969 z m 11.46679,1.56836 c 3.3859,1.09544 6.72151,2.14087 10.00782,3.13672 3.38589,0.99585 6.37368,2.34026 8.96289,4.0332 2.68879,1.69295 4.83046,3.88347 6.42383,6.57227 1.69294,2.68879 2.53906,6.17485 2.53906,10.45701 0,2.78838 -0.44749,5.37753 -1.34375,7.76758 -0.89627,2.39004 -2.29148,4.4809 -4.1836,6.27343 -1.79253,1.79253 -4.08271,3.2366 -6.87109,4.33203 -2.6888,0.99586 -5.8759,1.49415 -9.56055,1.49415 -3.68464,0 -6.9206,-0.49829 -9.70898,-1.49415 -2.6888,-1.09543 -4.97898,-2.5395 -6.87109,-4.33203 -1.79254,-1.79253 -3.13694,-3.88339 -4.03321,-6.27343 -0.89626,-2.39005 -1.34375,-4.9792 -1.34375,-7.76758 0,-5.67635 1.39326,-10.50681 4.18164,-14.49022 2.78838,-4.08298 6.72195,-7.31894 11.80078,-9.70898 z"
-         id="text926"
-         inkscape:connector-curvature="0" />
-      <path
-         style="font-style:normal;font-weight:normal;font-size:149.37759399px;line-height:1000%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:3.73443985px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-         d="m 105.28516,102.00002 c -3.78424,0 -7.219509,0.49829 -10.306639,1.49414 -3.08714,0.89627 -5.82481,1.99055 -8.214851,3.28516 -2.29045,1.2946 -4.23281,2.63901 -5.82617,4.0332 -1.49378,1.29461 -2.53921,2.29119 -3.13672,2.98828 l 5.07813,6.72266 c 0.59751,-0.59751 1.54328,-1.44363 2.83789,-2.53906 1.2946,-1.09544 2.838331,-2.14283 4.630861,-3.13868 1.89211,-1.09543 4.08264,-2.04121 6.57226,-2.83789 2.48963,-0.79668 5.328899,-1.19531 8.515629,-1.19531 5.67635,0 10.35637,1.54372 14.04101,4.63086 3.78423,2.98755 5.67578,7.96654 5.67578,14.9375 0,3.18672 -0.49829,6.12566 -1.49414,8.81445 -0.99585,2.6888 -2.34025,5.22715 -4.0332,7.61719 -1.69295,2.39004 -3.68415,4.73103 -5.97461,7.02148 -0.69065,0.69066 -1.49255,1.45557 -2.21289,2.16602 h 12.30859 c 1.46671,-1.68864 2.83889,-3.40569 4.09571,-5.1543 2.39004,-3.18672 4.28159,-6.47153 5.67578,-9.85742 1.39419,-3.48548 2.0918,-7.17087 2.0918,-11.05469 0,-8.76348 -2.54031,-15.58517 -7.61915,-20.46484 -5.07883,-4.97925 -12.64698,-7.46875 -22.70507,-7.46875 z m 88.64843,0 c -4.38174,0 -8.41496,0.69761 -12.09961,2.0918 -3.68464,1.2946 -6.86979,3.18615 -9.55859,5.67578 -2.58921,2.39004 -4.63122,5.32702 -6.125,8.8125 -1.49378,3.48548 -2.24023,7.37018 -2.24023,11.65234 0,4.78008 1.09428,9.21194 3.28515,13.29492 2.19087,4.08299 6.32375,7.61792 12.39844,10.60547 -1.05448,0.57118 -2.08585,1.19909 -3.10156,1.86719 h 31.875 c -0.38104,-0.17382 -0.74425,-0.3544 -1.13867,-0.52344 1.89211,-1.19502 3.83447,-2.63908 5.82617,-4.33203 1.9917,-1.69294 3.78359,-3.63335 5.37695,-5.82422 1.59336,-2.29045 2.88892,-4.77995 3.88477,-7.46875 0.99585,-2.78838 1.49414,-5.82697 1.49414,-9.11328 0,-3.38589 -0.59795,-6.67265 -1.79297,-9.85937 -1.09544,-3.18673 -2.88733,-6.02405 -5.37696,-8.51368 -2.39004,-2.48962 -5.47748,-4.48083 -9.26171,-5.97461 -3.78424,-1.59336 -8.26689,-2.39062 -13.44532,-2.39062 z m 0,8.36523 c 3.58507,0 6.62366,0.54715 9.11329,1.64258 2.48962,0.99585 4.48083,2.39107 5.9746,4.1836 1.59337,1.69294 2.73846,3.63334 3.43555,5.82421 0.79668,2.19088 1.19531,4.4322 1.19531,6.72266 0,5.67635 -1.3444,10.40718 -4.0332,14.19141 -2.6888,3.78423 -6.32338,6.97133 -10.9043,9.56054 -5.17842,-1.39419 -9.3621,-2.83825 -12.54882,-4.33203 -3.18673,-1.59336 -5.67622,-3.28754 -7.46875,-5.08008 -1.79254,-1.89211 -3.03728,-3.98298 -3.73438,-6.27343 -0.59751,-2.29046 -0.89648,-4.82881 -0.89648,-7.61719 0,-2.48963 0.39863,-4.88142 1.19531,-7.17188 0.89626,-2.29045 2.14101,-4.28166 3.73437,-5.9746 1.69295,-1.79254 3.78381,-3.18579 6.27344,-4.18164 2.48963,-0.99586 5.37776,-1.49415 8.66406,-1.49415 z"
-         id="text933"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07999998;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 40,156.00001 v 73.00585 C 39.82701,264.37398 43.625144,268 78.921875,268 H 225.07812 C 260.37483,268 264,264.37439 264,229.00586 v -73.00585 z"
-         id="rect4158-97"
-         inkscape:connector-curvature="0" />
-      <g
-         id="g905"
-         transform="matrix(0.185862,0,0,0.185862,315.74889,55.005541)"
-         style="display:inline;opacity:1;stroke-width:5.38033581;enable-background:new">
-        <path
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:296.13256836px;line-height:1.25;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:2.6901679px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-           d="m 105.25195,102.40039 c -3.55359,0 -6.859884,0.44363 -9.919919,1.33203 -3.060035,0.8884 -5.825193,1.97457 -8.292969,3.25781 -2.46777,1.28324 -4.590392,2.66388 -6.367187,4.14454 -1.776795,1.38195 -3.107699,2.56757 -3.996094,3.55468 l 6.808594,9.77149 c 0.69098,-0.59227 1.679646,-1.43176 2.962891,-2.51758 1.28324,-1.18452 2.862776,-2.26875 4.738281,-3.25586 1.87551,-1.08582 3.998127,-2.02282 6.367187,-2.8125 2.36906,-0.78969 4.983096,-1.18555 7.845706,-1.18555 2.36906,0 4.59113,0.34613 6.66406,1.03711 2.17164,0.59226 4.04758,1.57899 5.62695,2.96094 1.57937,1.38195 2.81278,3.10871 3.70117,5.18164 0.98712,2.07293 1.48047,4.5914 1.48047,7.55274 0,2.7639 -0.54308,5.37988 -1.6289,7.84765 -0.98711,2.46777 -2.36774,4.88485 -4.14453,7.25391 -1.67809,2.27035 -3.65349,4.58992 -5.92383,6.95898 -0.79382,0.8299 -1.62953,1.67434 -2.46289,2.51758 h 17.0664 c 1.37929,-1.62871 2.68265,-3.25589 3.9043,-4.88477 2.36907,-3.25746 4.24499,-6.51597 5.62695,-9.77343 1.48066,-3.35617 2.22266,-6.81165 2.22266,-10.36524 0,-9.0814 -2.71543,-16.08985 -8.14453,-21.02539 -5.33039,-5.03426 -13.37528,-7.55078 -24.13477,-7.55078 z m 88.46094,0 c -4.73812,0 -9.03114,0.78977 -12.88086,2.36914 -3.84972,1.48066 -7.15602,3.50383 -9.91992,6.07031 -2.6652,2.56648 -4.73809,5.57637 -6.21875,9.03125 -1.48066,3.35617 -2.2207,6.90915 -2.2207,10.66016 0,10.75949 4.8361,18.90383 14.50976,24.43164 -0.54317,0.33063 -1.07948,0.67827 -1.61133,1.03711 H 212.375 c -0.90352,-0.51362 -1.83287,-1.01278 -2.81836,-1.48047 1.97422,-1.28324 3.85016,-2.76332 5.62695,-4.44141 1.87551,-1.67808 3.50477,-3.60375 4.88672,-5.77539 1.48066,-2.17163 2.61462,-4.49121 3.4043,-6.95898 0.8884,-2.56649 1.33398,-5.28191 1.33398,-8.14453 0,-2.96132 -0.59281,-6.02094 -1.77734,-9.17969 -1.08582,-3.15874 -2.91204,-6.0214 -5.47852,-8.58789 -2.46778,-2.66519 -5.67656,-4.83753 -9.625,-6.51562 -3.94843,-1.67808 -8.68702,-2.51563 -14.21484,-2.51563 z m 0,11.40039 c 3.15875,0 5.82445,0.54309 7.99609,1.62891 2.17164,0.98711 3.95009,2.27024 5.33204,3.84961 1.38195,1.48066 2.36867,3.10992 2.96093,4.88672 0.69098,1.77679 1.03711,3.40605 1.03711,4.88671 0,5.33038 -1.23535,9.67313 -3.70312,13.0293 -2.46777,3.25746 -5.77407,6.12012 -9.91992,8.58789 -3.75102,-0.8884 -7.00759,-2.07403 -9.77149,-3.55469 -2.6652,-1.48066 -4.83753,-3.15769 -6.51562,-5.0332 -1.67808,-1.87551 -2.91149,-3.90062 -3.70118,-6.07226 -0.78969,-2.17164 -1.18554,-4.34204 -1.18554,-6.51368 0,-1.77679 0.29641,-3.55328 0.88867,-5.33007 0.69098,-1.87551 1.72741,-3.55449 3.10937,-5.03516 1.38194,-1.57937 3.15845,-2.8625 5.33008,-3.84961 2.27035,-0.98711 4.98384,-1.48047 8.14258,-1.48047 z"
-           id="path901"
-           inkscape:connector-curvature="0" />
-        <path
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2.6901679px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-           d="m 108.7207,156 c -1.44476,1.46177 -2.94216,2.94123 -4.50586,4.44238 -2.96132,2.96133 -5.972185,6.02094 -9.032225,9.17969 -3.060035,3.15875 -5.82324,6.51477 -8.291015,10.06836 -2.46777,3.55359 -4.49191,7.35423 -6.07129,11.40137 -1.48066,3.94844 -2.2207,8.24243 -2.2207,12.88184 v 1.6289 c 0,0.59227 0.0497,1.1841 0.148435,1.77637 H 140.93554 V 195.68164 H 93.70215 c 0,-1.67809 0.64156,-3.6525 1.924805,-5.92285 1.38195,-2.27035 3.05996,-4.63868 5.034185,-7.10645 1.97421,-2.46777 4.04711,-4.83707 6.21875,-7.10742 l 5.92285,-5.92285 c 2.96132,-2.96133 5.92246,-5.97219 8.88379,-9.03223 1.43424,-1.52986 2.79538,-3.06014 4.09082,-4.58984 z m 66.65039,0 c -1.69141,1.14114 -3.32612,2.42262 -4.90332,3.84961 -1.97422,1.77679 -3.7507,3.80094 -5.33008,6.07129 -1.48066,2.27035 -2.71504,4.73813 -3.70215,7.40332 -0.88839,2.56648 -1.33203,5.28094 -1.33203,8.14356 0,2.96132 0.54211,6.11941 1.62793,9.47558 1.08582,3.25746 2.91204,6.26833 5.47852,9.03223 2.56648,2.7639 5.97223,5.08348 10.2168,6.95898 4.34327,1.7768 9.72344,2.66504 16.13964,2.66504 5.52781,0 10.41364,-0.74004 14.65821,-2.2207 4.24456,-1.38195 7.74879,-3.35637 10.51269,-5.92285 2.86262,-2.6652 4.98524,-5.72481 6.36719,-9.17969 1.48066,-3.55359 2.2207,-7.40297 2.2207,-11.54883 C 227.14454,169.79807 222.16687,161.55701 212.39844,156 Z m 12.56836,3.40527 c 3.94843,0.8884 7.45266,1.97457 10.5127,3.25781 3.15875,1.18453 5.82446,2.66461 7.99609,4.44141 2.27035,1.77679 3.99712,3.85067 5.18165,6.21973 1.18453,2.36906 1.77734,5.13227 1.77734,8.29101 0,2.07293 -0.39488,4.09707 -1.18457,6.07129 -0.78969,1.97422 -1.97434,3.75071 -3.55371,5.33008 -1.57938,1.48066 -3.65227,2.71406 -6.21875,3.70117 -2.46777,0.98711 -5.38016,1.48145 -8.73633,1.48145 -3.75101,0 -6.86036,-0.54309 -9.32813,-1.62891 -2.46777,-1.08581 -4.49093,-2.41867 -6.07031,-3.99804 -1.57937,-1.67809 -2.71429,-3.45458 -3.40527,-5.33008 -0.59226,-1.97422 -0.88867,-3.85016 -0.88867,-5.62695 0,-5.03426 1.18465,-9.377 3.55371,-13.0293 2.46777,-3.6523 5.92227,-6.71289 10.36425,-9.18067 z"
-           id="path903"
-           inkscape:connector-curvature="0" />
-      </g>
-      <g
-         style="display:inline;opacity:1;stroke-width:8.36941147;enable-background:new"
-         transform="matrix(0.11948271,0,0,0.11948271,317.83857,129.36072)"
-         id="g917">
-        <path
-           inkscape:connector-curvature="0"
-           id="path913"
-           d="m 105.25195,102.40039 c -3.55359,0 -6.859884,0.44363 -9.919919,1.33203 -3.060035,0.8884 -5.825193,1.97457 -8.292969,3.25781 -2.46777,1.28324 -4.590392,2.66388 -6.367187,4.14454 -1.776795,1.38195 -3.107699,2.56757 -3.996094,3.55468 l 6.808594,9.77149 c 0.69098,-0.59227 1.679646,-1.43176 2.962891,-2.51758 1.28324,-1.18452 2.862776,-2.26875 4.738281,-3.25586 1.87551,-1.08582 3.998127,-2.02282 6.367187,-2.8125 2.36906,-0.78969 4.983096,-1.18555 7.845706,-1.18555 2.36906,0 4.59113,0.34613 6.66406,1.03711 2.17164,0.59226 4.04758,1.57899 5.62695,2.96094 1.57937,1.38195 2.81278,3.10871 3.70117,5.18164 0.98712,2.07293 1.48047,4.5914 1.48047,7.55274 0,2.7639 -0.54308,5.37988 -1.6289,7.84765 -0.98711,2.46777 -2.36774,4.88485 -4.14453,7.25391 -1.67809,2.27035 -3.65349,4.58992 -5.92383,6.95898 -0.79382,0.8299 -1.62953,1.67434 -2.46289,2.51758 h 17.0664 c 1.37929,-1.62871 2.68265,-3.25589 3.9043,-4.88477 2.36907,-3.25746 4.24499,-6.51597 5.62695,-9.77343 1.48066,-3.35617 2.22266,-6.81165 2.22266,-10.36524 0,-9.0814 -2.71543,-16.08985 -8.14453,-21.02539 -5.33039,-5.03426 -13.37528,-7.55078 -24.13477,-7.55078 z m 88.46094,0 c -4.73812,0 -9.03114,0.78977 -12.88086,2.36914 -3.84972,1.48066 -7.15602,3.50383 -9.91992,6.07031 -2.6652,2.56648 -4.73809,5.57637 -6.21875,9.03125 -1.48066,3.35617 -2.2207,6.90915 -2.2207,10.66016 0,10.75949 4.8361,18.90383 14.50976,24.43164 -0.54317,0.33063 -1.07948,0.67827 -1.61133,1.03711 H 212.375 c -0.90352,-0.51362 -1.83287,-1.01278 -2.81836,-1.48047 1.97422,-1.28324 3.85016,-2.76332 5.62695,-4.44141 1.87551,-1.67808 3.50477,-3.60375 4.88672,-5.77539 1.48066,-2.17163 2.61462,-4.49121 3.4043,-6.95898 0.8884,-2.56649 1.33398,-5.28191 1.33398,-8.14453 0,-2.96132 -0.59281,-6.02094 -1.77734,-9.17969 -1.08582,-3.15874 -2.91204,-6.0214 -5.47852,-8.58789 -2.46778,-2.66519 -5.67656,-4.83753 -9.625,-6.51562 -3.94843,-1.67808 -8.68702,-2.51563 -14.21484,-2.51563 z m 0,11.40039 c 3.15875,0 5.82445,0.54309 7.99609,1.62891 2.17164,0.98711 3.95009,2.27024 5.33204,3.84961 1.38195,1.48066 2.36867,3.10992 2.96093,4.88672 0.69098,1.77679 1.03711,3.40605 1.03711,4.88671 0,5.33038 -1.23535,9.67313 -3.70312,13.0293 -2.46777,3.25746 -5.77407,6.12012 -9.91992,8.58789 -3.75102,-0.8884 -7.00759,-2.07403 -9.77149,-3.55469 -2.6652,-1.48066 -4.83753,-3.15769 -6.51562,-5.0332 -1.67808,-1.87551 -2.91149,-3.90062 -3.70118,-6.07226 -0.78969,-2.17164 -1.18554,-4.34204 -1.18554,-6.51368 0,-1.77679 0.29641,-3.55328 0.88867,-5.33007 0.69098,-1.87551 1.72741,-3.55449 3.10937,-5.03516 1.38194,-1.57937 3.15845,-2.8625 5.33008,-3.84961 2.27035,-0.98711 4.98384,-1.48047 8.14258,-1.48047 z"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:296.13256836px;line-height:1.25;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:4.18470573px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path915"
-           d="m 108.7207,156 c -1.44476,1.46177 -2.94216,2.94123 -4.50586,4.44238 -2.96132,2.96133 -5.972185,6.02094 -9.032225,9.17969 -3.060035,3.15875 -5.82324,6.51477 -8.291015,10.06836 -2.46777,3.55359 -4.49191,7.35423 -6.07129,11.40137 -1.48066,3.94844 -2.2207,8.24243 -2.2207,12.88184 v 1.6289 c 0,0.59227 0.0497,1.1841 0.148435,1.77637 H 140.93554 V 195.68164 H 93.70215 c 0,-1.67809 0.64156,-3.6525 1.924805,-5.92285 1.38195,-2.27035 3.05996,-4.63868 5.034185,-7.10645 1.97421,-2.46777 4.04711,-4.83707 6.21875,-7.10742 l 5.92285,-5.92285 c 2.96132,-2.96133 5.92246,-5.97219 8.88379,-9.03223 1.43424,-1.52986 2.79538,-3.06014 4.09082,-4.58984 z m 66.65039,0 c -1.69141,1.14114 -3.32612,2.42262 -4.90332,3.84961 -1.97422,1.77679 -3.7507,3.80094 -5.33008,6.07129 -1.48066,2.27035 -2.71504,4.73813 -3.70215,7.40332 -0.88839,2.56648 -1.33203,5.28094 -1.33203,8.14356 0,2.96132 0.54211,6.11941 1.62793,9.47558 1.08582,3.25746 2.91204,6.26833 5.47852,9.03223 2.56648,2.7639 5.97223,5.08348 10.2168,6.95898 4.34327,1.7768 9.72344,2.66504 16.13964,2.66504 5.52781,0 10.41364,-0.74004 14.65821,-2.2207 4.24456,-1.38195 7.74879,-3.35637 10.51269,-5.92285 2.86262,-2.6652 4.98524,-5.72481 6.36719,-9.17969 1.48066,-3.55359 2.2207,-7.40297 2.2207,-11.54883 C 227.14454,169.79807 222.16687,161.55701 212.39844,156 Z m 12.56836,3.40527 c 3.94843,0.8884 7.45266,1.97457 10.5127,3.25781 3.15875,1.18453 5.82446,2.66461 7.99609,4.44141 2.27035,1.77679 3.99712,3.85067 5.18165,6.21973 1.18453,2.36906 1.77734,5.13227 1.77734,8.29101 0,2.07293 -0.39488,4.09707 -1.18457,6.07129 -0.78969,1.97422 -1.97434,3.75071 -3.55371,5.33008 -1.57938,1.48066 -3.65227,2.71406 -6.21875,3.70117 -2.46777,0.98711 -5.38016,1.48145 -8.73633,1.48145 -3.75101,0 -6.86036,-0.54309 -9.32813,-1.62891 -2.46777,-1.08581 -4.49093,-2.41867 -6.07031,-3.99804 -1.57937,-1.67809 -2.71429,-3.45458 -3.40527,-5.33008 -0.59226,-1.97422 -0.88867,-3.85016 -0.88867,-5.62695 0,-5.03426 1.18465,-9.377 3.55371,-13.0293 2.46777,-3.6523 5.92227,-6.71289 10.36425,-9.18067 z"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:4.18470573px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new" />
-      </g>
-      <g
-         id="g923"
-         transform="matrix(0.092931,0,0,0.092931,317.87444,185.50291)"
-         style="display:inline;opacity:1;stroke-width:10.76067162;enable-background:new">
-        <path
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:296.13256836px;line-height:1.25;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:5.38033581px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-           d="m 105.25195,102.40039 c -3.55359,0 -6.859884,0.44363 -9.919919,1.33203 -3.060035,0.8884 -5.825193,1.97457 -8.292969,3.25781 -2.46777,1.28324 -4.590392,2.66388 -6.367187,4.14454 -1.776795,1.38195 -3.107699,2.56757 -3.996094,3.55468 l 6.808594,9.77149 c 0.69098,-0.59227 1.679646,-1.43176 2.962891,-2.51758 1.28324,-1.18452 2.862776,-2.26875 4.738281,-3.25586 1.87551,-1.08582 3.998127,-2.02282 6.367187,-2.8125 2.36906,-0.78969 4.983096,-1.18555 7.845706,-1.18555 2.36906,0 4.59113,0.34613 6.66406,1.03711 2.17164,0.59226 4.04758,1.57899 5.62695,2.96094 1.57937,1.38195 2.81278,3.10871 3.70117,5.18164 0.98712,2.07293 1.48047,4.5914 1.48047,7.55274 0,2.7639 -0.54308,5.37988 -1.6289,7.84765 -0.98711,2.46777 -2.36774,4.88485 -4.14453,7.25391 -1.67809,2.27035 -3.65349,4.58992 -5.92383,6.95898 -0.79382,0.8299 -1.62953,1.67434 -2.46289,2.51758 h 17.0664 c 1.37929,-1.62871 2.68265,-3.25589 3.9043,-4.88477 2.36907,-3.25746 4.24499,-6.51597 5.62695,-9.77343 1.48066,-3.35617 2.22266,-6.81165 2.22266,-10.36524 0,-9.0814 -2.71543,-16.08985 -8.14453,-21.02539 -5.33039,-5.03426 -13.37528,-7.55078 -24.13477,-7.55078 z m 88.46094,0 c -4.73812,0 -9.03114,0.78977 -12.88086,2.36914 -3.84972,1.48066 -7.15602,3.50383 -9.91992,6.07031 -2.6652,2.56648 -4.73809,5.57637 -6.21875,9.03125 -1.48066,3.35617 -2.2207,6.90915 -2.2207,10.66016 0,10.75949 4.8361,18.90383 14.50976,24.43164 -0.54317,0.33063 -1.07948,0.67827 -1.61133,1.03711 H 212.375 c -0.90352,-0.51362 -1.83287,-1.01278 -2.81836,-1.48047 1.97422,-1.28324 3.85016,-2.76332 5.62695,-4.44141 1.87551,-1.67808 3.50477,-3.60375 4.88672,-5.77539 1.48066,-2.17163 2.61462,-4.49121 3.4043,-6.95898 0.8884,-2.56649 1.33398,-5.28191 1.33398,-8.14453 0,-2.96132 -0.59281,-6.02094 -1.77734,-9.17969 -1.08582,-3.15874 -2.91204,-6.0214 -5.47852,-8.58789 -2.46778,-2.66519 -5.67656,-4.83753 -9.625,-6.51562 -3.94843,-1.67808 -8.68702,-2.51563 -14.21484,-2.51563 z m 0,11.40039 c 3.15875,0 5.82445,0.54309 7.99609,1.62891 2.17164,0.98711 3.95009,2.27024 5.33204,3.84961 1.38195,1.48066 2.36867,3.10992 2.96093,4.88672 0.69098,1.77679 1.03711,3.40605 1.03711,4.88671 0,5.33038 -1.23535,9.67313 -3.70312,13.0293 -2.46777,3.25746 -5.77407,6.12012 -9.91992,8.58789 -3.75102,-0.8884 -7.00759,-2.07403 -9.77149,-3.55469 -2.6652,-1.48066 -4.83753,-3.15769 -6.51562,-5.0332 -1.67808,-1.87551 -2.91149,-3.90062 -3.70118,-6.07226 -0.78969,-2.17164 -1.18554,-4.34204 -1.18554,-6.51368 0,-1.77679 0.29641,-3.55328 0.88867,-5.33007 0.69098,-1.87551 1.72741,-3.55449 3.10937,-5.03516 1.38194,-1.57937 3.15845,-2.8625 5.33008,-3.84961 2.27035,-0.98711 4.98384,-1.48047 8.14258,-1.48047 z"
-           id="path919"
-           inkscape:connector-curvature="0" />
-        <path
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:5.38033581px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-           d="m 108.7207,156 c -1.44476,1.46177 -2.94216,2.94123 -4.50586,4.44238 -2.96132,2.96133 -5.972185,6.02094 -9.032225,9.17969 -3.060035,3.15875 -5.82324,6.51477 -8.291015,10.06836 -2.46777,3.55359 -4.49191,7.35423 -6.07129,11.40137 -1.48066,3.94844 -2.2207,8.24243 -2.2207,12.88184 v 1.6289 c 0,0.59227 0.0497,1.1841 0.148435,1.77637 H 140.93554 V 195.68164 H 93.70215 c 0,-1.67809 0.64156,-3.6525 1.924805,-5.92285 1.38195,-2.27035 3.05996,-4.63868 5.034185,-7.10645 1.97421,-2.46777 4.04711,-4.83707 6.21875,-7.10742 l 5.92285,-5.92285 c 2.96132,-2.96133 5.92246,-5.97219 8.88379,-9.03223 1.43424,-1.52986 2.79538,-3.06014 4.09082,-4.58984 z m 66.65039,0 c -1.69141,1.14114 -3.32612,2.42262 -4.90332,3.84961 -1.97422,1.77679 -3.7507,3.80094 -5.33008,6.07129 -1.48066,2.27035 -2.71504,4.73813 -3.70215,7.40332 -0.88839,2.56648 -1.33203,5.28094 -1.33203,8.14356 0,2.96132 0.54211,6.11941 1.62793,9.47558 1.08582,3.25746 2.91204,6.26833 5.47852,9.03223 2.56648,2.7639 5.97223,5.08348 10.2168,6.95898 4.34327,1.7768 9.72344,2.66504 16.13964,2.66504 5.52781,0 10.41364,-0.74004 14.65821,-2.2207 4.24456,-1.38195 7.74879,-3.35637 10.51269,-5.92285 2.86262,-2.6652 4.98524,-5.72481 6.36719,-9.17969 1.48066,-3.55359 2.2207,-7.40297 2.2207,-11.54883 C 227.14454,169.79807 222.16687,161.55701 212.39844,156 Z m 12.56836,3.40527 c 3.94843,0.8884 7.45266,1.97457 10.5127,3.25781 3.15875,1.18453 5.82446,2.66461 7.99609,4.44141 2.27035,1.77679 3.99712,3.85067 5.18165,6.21973 1.18453,2.36906 1.77734,5.13227 1.77734,8.29101 0,2.07293 -0.39488,4.09707 -1.18457,6.07129 -0.78969,1.97422 -1.97434,3.75071 -3.55371,5.33008 -1.57938,1.48066 -3.65227,2.71406 -6.21875,3.70117 -2.46777,0.98711 -5.38016,1.48145 -8.73633,1.48145 -3.75101,0 -6.86036,-0.54309 -9.32813,-1.62891 -2.46777,-1.08581 -4.49093,-2.41867 -6.07031,-3.99804 -1.57937,-1.67809 -2.71429,-3.45458 -3.40527,-5.33008 -0.59226,-1.97422 -0.88867,-3.85016 -0.88867,-5.62695 0,-5.03426 1.18465,-9.377 3.55371,-13.0293 2.46777,-3.6523 5.92227,-6.71289 10.36425,-9.18067 z"
-           id="path921"
-           inkscape:connector-curvature="0" />
-      </g>
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient4251-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:23.99999809;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 321,198 v 4 h 1 v -4 z"
-         id="path21973"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient21975);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:23.99999809;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 342,198 v 4 h 1 v -4 z"
-         id="rect4243-5"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="cccccccccc"
+         id="path1"
+         d="m 204.40705,150.8447 7.50318,-14.09149 -1.38354,-7.66339 -55.18795,11.56632 1.38355,7.66312 47.48274,-9.95138 c -4.67341,8.56466 -8.48903,16.58105 -11.49977,24.13443 -3.53549,9.94609 -5.80889,17.41845 -6.91181,22.28886 -1.64041,7.19244 -2.59689,14.38884 -2.84323,21.73115 0.07,9.8532 0.41457,17.43955 1.03313,22.75928 l 8.29804,-1.73893 c -1.40755,-10.82494 -1.60759,-21.01904 -0.58745,-30.51161 0.71503,-6.26215 2.37552,-14.85792 4.9817,-25.7876 2.28787,-7.76998 4.88719,-14.57405 7.73141,-20.39876 z m -58.48957,16.75017 c -0.78139,-4.32823 -2.13187,-8.02195 -4.1041,-10.99616 -1.95946,-2.903 -4.30292,-5.28385 -7.07097,-6.98666 -2.82094,-1.6181 -5.94749,-2.65656 -9.36666,-3.04467 -3.41918,-0.38809 -7.01196,-0.22426 -10.76589,0.5625 -4.60974,0.96618 -8.4861,2.58877 -11.68193,4.9522 -3.195848,2.36346 -5.683528,5.24139 -7.463268,8.63379 -1.77974,3.39214 -2.8114,7.1431 -3.20074,11.42225 -0.38935,4.27917 -0.13499,8.71794 0.85509,13.44458 l 7.705198,-1.61494 c -0.69349,-3.46312 -1.019408,-6.78245 -0.845788,-9.98516 0.107668,-3.18925 0.740488,-6.12021 1.885528,-8.86411 1.09213,-2.65894 2.78764,-5.00259 5.0341,-6.94628 2.25922,-1.8727 5.16047,-3.21695 8.6509,-3.94857 2.56824,-0.53823 5.14774,-0.63716 7.59354,-0.33956 2.45878,0.36833 4.71823,1.1469 6.79084,2.4062 2.07286,1.25929 3.81464,2.95629 5.22511,5.09071 1.47636,2.12071 2.47715,4.6356 3.02813,7.68688 0.65331,3.61877 0.63716,6.93598 -0.0615,9.88093 -0.76451,2.95839 -2.0687,5.95661 -3.91259,8.99389 -1.90978,3.05153 -4.17438,6.02973 -6.74065,8.85066 l -15.37319,17.06624 c -2.47492,2.9489 -4.56934,6.11255 -6.37454,9.36303 -1.79273,3.32142 -2.99432,6.88689 -3.74976,10.65369 -0.74245,3.83777 -0.80246,8.04779 -0.0485,12.60293 l 56.50512,-11.84229 -1.38353,-7.66338 -47.68035,9.9928 c -0.0898,-3.14783 0.64915,-6.24818 2.15072,-9.28757 1.51455,-2.96869 3.31828,-5.85031 5.48959,-8.5884 l 20.26624,-22.14218 c 2.17129,-2.73783 4.02792,-5.70439 5.52948,-8.7438 1.56769,-3.05337 2.6231,-6.29381 3.23211,-9.73528 0.609,-3.44148 0.57397,-7.04257 -0.1177,-10.87427 z"
          inkscape:connector-curvature="0"
-         id="path983"
-         d="m 321,242 v 3 h 1 v -3 z m 13,0 v 3 h 1 v -3 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient985);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:23.99999809;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         style="display:inline;fill:#333333;fill-opacity:1;stroke-width:0.254179;enable-background:new" />
       <path
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:296.13256836px;line-height:1.25;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:0.5px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-         d="m 325.29297,240.36328 c -0.21229,0 -0.41094,0.027 -0.59375,0.0801 -0.18282,0.0531 -0.34671,0.11865 -0.49414,0.19531 -0.14743,0.0767 -0.27471,0.1596 -0.38086,0.24805 -0.10615,0.0826 -0.18521,0.15197 -0.23828,0.21094 l 0.40625,0.58398 c 0.0413,-0.0354 0.0991,-0.0855 0.17578,-0.15039 0.0767,-0.0708 0.17115,-0.13439 0.2832,-0.19336 0.11204,-0.0649 0.23933,-0.12079 0.38086,-0.16797 0.14153,-0.0472 0.29773,-0.0723 0.46875,-0.0723 0.14153,0 0.2746,0.0212 0.39844,0.0625 0.12973,0.0354 0.24158,0.0951 0.33594,0.17773 0.0943,0.0826 0.16763,0.18475 0.2207,0.30859 0.059,0.12384 0.0898,0.27427 0.0898,0.45118 0,0.16512 -0.0328,0.32132 -0.0977,0.46875 -0.059,0.14743 -0.1419,0.29206 -0.24805,0.43359 -0.10025,0.13563 -0.21789,0.27449 -0.35352,0.41602 -0.0474,0.0496 -0.0967,0.10002 -0.14648,0.15039 -0.0863,0.0873 -0.17612,0.17594 -0.26953,0.26562 -0.17692,0.17691 -0.35625,0.36013 -0.53906,0.54883 -0.18281,0.18871 -0.34867,0.38731 -0.4961,0.59961 -0.14743,0.2123 -0.26893,0.43986 -0.36328,0.68164 -0.0885,0.23589 -0.13281,0.49237 -0.13281,0.76953 v 0.0977 c 0,0.0354 0.004,0.07 0.01,0.10547 h 3.71485 v -0.69727 h -2.82227 c 0,-0.10025 0.0385,-0.21984 0.11524,-0.35547 0.0826,-0.13564 0.18284,-0.2764 0.30078,-0.42383 0.11795,-0.14743 0.2433,-0.28818 0.37304,-0.42382 l 0.35352,-0.35352 c 0.17691,-0.17691 0.35238,-0.35821 0.5293,-0.54102 0.0857,-0.0914 0.1687,-0.18204 0.24609,-0.27343 0.0824,-0.0973 0.15943,-0.19566 0.23242,-0.29297 0.14153,-0.19461 0.25338,-0.38742 0.33594,-0.58203 0.0885,-0.2005 0.13281,-0.40685 0.13281,-0.61914 0,-0.54254 -0.16198,-0.96296 -0.48632,-1.25782 -0.31845,-0.30075 -0.79862,-0.45117 -1.44141,-0.45117 z m 5.2832,0 c -0.28306,0 -0.53954,0.0482 -0.76953,0.14258 -0.22999,0.0885 -0.42668,0.20996 -0.5918,0.36328 -0.15922,0.15333 -0.28264,0.33266 -0.37109,0.53906 -0.0885,0.2005 -0.13281,0.41263 -0.13281,0.63672 0,0.64279 0.28927,1.12875 0.86718,1.45899 -0.0325,0.0198 -0.0659,0.041 -0.0976,0.0625 -0.10105,0.0682 -0.19875,0.14521 -0.29297,0.23047 -0.11795,0.10615 -0.22401,0.22569 -0.31836,0.36132 -0.0885,0.13563 -0.16173,0.28414 -0.2207,0.44336 -0.0531,0.15333 -0.0801,0.31532 -0.0801,0.48633 0,0.17692 0.0328,0.3659 0.0977,0.56641 0.0649,0.1946 0.1748,0.37394 0.32812,0.53906 0.15333,0.16512 0.3558,0.30398 0.60938,0.41602 0.25947,0.10615 0.58153,0.1582 0.96484,0.1582 0.33024,0 0.62143,-0.0443 0.875,-0.13281 0.25358,-0.0826 0.46379,-0.2002 0.62891,-0.35352 0.17102,-0.15922 0.2983,-0.34243 0.38085,-0.54883 0.0885,-0.21229 0.13282,-0.44177 0.13282,-0.68945 -0.0108,-0.65294 -0.309,-1.14457 -0.89258,-1.47656 h -0.002 c -0.054,-0.0307 -0.1091,-0.06 -0.16797,-0.0879 0.11794,-0.0767 0.22979,-0.16538 0.33594,-0.26563 0.11205,-0.10025 0.2104,-0.21596 0.29296,-0.3457 0.0885,-0.12973 0.15595,-0.26859 0.20313,-0.41602 0.0531,-0.15332 0.0801,-0.31532 0.0801,-0.48633 0,-0.17692 -0.0366,-0.36011 -0.10743,-0.54882 -0.0649,-0.18871 -0.17285,-0.3584 -0.32617,-0.51172 -0.14743,-0.15922 -0.34029,-0.29038 -0.57617,-0.39063 -0.23589,-0.10026 -0.51937,-0.15039 -0.84961,-0.15039 z m 0,0.68164 h 0.002 c 0.1878,2.4e-4 0.34731,0.0331 0.47657,0.0977 0.12974,0.059 0.2358,0.13611 0.31836,0.23047 0.0826,0.0884 0.14235,0.18486 0.17773,0.29101 0.0413,0.10614 0.0606,0.20451 0.0606,0.29297 0,0.31844 -0.0733,0.57684 -0.22071,0.77735 -0.14742,0.19461 -0.34411,0.36624 -0.59179,0.51367 -0.22409,-0.0531 -0.41887,-0.12443 -0.58399,-0.21289 -0.15922,-0.0884 -0.28842,-0.18874 -0.38867,-0.30078 -0.10025,-0.11205 -0.17547,-0.23355 -0.22265,-0.36329 -0.0472,-0.12974 -0.0703,-0.25893 -0.0703,-0.38867 0,-0.10615 0.0173,-0.21222 0.0527,-0.31836 0.0413,-0.11205 0.10298,-0.21232 0.18554,-0.30078 0.0826,-0.0943 0.18863,-0.1715 0.31836,-0.23047 0.13514,-0.0588 0.29851,-0.0877 0.48633,-0.0879 z m -0.34375,2.72461 c 0.23588,0.0531 0.44415,0.11865 0.62696,0.19531 0.18871,0.0708 0.34877,0.15948 0.47851,0.26563 0.13563,0.10615 0.23978,0.22956 0.31055,0.37109 0.0708,0.14154 0.10547,0.30543 0.10547,0.49414 0,0.12384 -0.0231,0.24534 -0.0703,0.36328 -0.0472,0.11794 -0.11854,0.22401 -0.21289,0.31836 -0.0944,0.0885 -0.21776,0.16174 -0.37109,0.22071 -0.14743,0.059 -0.32294,0.0898 -0.52344,0.0898 -0.22409,0 -0.40921,-0.0328 -0.55664,-0.0977 -0.14742,-0.0649 -0.26893,-0.14393 -0.36328,-0.23828 -0.0944,-0.10025 -0.16184,-0.20826 -0.20313,-0.32031 -0.0354,-0.11794 -0.0527,-0.22979 -0.0527,-0.33594 0,-0.30075 0.0714,-0.55914 0.21289,-0.77734 0.14743,-0.21819 0.35377,-0.4014 0.61914,-0.54883 z"
-         id="path987"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient998);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:23.99999809;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 322,145.00002 v 6 h 1 v -6 z"
-         id="path21967"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient21969);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:23.99999809;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 349,145.00002 v 6 h 1 v -6 z"
-         id="path996-3"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="cccccccccc"
+         id="path571"
+         d="m 354.76216,82.941322 1.54083,-2.893788 -0.28412,-1.573732 -11.33324,2.375227 0.28412,1.573676 9.75092,-2.043587 c -0.95971,1.758814 -1.74328,3.405037 -2.36156,4.956178 -0.72603,2.0425 -1.19289,3.577003 -1.41939,4.577176 -0.33686,1.477019 -0.53328,2.954851 -0.58387,4.462647 0.0144,2.023425 0.0851,3.581336 0.21216,4.673781 l 1.70406,-0.357102 c -0.28905,-2.222979 -0.33013,-4.31641 -0.12064,-6.265777 0.14684,-1.285977 0.48783,-3.05118 1.02303,-5.295668 0.46983,-1.595621 1.00362,-2.992885 1.5877,-4.189031 z m -12.01125,3.439767 c -0.16046,-0.888833 -0.43779,-1.647364 -0.84281,-2.25814 -0.40239,-0.596152 -0.88363,-1.085076 -1.45207,-1.43476 -0.5793,-0.332289 -1.22136,-0.545544 -1.92351,-0.625245 -0.70215,-0.0797 -1.43996,-0.04605 -2.21085,0.115513 -0.94665,0.198412 -1.74268,0.531623 -2.39897,1.01697 -0.65629,0.485353 -1.16715,1.076357 -1.53264,1.77301 -0.36548,0.696601 -0.57734,1.466887 -0.65729,2.345641 -0.08,0.878758 -0.0277,1.790291 0.1756,2.760941 l 1.58231,-0.33164 c -0.14241,-0.711176 -0.20934,-1.392824 -0.17368,-2.050524 0.0221,-0.654935 0.15206,-1.256829 0.3872,-1.820308 0.22428,-0.546032 0.57246,-1.027318 1.03379,-1.426468 0.46395,-0.384573 1.05974,-0.660624 1.77653,-0.810867 0.5274,-0.11053 1.05712,-0.130846 1.55938,-0.06973 0.50493,0.07564 0.96893,0.235524 1.39455,0.49413 0.42568,0.258604 0.78336,0.607095 1.07301,1.045414 0.30319,0.435503 0.5087,0.951953 0.62185,1.578555 0.13416,0.743141 0.13085,1.424353 -0.0126,2.02912 -0.15699,0.607526 -0.42482,1.223232 -0.80348,1.846959 -0.39218,0.626654 -0.85723,1.238249 -1.38424,1.817547 l -3.15699,3.504674 c -0.50824,0.605578 -0.93835,1.255256 -1.30906,1.922765 -0.36815,0.682077 -0.6149,1.414272 -0.77004,2.187811 -0.15247,0.788113 -0.16479,1.652673 -0.01,2.588103 l 11.60373,-2.4319 -0.28412,-1.57373 -9.7915,2.05209 c -0.0184,-0.646426 0.13331,-1.283105 0.44167,-1.907266 0.31102,-0.609641 0.68143,-1.201403 1.12733,-1.763689 l 4.16181,-4.547055 c 0.44589,-0.562233 0.82717,-1.171437 1.13552,-1.795601 0.32194,-0.627032 0.53867,-1.292479 0.66374,-1.99921 0.12506,-0.706732 0.11787,-1.446242 -0.0242,-2.233109 z"
          inkscape:connector-curvature="0"
-         id="path1004"
-         d="m 322,80.00001 v 10 h 2 v -10 z m 42,0 v 10 h 2 v -10 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:23.99999809;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         style="display:inline;fill:#333333;fill-opacity:1;stroke-width:0.0521975;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1002);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:23.99999809;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 322,79.00001 v 10 h 2 v -10 z m 42,0 v 10 h 2 v -10 z"
-         id="path1000"
+         id="path583"
+         d="m 343.0188,147.30956 1.00489,-1.88726 -0.1853,-1.02634 -7.39124,1.54906 0.1853,1.02631 6.35929,-1.33278 c -0.6259,1.14706 -1.13692,2.22068 -1.54015,3.23229 -0.47349,1.33207 -0.77797,2.33283 -0.92569,2.98512 -0.21969,0.96327 -0.34779,1.92708 -0.38078,2.91042 0.009,1.31963 0.0555,2.33565 0.13836,3.04812 l 1.11135,-0.23289 c -0.18851,-1.44977 -0.2153,-2.81505 -0.0787,-4.08638 0.0958,-0.83868 0.31815,-1.9899 0.66719,-3.4537 0.30641,-1.04062 0.65454,-1.95188 1.03546,-2.73197 z m -7.83342,2.24332 c -0.10465,-0.57967 -0.28552,-1.07436 -0.54966,-1.4727 -0.26243,-0.38879 -0.57628,-0.70766 -0.947,-0.93571 -0.37781,-0.21671 -0.79654,-0.35579 -1.25447,-0.40777 -0.45792,-0.052 -0.9391,-0.03 -1.44186,0.0753 -0.61738,0.1294 -1.13653,0.34671 -1.56454,0.66324 -0.42802,0.31654 -0.76119,0.70197 -0.99955,1.15631 -0.23836,0.45431 -0.37653,0.95667 -0.42867,1.52977 -0.0522,0.5731 -0.0181,1.16758 0.11452,1.80061 l 1.03195,-0.21628 c -0.0929,-0.46381 -0.13653,-0.90837 -0.11327,-1.3373 0.0144,-0.42713 0.0992,-0.81967 0.25252,-1.18716 0.14627,-0.35611 0.37334,-0.66999 0.67421,-0.9303 0.30258,-0.25081 0.69113,-0.43085 1.15861,-0.52883 0.34395,-0.0721 0.68942,-0.0853 1.01698,-0.0455 0.3293,0.0493 0.63191,0.1536 0.90949,0.32226 0.27762,0.16865 0.51089,0.39593 0.69979,0.68179 0.19773,0.28402 0.33176,0.62084 0.40555,1.02949 0.0875,0.48466 0.0853,0.92893 -0.008,1.32334 -0.10239,0.39621 -0.27706,0.79776 -0.52401,1.20454 -0.25577,0.40869 -0.55906,0.80755 -0.90277,1.18536 l -2.0589,2.28565 c -0.33146,0.39494 -0.61197,0.81865 -0.85374,1.25398 -0.2401,0.44483 -0.40102,0.92235 -0.5022,1.42683 -0.0994,0.51399 -0.10747,1.07783 -0.007,1.6879 l 7.56765,-1.58603 -0.1853,-1.02634 -6.38576,1.33832 c -0.012,-0.42158 0.087,-0.83681 0.28805,-1.24387 0.20284,-0.39759 0.44441,-0.78352 0.73522,-1.15023 l 2.71422,-2.96547 c 0.2908,-0.36668 0.53946,-0.76398 0.74056,-1.17105 0.20996,-0.40893 0.3513,-0.84292 0.43287,-1.30383 0.0816,-0.46091 0.0769,-0.9432 -0.0158,-1.45638 z"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
+         style="display:inline;fill:#333333;fill-opacity:1;stroke-width:0.0340418;enable-background:new" />
       <path
-         style="display:inline;opacity:0.07999998;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 321.55664,84.00001 v 0.17187 12.75196 c 0,8.84213 1.82728,9.74805 11.83594,9.74805 h 21.33008 c 10.01116,0 11.88668,-0.90602 11.83398,-9.74805 V 84.17188 84.00001 Z"
-         id="path908"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;opacity:0.07999998;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 321.5,148.00001 v 8.2168 c 0,5.69824 1.17692,6.2832 7.62695,6.2832 h 13.7461 c 6.45163,0 7.66095,-0.58502 7.62695,-6.2832 v -8.2168 z"
-         id="path925"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;opacity:0.07999998;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 320.50011,200 v 6.84783 c 0,4.22052 0.52913,4.65234 5.67578,4.65234 h 11.6462 c 5.14666,0 5.69912,-0.43188 5.67382,-4.65234 V 200 Z"
-         id="path927"
+         id="path595"
+         d="m 337.38108,199.47066 0.77042,-1.4469 -0.14207,-0.78686 -5.66661,1.18761 0.14206,0.78684 4.87545,-1.0218 c -0.47985,0.87942 -0.87163,1.70253 -1.18078,2.47809 -0.36301,1.02126 -0.59644,1.78851 -0.70969,2.2886 -0.16843,0.7385 -0.26664,1.47742 -0.29193,2.23132 0.007,1.01171 0.0426,1.79066 0.10607,2.33689 l 0.85204,-0.17855 c -0.14453,-1.11149 -0.16507,-2.1582 -0.0603,-3.13289 0.0735,-0.64299 0.24392,-1.52559 0.51151,-2.64784 0.23492,-0.79781 0.50182,-1.49644 0.79386,-2.09451 z m -6.00562,1.71988 c -0.0802,-0.44441 -0.2189,-0.82368 -0.42141,-1.12907 -0.20119,-0.29807 -0.44181,-0.54254 -0.72603,-0.71738 -0.28965,-0.16614 -0.61068,-0.27277 -0.96176,-0.31262 -0.35107,-0.0399 -0.71998,-0.023 -1.10543,0.0577 -0.47332,0.0992 -0.87134,0.26581 -1.19948,0.50848 -0.32815,0.24268 -0.58358,0.53818 -0.76632,0.88651 -0.18274,0.3483 -0.28867,0.73344 -0.32865,1.17282 -0.04,0.43938 -0.0139,0.89515 0.0878,1.38047 l 0.79116,-0.16582 c -0.0712,-0.35558 -0.10467,-0.69641 -0.0868,-1.02526 0.011,-0.32747 0.0761,-0.62841 0.1936,-0.91015 0.11214,-0.27302 0.28623,-0.51366 0.5169,-0.71323 0.23197,-0.19229 0.52986,-0.33032 0.88826,-0.40544 0.2637,-0.0553 0.52856,-0.0654 0.77969,-0.0349 0.25246,0.0378 0.48446,0.11776 0.69727,0.24706 0.21285,0.1293 0.39169,0.30355 0.53651,0.52271 0.15159,0.21775 0.25435,0.47597 0.31092,0.78927 0.0671,0.37158 0.0654,0.71218 -0.006,1.01456 -0.0785,0.30376 -0.21241,0.61162 -0.40174,0.92348 -0.19609,0.31333 -0.42861,0.61913 -0.69213,0.90878 l -1.57849,1.75233 c -0.25412,0.30279 -0.46917,0.62763 -0.65453,0.96139 -0.18408,0.34103 -0.30745,0.70713 -0.38502,1.0939 -0.0762,0.39406 -0.0824,0.82634 -0.005,1.29406 l 5.80187,-1.21596 -0.14206,-0.78686 -4.89575,1.02604 c -0.009,-0.32321 0.0667,-0.64155 0.22083,-0.95363 0.15551,-0.30482 0.34072,-0.6007 0.56367,-0.88184 l 2.0809,-2.27353 c 0.22295,-0.28112 0.41359,-0.58572 0.56777,-0.8978 0.16097,-0.31352 0.26933,-0.64624 0.33186,-0.99961 0.0626,-0.35336 0.059,-0.72312 -0.0121,-1.11656 z"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csssccc" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer4"
-       inkscape:label="Borders"
-       style="display:inline;opacity:1">
+         style="display:inline;fill:#333333;fill-opacity:1;stroke-width:0.0260987;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92188,43.999698 c -35.296728,0 -39.09487,3.62603 -38.92188,38.99414 v 2 c -0.17299,-35.36811 3.625152,-38.99414 38.92188,-38.99414 h 146.15624 c 35.29673,0 38.92188,3.62561 38.92188,38.99414 v -2 c 0,-35.36853 -3.62515,-38.99414 -38.92188,-38.99414 z"
-         id="path931"
+         id="path607"
+         d="m 331.50942,243.65477 0.50245,-0.94363 -0.0927,-0.51317 -3.69561,0.77453 0.0926,0.51315 3.17964,-0.66639 c -0.31295,0.57354 -0.56846,1.11035 -0.77008,1.61615 -0.23674,0.66604 -0.38898,1.16642 -0.46284,1.49256 -0.10984,0.48163 -0.17389,0.96354 -0.19039,1.45521 0.005,0.65981 0.0278,1.16782 0.0692,1.52406 l 0.55568,-0.11645 c -0.0943,-0.72488 -0.10766,-1.40752 -0.0393,-2.04319 0.0479,-0.41934 0.15908,-0.99495 0.3336,-1.72685 0.1532,-0.52031 0.32727,-0.97594 0.51773,-1.36598 z m -3.91671,1.12166 c -0.0523,-0.28983 -0.14276,-0.53718 -0.27483,-0.73635 -0.13121,-0.19439 -0.28814,-0.35383 -0.4735,-0.46786 -0.1889,-0.10835 -0.39827,-0.17789 -0.62723,-0.20388 -0.22896,-0.026 -0.46956,-0.015 -0.72094,0.0376 -0.30868,0.0647 -0.56826,0.17335 -0.78227,0.33162 -0.21401,0.15827 -0.38059,0.35098 -0.49977,0.57816 -0.11918,0.22715 -0.18826,0.47833 -0.21434,0.76488 -0.0261,0.28655 -0.009,0.58379 0.0573,0.90031 l 0.51598,-0.10815 c -0.0464,-0.2319 -0.0683,-0.45418 -0.0566,-0.66865 0.007,-0.21356 0.0496,-0.40983 0.12626,-0.59357 0.0731,-0.17806 0.18667,-0.335 0.33711,-0.46515 0.15128,-0.12541 0.34556,-0.21543 0.5793,-0.26442 0.17198,-0.0361 0.34471,-0.0427 0.50849,-0.0228 0.16465,0.0247 0.31595,0.0768 0.45474,0.16113 0.13882,0.0843 0.25545,0.19796 0.3499,0.34089 0.0989,0.14201 0.16588,0.31042 0.20278,0.51474 0.0438,0.24234 0.0426,0.46447 -0.004,0.66167 -0.0512,0.19811 -0.13853,0.39889 -0.262,0.60227 -0.12789,0.20435 -0.27953,0.40378 -0.45139,0.59269 l -1.02945,1.14282 c -0.16573,0.19747 -0.30598,0.40932 -0.42687,0.62699 -0.12005,0.22241 -0.20051,0.46118 -0.2511,0.71342 -0.0497,0.25699 -0.0537,0.53891 -0.003,0.84395 l 3.78383,-0.79302 -0.0926,-0.51317 -3.19288,0.66916 c -0.006,-0.21079 0.0435,-0.4184 0.14402,-0.62193 0.10142,-0.1988 0.22221,-0.39176 0.36761,-0.57512 l 1.35711,-1.48273 c 0.1454,-0.18334 0.26973,-0.382 0.37028,-0.58553 0.10499,-0.20447 0.17565,-0.42146 0.21644,-0.65192 0.0408,-0.23045 0.0385,-0.4716 -0.008,-0.72819 z"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500047 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 V 84 96.75181 c -0.0527,8.84203 1.82291,9.74838 11.83407,9.74838 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 337.97659,211.50015 c 4.67187,0 5.5471,-0.42296 5.52255,-4.54923 v -7.95037 -5.95084 c 0.0245,-4.12627 -0.85068,-4.54923 -5.52255,-4.54923 h -11.95364 c -4.67071,0 -5.52256,0.42291 -5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 0.85185,4.54923 5.52256,4.54923 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.55494,251.5 c 3.33705,0 3.96221,-0.30212 3.94468,-3.24946 v -4.2505 -4.25059 c 0.0175,-2.94734 -0.60763,-3.24945 -3.94468,-3.24945 h -7.11025 c -3.33622,0 -3.94469,0.30208 -3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 0.60847,3.24946 3.94469,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 78.92728,267.9997 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 c -0.17299,35.36811 3.625154,38.99414 38.921885,38.99414 h 146.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 c 0,35.36853 -3.62515,38.99414 -38.92188,38.99414 z"
-         id="path931-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline;opacity:0.7">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.44531,237 c -1.65302,0 -2.54604,0.12548 -2.91601,0.41406 -0.18499,0.14429 -0.30479,0.33122 -0.39649,0.70313 C 321.0411,238.4891 321,239.03036 321,239.75 v 4.25 4.25 c 0,0.71964 0.0411,1.26082 0.13281,1.63281 0.0917,0.37191 0.2115,0.55884 0.39649,0.70313 0.36997,0.28858 1.26299,0.41406 2.91601,0.41406 h 7.10938 c 1.65343,0 2.55203,-0.12511 2.92383,-0.41406 0.18589,-0.14448 0.30578,-0.33208 0.39648,-0.70313 0.0907,-0.37105 0.129,-0.90979 0.125,-1.6289 v -0.002 V 244 v -4.25195 -0.002 c 0.004,-0.71911 -0.0343,-1.25785 -0.125,-1.6289 -0.0907,-0.37105 -0.21059,-0.55865 -0.39648,-0.70313 C 334.10673,237.12512 333.20812,237 331.55469,237 Z m 5.32813,1.04688 c 1.10767,-3.4e-4 2.21363,0.008 3.32031,0.0449 0.26616,0.0599 0.75737,-0.0208 0.79297,0.3457 0.13405,1.84438 0.0662,3.68774 0.10156,5.53906 -0.0126,1.86745 0.0543,3.67031 -0.10351,5.49805 0.0642,0.42314 -0.43946,0.35577 -0.70313,0.42187 -3.43277,0.0703 -6.87577,0.0589 -10.29883,0.002 -0.22288,-0.0398 -0.55622,-3.2e-4 -0.71093,-0.1875 -0.19863,-1.12995 -0.12696,-2.26946 -0.16016,-3.41992 0.0138,-2.55648 -0.029,-5.10728 0.0898,-7.65625 -0.03,-0.2727 0.10944,-0.49629 0.40039,-0.48829 1.30659,-0.161 2.63265,-0.0636 3.94727,-0.0976 1.10718,0.006 2.21655,-0.002 3.32422,-0.002 z"
-         id="path918-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate"
-         d="m 326.02383,189.00048 c -2.32027,0 -3.60941,0.15494 -4.20703,0.62109 -0.29882,0.23308 -0.48964,0.54668 -0.625,1.09571 -0.13541,0.54902 -0.19141,1.31765 -0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 0.056,1.783 0.19141,2.33203 0.13536,0.54903 0.32618,0.86263 0.625,1.09571 0.59762,0.46615 1.88676,0.62109 4.20703,0.62109 h 11.9524 c 2.32085,0 3.61652,-0.15457 4.2168,-0.62109 0.30014,-0.23327 0.49095,-0.54754 0.625,-1.09571 0.13404,-0.54816 0.18764,-1.31623 0.18164,-2.33008 v -7.95279 -5.95312 c 0.006,-1.01386 -0.0476,-1.78191 -0.18164,-2.33008 -0.13406,-0.54817 -0.32486,-0.86244 -0.625,-1.09571 -0.60028,-0.46652 -1.89595,-0.62109 -4.2168,-0.62109 z m 4.95859,1.00977 c 1.5798,-0.002 4.16014,-3.9e-4 5.73991,0.0117 1.50021,0.0511 3.02236,-0.0712 4.5,0.28321 0.55111,0.0919 0.61303,0.71807 0.67773,1.16601 0.1117,4.30832 0.075,10.62608 0.0508,14.94108 -0.0716,0.99089 0.13687,2.07606 -0.30078,3.01366 -0.34356,0.40964 -0.9694,0.35958 -1.45117,0.45509 -3.95407,0.0823 -9.92936,0.0499 -13.89381,0.0371 -1.16908,-0.0622 -2.37292,0.11291 -3.51758,-0.22266 -0.57935,-0.098 -0.6137,-0.75914 -0.6875,-1.2207 -0.1146,-4.11835 -0.0751,-10.24472 -0.0547,-14.36881 0.0572,-1.06305 -0.0797,-2.16734 0.18164,-3.21485 0.10495,-0.6386 0.8614,-0.66043 1.36719,-0.74023 2.1305,-0.19658 5.24071,-0.10662 7.38828,-0.14062 z"
-         id="path914-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12695,134 c -3.21072,0 -5.03255,0.19514 -5.9375,0.89844 -0.45247,0.35165 -0.74178,0.83286 -0.93359,1.61718 -0.19176,0.78433 -0.26386,1.85686 -0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c -0.008,1.40682 0.0641,2.47935 0.25586,3.26368 0.1918,0.78431 0.48112,1.26553 0.93359,1.61718 0.90496,0.7033 2.72678,0.89844 5.9375,0.89844 h 13.7461 c 3.20992,0 5.02461,-0.19551 5.92578,-0.89844 0.45058,-0.35146 0.73805,-0.83201 0.93164,-1.61718 C 349.9241,158.69918 350,157.62415 350,156.2168 V 148 139.7832 c 0,-1.40735 -0.0759,-2.48237 -0.26953,-3.26758 -0.19359,-0.78517 -0.48106,-1.26572 -0.93164,-1.61718 C 347.89766,134.19551 346.08297,134 342.87305,134 Z m 6.49805,1.04688 c 3.45647,0.0171 6.9142,-0.0268 10.36133,0.0918 0.8211,0.13276 1.80664,0.14835 2.39062,0.82617 0.67884,1.16473 0.51296,2.58781 0.56446,3.87305 0.0431,6.02893 0.0678,12.06719 -0.0332,18.08789 -0.0775,0.77792 -0.12055,1.67263 -0.67968,2.27539 -0.70249,0.51038 -1.61833,0.59683 -2.45899,0.67383 -4.04742,0.0864 -8.16222,0.0456 -12.24023,0.0606 -2.45188,-0.0199 -4.91402,0.0317 -7.35352,-0.0606 -0.87784,-0.12055 -1.915,-0.14021 -2.56055,-0.83398 -0.64775,-1.02591 -0.50264,-2.30525 -0.56054,-3.46485 -0.035,-5.65575 -0.0351,-11.35518 0,-17.00976 0.0632,-1.22153 -0.10864,-2.57724 0.59179,-3.65235 0.6025,-0.62665 1.55621,-0.63986 2.35938,-0.77344 2.73743,-0.10739 5.48083,-0.0704 8.22656,-0.0918 0.46403,-2.9e-4 0.92855,-0.002 1.39258,-0.002 z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33594,62 c -4.99049,0 -7.87051,0.276282 -9.38477,1.453125 -0.75713,0.588421 -1.23761,1.403518 -1.54492,2.660156 -0.3073,1.256638 -0.4173,2.940031 -0.4043,5.132813 V 84 96.753906 c -0.0131,2.19278 0.097,3.876174 0.4043,5.132814 0.30731,1.25663 0.78779,2.07172 1.54492,2.66016 1.51427,1.17683 4.39428,1.45312 9.38477,1.45312 h 21.33008 c 4.98923,0 7.85502,-0.27668 9.36328,-1.45312 0.75412,-0.58824 1.23293,-1.40461 1.54297,-2.66211 C 365.8823,100.62727 366,98.945281 366,96.751953 V 84 71.248047 c 0,-2.193329 -0.1177,-3.875313 -0.42773,-5.132813 -0.31004,-1.257499 -0.78884,-2.073874 -1.54297,-2.662109 C 362.52104,62.276656 359.65526,62 354.66602,62 Z m 2.40234,1.097656 c 6.94737,8.3e-4 13.91063,0.0034 20.84961,0.05469 2.14296,0.08293 4.46431,-0.147701 6.42383,0.93164 1.29609,0.695228 1.54862,2.250325 1.76953,3.564454 0.17551,2.202888 0.0915,4.442228 0.13867,6.669921 0.0227,8.479532 0.077,16.968993 -0.0801,25.447266 -0.16151,1.483233 -0.38135,3.305793 -1.79882,4.142573 -1.6055,0.82871 -3.47551,0.90643 -5.24805,0.95313 -9.49974,0.0678 -19.0243,0.0843 -28.52344,-0.0176 -1.57816,-0.11413 -3.27053,-0.24014 -4.63281,-1.12109 -1.22952,-0.99538 -1.36082,-2.72739 -1.50391,-4.193361 -0.1272,-8.998585 -0.0836,-18.004484 -0.0527,-27.007813 0.0997,-2.381275 -0.24538,-4.900002 0.70508,-7.160156 0.67165,-1.50972 2.46573,-1.859954 3.93945,-2.05664 2.66168,-0.316582 5.34184,-0.147022 8.01367,-0.207032 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
+         style="display:inline;fill:#333333;fill-opacity:1;stroke-width:0.0170209;enable-background:new" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/calls-app.svg
+++ b/icons/src/fullcolor/default/apps/calls-app.svg
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
-   sodipodi:docname="calls.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="calls-app.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,18 +30,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.9999999"
-     inkscape:cx="229.50001"
-     inkscape:cy="-1.7500001"
-     inkscape:current-layer="svg11300"
-     showgrid="true"
+     inkscape:zoom="1.6125"
+     inkscape:cx="265.42636"
+     inkscape:cy="144.49612"
+     inkscape:current-layer="layer2"
+     showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1366"
-     inkscape:window-height="704"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +60,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -90,409 +90,7 @@
        originy="0" />
   </sodipodi:namedview>
   <defs
-     id="defs3">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4220"
-       id="linearGradient1686"
-       x1="320.99991"
-       y1="92.000153"
-       x2="366.99991"
-       y2="76.000153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000121)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4220"
-       id="linearGradient1688"
-       x1="321.00003"
-       y1="153.00002"
-       x2="351.00003"
-       y2="143.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00002,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4220"
-       id="linearGradient1690"
-       x1="320.9993"
-       y1="202.99928"
-       x2="342.9993"
-       y2="196.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4220"
-       id="linearGradient1692"
-       x1="320.00031"
-       y1="247.00034"
-       x2="336.00031"
-       y2="241.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4220"
-       id="linearGradient1694"
-       x1="39.997601"
-       y1="203.99699"
-       x2="263.99759"
-       y2="107.997"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,151.9973,155.9997)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1692-6"
-       x1="321.00031"
-       y1="244.00034"
-       x2="335.00031"
-       y2="244.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1690-9"
-       x1="320.9993"
-       y1="199.99928"
-       x2="342.9993"
-       y2="199.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1688-4"
-       x1="322"
-       y1="148.00002"
-       x2="350"
-       y2="148.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00001,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1686-0"
-       x1="321.99991"
-       y1="84.000153"
-       x2="365.99991"
-       y2="84.000153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000125)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58449"
-       x="-0.047999425"
-       width="1.0959989"
-       y="-0.048000575"
-       height="1.0960012">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.4800539"
-         id="feGaussianBlur58451" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58492"
-       x="-0.011999856"
-       width="1.0239997"
-       y="-0.012000144"
-       height="1.0240003">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1200135"
-         id="feGaussianBlur58494" />
-    </filter>
-    <linearGradient
-       id="linearGradient4220"
-       inkscape:collect="always">
-      <stop
-         id="stop4222"
-         offset="0"
-         style="stop-color:#45a926;stop-opacity:1" />
-      <stop
-         id="stop4224"
-         offset="1"
-         style="stop-color:#79c32a;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(-1.655943e-6,2.8859727)"
-       y2="48.20969"
-       x2="309.44595"
-       y1="463.79126"
-       x1="309.44595"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4284"
-       xlink:href="#linearGradient4347"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient4347"
-       inkscape:collect="always">
-      <stop
-         id="stop4349"
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.49620295"
-         id="stop4355" />
-      <stop
-         id="stop4351"
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0" />
-    </linearGradient>
-    <filter
-       height="1.1920039"
-       y="-0.096001969"
-       width="1.1919961"
-       x="-0.09599804"
-       id="filter4300"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur4302"
-         stdDeviation="16.623603"
-         inkscape:collect="always" />
-    </filter>
-    <filter
-       height="1.0240005"
-       y="-0.012000246"
-       width="1.0239995"
-       x="-0.011999755"
-       id="filter4315"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur4317"
-         stdDeviation="2.0779504"
-         inkscape:collect="always" />
-    </filter>
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="255.66826"
-       x2="344.64804"
-       y1="236.4198"
-       x1="364.34528"
-       id="linearGradient4432"
-       xlink:href="#linearGradient4142"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient4142"
-       inkscape:collect="always">
-      <stop
-         id="stop4144"
-         offset="0"
-         style="stop-color:#88b637;stop-opacity:1" />
-      <stop
-         id="stop4146"
-         offset="1"
-         style="stop-color:#88b637;stop-opacity:0" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(-1.655943e-6,2.8859727)"
-       y2="48.20969"
-       x2="309.44595"
-       y1="463.79126"
-       x1="309.44595"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4284-3"
-       xlink:href="#linearGradient4347"
-       inkscape:collect="always" />
-    <filter
-       height="1.1920039"
-       y="-0.096001969"
-       width="1.1919961"
-       x="-0.09599804"
-       id="filter4300-9"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur4302-1"
-         stdDeviation="16.623603"
-         inkscape:collect="always" />
-    </filter>
-    <filter
-       height="1.0240005"
-       y="-0.012000246"
-       width="1.0239995"
-       x="-0.011999755"
-       id="filter4315-2"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur4317-7"
-         stdDeviation="2.0779504"
-         inkscape:collect="always" />
-    </filter>
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="255.66826"
-       x2="344.64804"
-       y1="236.4198"
-       x1="364.34528"
-       id="linearGradient4432-0"
-       xlink:href="#linearGradient4142"
-       inkscape:collect="always" />
-    <filter
-       height="1.1920039"
-       y="-0.096001969"
-       width="1.1919961"
-       x="-0.09599804"
-       id="filter4300-9-3"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur4302-1-7"
-         stdDeviation="16.623603"
-         inkscape:collect="always" />
-    </filter>
-    <filter
-       height="1.0240005"
-       y="-0.012000246"
-       width="1.0239995"
-       x="-0.011999755"
-       id="filter4315-2-5"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur4317-7-9"
-         stdDeviation="2.0779504"
-         inkscape:collect="always" />
-    </filter>
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="255.66826"
-       x2="344.64804"
-       y1="236.4198"
-       x1="364.34528"
-       id="linearGradient4432-0-2"
-       xlink:href="#linearGradient4142"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4347"
-       id="linearGradient2563"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-1.655943e-6,2.8859727)"
-       x1="309.44595"
-       y1="463.79126"
-       x2="309.44595"
-       y2="48.20969" />
-    <filter
-       height="1.1920039"
-       y="-0.096001969"
-       width="1.1919961"
-       x="-0.09599804"
-       id="filter4300-9-3-4"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur4302-1-7-5"
-         stdDeviation="16.623603"
-         inkscape:collect="always" />
-    </filter>
-    <filter
-       height="1.0240005"
-       y="-0.012000246"
-       width="1.0239995"
-       x="-0.011999755"
-       id="filter4315-2-5-0"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur4317-7-9-3"
-         stdDeviation="2.0779504"
-         inkscape:collect="always" />
-    </filter>
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="255.66826"
-       x2="344.64804"
-       y1="236.4198"
-       x1="364.34528"
-       id="linearGradient4432-0-2-6"
-       xlink:href="#linearGradient4142"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4347"
-       id="linearGradient2933"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-1.655943e-6,2.8859727)"
-       x1="309.44595"
-       y1="463.79126"
-       x2="309.44595"
-       y2="48.20969" />
-    <filter
-       height="1.1920039"
-       y="-0.096001969"
-       width="1.1919961"
-       x="-0.09599804"
-       id="filter4300-9-3-4-9"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur4302-1-7-5-3"
-         stdDeviation="16.623603"
-         inkscape:collect="always" />
-    </filter>
-    <filter
-       height="1.0240005"
-       y="-0.012000246"
-       width="1.0239995"
-       x="-0.011999755"
-       id="filter4315-2-5-0-7"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur4317-7-9-3-4"
-         stdDeviation="2.0779504"
-         inkscape:collect="always" />
-    </filter>
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="255.66826"
-       x2="344.64804"
-       y1="236.4198"
-       x1="364.34528"
-       id="linearGradient4432-0-2-6-5"
-       xlink:href="#linearGradient4142"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4347"
-       id="linearGradient3067"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-1.655943e-6,2.8859727)"
-       x1="309.44595"
-       y1="463.79126"
-       x2="309.44595"
-       y2="48.20969" />
-  </defs>
+     id="defs3" />
   <metadata
      id="metadata4">
     <rdf:RDF>
@@ -503,13 +101,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -591,7 +189,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">org.gnome.Calls</tspan></text>
+           id="tspan924">org.gnome.Calls</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -626,405 +224,98 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer9"
-       inkscape:label="Optional outline for white icons"
-       style="display:none">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 225.07297,43.99969 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 c 0.17299,35.36812 -3.62489,38.99353 -38.92162,38.99353 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 155.99969 82.99322 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 43.787062,92.125939 c 0.0052,1.533601 -3.766196,1.116294 -3.687951,3.077638 0.95459,23.504823 8.320059,75.855993 52.580689,120.116623 44.95441,44.9544 98.26016,51.8504 121.20162,52.62242 1.52839,0.0467 1.83615,-3.46365 3.08285,-3.45843 l 1.26236,-49.07532 C 206.03605,215.66969 155.91225,227.90201 118.15118,190.14093 80.390107,152.37986 93.936937,102.1413 94.202971,89.950723 Z"
+         fill="#0067bb"
+         id="path121"
+         style="fill-rule:nonzero;stroke-width:5.21633" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 213.30762,187.65274 C 241.142,187.65274 264,193.48982 264,219.99925 264,246.50868 241.43412,268 213.59974,268 c -27.83438,0 -50.40026,-21.49132 -50.40026,-48.00075 0,-26.50943 22.27376,-32.34651 50.10814,-32.34651 z M 118.88669,94.546317 c 0,27.834383 -4.37652,50.254203 -30.885943,50.254203 C 61.491314,144.80052 40,122.23464 40,94.400259 40,66.56588 61.491314,44 88.000747,44 114.51017,44 118.88669,66.711937 118.88669,94.546317 Z"
+         fill="#2bb7f6"
+         id="path123"
+         style="fill-rule:nonzero;stroke-width:5.21633" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.12858,237.00001 c -3.74357,0 -4.14638,0.30899 -4.12803,3.32331 v 4.17669 4.17668 c -0.0183,3.01433 0.38446,3.32332 4.12803,3.32332 h 7.74335 c 3.7436,0 4.12805,-0.30895 4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 -0.38446,-3.32331 -4.12805,-3.32331 z"
-         id="path918-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         id="path4245-0"
+         d="M 264,57.436135 C 264,48.480161 264.00014,44 253.56792,44 h -12.52716 c -10.43221,0 -10.43208,4.480161 -10.43208,13.436135 v 6.521731 c 0,8.955973 -1.3e-4,13.433459 10.43208,13.433459 h 12.52716 C 263.62753,77.391325 264,72.913839 264,63.957866 Z m 0,41.739157 c 0,-8.955973 1.4e-4,-13.436134 -10.43208,-13.436134 h -12.52716 c -10.43221,0 -10.43208,4.480161 -10.43208,13.436134 v 6.521728 c 0,8.95598 -1.3e-4,13.43339 10.43208,13.43339 h 12.52716 C 263.62753,119.13041 264,114.653 264,105.69702 Z m 0,41.739088 c 0,-8.95598 1.4e-4,-13.43614 -10.43208,-13.43614 h -12.52716 c -10.43221,0 -10.43208,4.48016 -10.43208,13.43614 v 6.52173 c 0,8.95597 -1.3e-4,13.43346 10.43208,13.43346 h 12.52716 C 263.62753,160.86957 264,156.39208 264,147.43611 Z M 222.26085,57.436135 C 222.26085,48.480161 222.26105,44 211.82884,44 h -12.52723 c -10.43222,0 -10.43202,4.480161 -10.43202,13.436135 v 6.521731 c 0,8.955973 -2e-4,13.433459 10.43202,13.433459 h 12.52723 c 10.05961,0 10.43201,-4.477486 10.43201,-13.433459 z m 0,41.739157 c 0,-8.955973 2e-4,-13.436134 -10.43201,-13.436134 h -12.52723 c -10.43222,0 -10.43202,4.480161 -10.43202,13.436134 v 6.521728 c 0,8.95598 -2e-4,13.43339 10.43202,13.43339 h 12.52723 c 10.05961,0 10.43201,-4.47741 10.43201,-13.43339 z M 180.52176,57.436135 C 180.52176,48.480161 180.52189,44 170.08968,44 h -12.52716 c -10.43221,0 -10.43208,4.480161 -10.43208,13.436135 v 6.521731 c 0,8.955973 -1.3e-4,13.433459 10.43208,13.433459 h 12.52716 c 10.05961,0 10.43208,-4.477486 10.43208,-13.433459 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#0067bb;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.95647;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 326.45275,189.00048 c -1.2321,0 -2.21668,0.0221 -3.06999,0.14144 -0.85332,0.11937 -1.62809,0.35533 -2.21066,0.83967 -0.58256,0.48436 -0.86983,1.13381 -1.01188,1.84587 -0.14202,0.71207 -0.16501,1.53239 -0.15897,2.56202 v 7.61066 4.6143 c -0.006,1.02762 0.0171,1.84735 0.15897,2.55843 0.14203,0.71208 0.42931,1.36152 1.01188,1.84587 0.58258,0.48434 1.35734,0.7203 2.21066,0.83967 0.85331,0.11936 1.83789,0.14144 3.06999,0.14144 h 11.09542 c 1.2321,0 2.21381,-0.022 3.0657,-0.14144 0.85187,-0.11947 1.62795,-0.35683 2.2085,-0.84146 0.58057,-0.48464 0.86451,-1.13152 1.00758,-1.84228 0.14307,-0.71077 0.16972,-1.5314 0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 -0.0266,-1.84946 -0.16972,-2.56023 -0.14307,-0.71076 -0.42701,-1.35765 -1.00758,-1.84228 -0.58055,-0.48464 -1.35661,-0.722 -2.2085,-0.84147 -0.8519,-0.11947 -1.83359,-0.14144 -3.0657,-0.14144 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         d="m 321.7777,70.883005 c 0.001,0.314936 -0.77342,0.229239 -0.75735,0.632015 0.19603,4.826883 1.70859,15.577569 10.79782,24.666806 9.23171,9.231704 20.17843,10.647854 24.88962,10.806384 0.31387,0.01 0.37707,-0.71128 0.63309,-0.71021 l 0.25923,-10.077964 c -2.50342,0.05356 -12.7967,2.565554 -20.55121,-5.188952 -7.7545,-7.754506 -4.97257,-18.071352 -4.91793,-20.574775 z"
+         fill="#0067bb"
+         id="path868"
+         style="fill-rule:nonzero;stroke-width:1.07121" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 329.30094,134 c -1.63949,0 -2.94082,0.0308 -4.04505,0.19141 -1.10422,0.16064 -2.06697,0.4726 -2.78308,1.09179 -0.71611,0.61919 -1.0805,1.45612 -1.26421,2.41407 -0.18374,0.95795 -0.21537,2.08705 -0.20733,3.51171 V 149 v 7.79688 c -0.009,1.42131 0.0239,2.5495 0.20733,3.50585 0.18371,0.95796 0.5481,1.79488 1.26421,2.41407 0.71611,0.61919 1.67886,0.93115 2.78308,1.09179 1.10423,0.16065 2.40556,0.19141 4.04505,0.19141 h 13.40164 c 1.63949,0 2.93835,-0.0307 4.04054,-0.19141 1.10219,-0.16075 2.06274,-0.47425 2.77633,-1.09375 0.71357,-0.6195 1.07457,-1.45363 1.25969,-2.41015 C 350.96429,159.34816 351,158.22066 351,156.79688 V 149 141.20312 c 0,-1.42378 -0.0358,-2.55128 -0.22086,-3.50781 -0.18512,-0.95653 -0.54612,-1.79065 -1.25969,-2.41015 -0.71359,-0.61951 -1.67414,-0.933 -2.77633,-1.09375 C 345.64093,134.03065 344.34207,134 342.70258,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
+         d="M 356.58996,90.500116 C 362.30595,90.500116 367,91.698802 367,97.142703 367,102.5866 362.36593,107 356.64994,107 c -5.71598,0 -10.35005,-4.4134 -10.35005,-9.857297 0,-5.443901 4.57408,-6.642587 10.29007,-6.642587 z M 337.19994,71.380047 c 0,5.715989 -0.89874,10.320059 -6.34264,10.320059 C 325.41339,81.700106 321,77.066042 321,71.350053 321,65.634064 325.41339,61 330.8573,61 c 5.4439,0 6.34264,4.664058 6.34264,10.380047 z"
+         fill="#2bb7f6"
+         id="path870"
+         style="fill-rule:nonzero;stroke-width:1.07121" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 333.65776,62 c -2.6221,0 -4.68675,0.05009 -6.38561,0.286735 -1.69887,0.236639 -3.08904,0.680503 -4.10735,1.523515 -1.0183,0.843013 -1.55577,1.996072 -1.83828,3.406406 -0.28252,1.410336 -0.33767,3.127346 -0.32482,5.308412 v 12.474816 12.480783 c -0.0127,2.177715 0.0426,3.893853 0.32482,5.302673 0.28251,1.41034 0.81998,2.5634 1.83828,3.40641 1.01831,0.84301 2.40848,1.28688 4.10735,1.52351 1.69888,0.23665 3.76351,0.28674 6.38561,0.28674 h 20.68618 c 2.62213,0 4.68568,-0.05 6.38104,-0.28674 1.69534,-0.23674 3.08126,-0.6821 4.09581,-1.52542 1.01457,-0.84331 1.54885,-1.99555 1.83367,-3.4045 C 366.93929,101.37441 367,99.660878 367,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0608,-3.893733 -0.34554,-5.302677 -0.28482,-1.408942 -0.81911,-2.561177 -1.83368,-3.404494 -1.01455,-0.843317 -2.40047,-1.288685 -4.09582,-1.525427 C 359.02962,62.049992 356.96605,62 354.34394,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
+         id="path872"
+         d="M 367,63.759206 C 367,61.920033 367.00003,61 364.8577,61 h -2.57255 c -2.14232,0 -2.1423,0.920033 -2.1423,2.759206 v 1.339284 c 0,1.839173 -2e-5,2.758657 2.1423,2.758657 h 2.57255 c 2.06581,0 2.1423,-0.919484 2.1423,-2.758657 z m 0,8.571434 c 0,-1.839173 3e-5,-2.759206 -2.1423,-2.759206 h -2.57255 c -2.14232,0 -2.1423,0.920033 -2.1423,2.759206 v 1.339284 c 0,1.839173 -2e-5,2.758643 2.1423,2.758643 h 2.57255 c 2.06581,0 2.1423,-0.91947 2.1423,-2.758643 z m 0,8.571419 c 0,-1.839173 3e-5,-2.759206 -2.1423,-2.759206 h -2.57255 c -2.14232,0 -2.1423,0.920033 -2.1423,2.759206 v 1.339284 c 0,1.839174 -2e-5,2.758657 2.1423,2.758657 h 2.57255 C 366.92351,85 367,84.080517 367,82.241343 Z m -8.57143,-17.142853 c 0,-1.839173 4e-5,-2.759206 -2.14229,-2.759206 h -2.57256 c -2.14233,0 -2.14229,0.920033 -2.14229,2.759206 v 1.339284 c 0,1.839173 -4e-5,2.758657 2.14229,2.758657 h 2.57256 c 2.06581,0 2.14229,-0.919484 2.14229,-2.758657 z m 0,8.571434 c 0,-1.839173 4e-5,-2.759206 -2.14229,-2.759206 h -2.57256 c -2.14233,0 -2.14229,0.920033 -2.14229,2.759206 v 1.339284 c 0,1.839173 -4e-5,2.758643 2.14229,2.758643 h 2.57256 c 2.06581,0 2.14229,-0.91947 2.14229,-2.758643 z m -8.57142,-8.571434 c 0,-1.839173 2e-5,-2.759206 -2.1423,-2.759206 H 345.1423 C 342.99997,61 343,61.920033 343,63.759206 v 1.339284 c 0,1.839173 -3e-5,2.758657 2.1423,2.758657 h 2.57255 c 2.06581,0 2.1423,-0.919484 2.1423,-2.758657 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#0067bb;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.42856;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500049 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 v 12.75157 12.75181 c -0.0527,8.842031 1.82291,9.748381 11.83407,9.748381 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.748381 v -12.75181 -12.75157 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 321.5072,139.44544 c 7e-4,0.2054 -0.5044,0.14951 -0.49392,0.41219 0.12784,3.14796 1.11429,10.15928 7.04205,16.08704 6.02068,6.02068 13.15985,6.94425 16.23236,7.04765 0.2047,0.006 0.24592,-0.46388 0.41289,-0.46318 l 0.16906,-6.57259 c -1.63267,0.0349 -8.34567,1.67319 -13.40296,-3.3841 -5.05729,-5.05729 -3.24298,-11.78566 -3.20735,-13.41833 z"
+         fill="#0067bb"
+         id="path876"
+         style="fill-rule:nonzero;stroke-width:0.698615" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1694);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 225.07297,43.999694 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.006466 73.00648 c 0.17299,35.36812 -3.62489,38.99353 -38.92162,38.99353 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 155.99969 82.993224 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 344.21085,152.23921 c 3.72782,0 6.78915,0.78175 6.78915,4.33212 0,3.55037 -3.02221,6.42867 -6.75003,6.42867 -3.72782,0 -6.75004,-2.8783 -6.75004,-6.42867 0,-3.55037 2.9831,-4.33212 6.71092,-4.33212 z M 331.56519,139.7696 c 0,3.72782 -0.58614,6.73047 -4.13651,6.73047 -3.55038,0 -6.42868,-3.02221 -6.42868,-6.75003 0,-3.72782 2.8783,-6.75004 6.42868,-6.75004 3.55037,0 4.13651,3.04178 4.13651,6.7696 z"
+         fill="#2bb7f6"
+         id="path878"
+         style="fill-rule:nonzero;stroke-width:0.698615" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 326.17688,188.49945 c -5.14666,0 -5.70043,0.43262 -5.67521,4.65309 v 5.84793 7.84761 c -0.0253,4.22046 0.52855,4.65307 5.67521,4.65307 h 11.64568 c 5.14665,0 5.67521,-0.43255 5.67521,-4.65307 v -7.84761 -5.84793 c 0,-4.22051 -0.52857,-4.65309 -5.67522,-4.65309 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
+         id="path880"
+         d="M 351,134.79949 C 351,133.60003 351.00002,133 349.60285,133 h -1.67774 c -1.39718,0 -1.39716,0.60003 -1.39716,1.79949 v 0.87344 c 0,1.19946 -2e-5,1.79913 1.39716,1.79913 h 1.67774 c 1.34727,0 1.39715,-0.59967 1.39715,-1.79913 z m 0,5.59006 c 0,-1.19946 2e-5,-1.79948 -1.39715,-1.79948 h -1.67774 c -1.39718,0 -1.39716,0.60002 -1.39716,1.79948 v 0.87345 c 0,1.19946 -2e-5,1.79911 1.39716,1.79911 h 1.67774 c 1.34727,0 1.39715,-0.59965 1.39715,-1.79911 z m 0,5.59006 c 0,-1.19946 2e-5,-1.79948 -1.39715,-1.79948 h -1.67774 c -1.39718,0 -1.39716,0.60002 -1.39716,1.79948 v 0.87344 c 0,1.19947 -2e-5,1.79913 1.39716,1.79913 h 1.67774 c 1.34727,0 1.39715,-0.59966 1.39715,-1.79913 z m -5.59006,-11.18012 c 0,-1.19946 3e-5,-1.79949 -1.39715,-1.79949 h -1.67775 c -1.39717,0 -1.39714,0.60003 -1.39714,1.79949 v 0.87344 c 0,1.19946 -3e-5,1.79913 1.39714,1.79913 h 1.67775 c 1.34727,0 1.39715,-0.59967 1.39715,-1.79913 z m 0,5.59006 c 0,-1.19946 3e-5,-1.79948 -1.39715,-1.79948 h -1.67775 c -1.39717,0 -1.39714,0.60002 -1.39714,1.79948 v 0.87345 c 0,1.19946 -3e-5,1.79911 1.39714,1.79911 h 1.67775 c 1.34727,0 1.39715,-0.59965 1.39715,-1.79911 z m -5.59006,-5.59006 c 0,-1.19946 2e-5,-1.79949 -1.39715,-1.79949 h -1.67775 c -1.39717,0 -1.39715,0.60003 -1.39715,1.79949 v 0.87344 c 0,1.19946 -2e-5,1.79913 1.39715,1.79913 h 1.67775 c 1.34727,0 1.39715,-0.59967 1.39715,-1.79913 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#0067bb;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.93167;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.4056,236.50001 c -3.47604,0 -3.85006,0.30899 -3.83302,3.32331 v 4.17669 4.17668 c -0.017,3.01433 0.35698,3.32332 3.83302,3.32332 h 7.18996 c 3.47605,0 3.83303,-0.30895 3.83303,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.35699,-3.32331 -3.83303,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 320.88885,193.4415 c 5.4e-4,0.15747 -0.38671,0.11462 -0.37867,0.31601 0.098,2.41344 0.85429,7.78878 5.39891,12.3334 4.61585,4.61586 10.08921,5.32393 12.44481,5.4032 0.15693,0.005 0.18853,-0.35565 0.31654,-0.35511 l 0.12962,-5.03898 c -1.25172,0.0268 -6.39836,1.28277 -10.27561,-2.59448 -3.87725,-3.87725 -2.48628,-9.03567 -2.45897,-10.28739 z"
+         fill="#0067bb"
+         id="path884"
+         style="fill-rule:nonzero;stroke-width:0.535605" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <g
-         id="g1279"
-         style="enable-background:new"
-         transform="matrix(0.49519677,0,0,0.49519677,28.133724,31.239082)">
-        <path
-           id="path4245"
-           d="M 132.89478,112 C 118.96719,112 112,111.99975 112,128.22309 v 19.48123 c 0,16.22333 6.96719,16.22309 20.89478,16.22309 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22309 V 128.22309 C 163.92741,112.57919 156.96444,112 143.03685,112 Z m 64.90926,0 c -13.92759,0 -20.89478,-2.5e-4 -20.89478,16.22309 v 19.48123 c 0,16.22333 6.96719,16.22309 20.89478,16.22309 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22309 V 128.22309 C 228.83667,112.57919 221.8737,112 207.94611,112 Z m 64.90926,0 c -13.92759,0 -20.89477,-2.5e-4 -20.89477,16.22309 v 19.48123 c 0,16.22333 6.96718,16.22309 20.89477,16.22309 h 10.14208 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22309 V 128.22309 C 293.74594,112.57919 286.78297,112 272.85538,112 Z M 132.89478,176.90926 C 118.96719,176.90926 112,176.90901 112,193.13235 v 19.48124 c 0,16.22332 6.96719,16.22308 20.89478,16.22308 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22308 v -19.48124 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m 64.90926,0 c -13.92759,0 -20.89478,-2.5e-4 -20.89478,16.22309 v 19.48124 c 0,16.22332 6.96719,16.22308 20.89478,16.22308 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22308 v -19.48124 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m -64.90926,64.90927 C 118.96719,241.81853 112,241.81828 112,258.04161 v 19.48124 c 0,16.22332 6.96719,16.22309 20.89478,16.22309 h 10.14207 c 13.92759,0 20.89056,2.3e-4 20.89056,-16.22309 v -19.48124 c 0,-15.6439 -6.96297,-16.22308 -20.89056,-16.22308 z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#a4ff80;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.8182;marker:none;enable-background:accumulate"
-           inkscape:connector-curvature="0" />
-        <g
-           style="stroke-width:1.44299;enable-background:new"
-           transform="matrix(0.6930063,0,0,0.6930063,78.65179,78.59038)"
-           id="g4342">
-          <path
-             inkscape:connector-curvature="0"
-             id="path4277"
-             d="m 377.0604,51.095662 -52.99035,120.503618 25.46366,42.43569 c -0.0369,0.0579 -0.0783,0.11964 -0.11555,0.17756 l 4.41915,7.42913 c -19.13771,25.88597 -40.55985,49.80119 -62.6037,71.8535 l 0.003,0.003 c -0.0523,0.0521 -0.10561,0.10277 -0.15783,0.15501 l -0.15782,0.15782 c -22.08963,22.08117 -46.04947,43.53441 -71.98595,62.69671 l -7.42069,-4.41351 c -0.0579,0.0372 -0.11684,0.0787 -0.17473,0.11556 L 168.9037,326.74871 48.400091,379.73625 c 8.44659,37.30755 21.008251,101.08139 77.786089,84.13298 52.31512,-15.61629 96.19126,-46.80634 135.5197,-81.92059 l -0.008,-0.006 c 21.41516,-17.9596 41.50101,-37.33726 60.76333,-56.5922 l 0.003,0.003 0.15784,-0.15784 c 0.0517,-0.0517 0.10326,-0.10617 0.155,-0.15782 19.21912,-19.22646 38.55928,-39.2746 56.49074,-60.64496 l 0.006,0.008 C 414.38706,225.07303 445.57427,181.19689 461.19057,128.88175 478.13896,72.103926 414.36794,59.542266 377.0604,51.095662 Z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient4284);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:17.3159;marker:none;filter:url(#filter4300);enable-background:accumulate" />
-          <path
-             id="path4277-6"
-             d="m 377.06041,51.095748 -52.99036,120.503632 25.46366,42.43569 c -0.0369,0.0579 -0.0784,0.11962 -0.11558,0.17756 l 4.41915,7.42912 c -19.1377,25.88597 -40.55984,49.80119 -62.6037,71.8535 l 0.003,0.003 c -0.0524,0.0521 -0.10562,0.10274 -0.15783,0.15501 l -0.15782,0.15782 c -22.08964,22.08115 -46.04948,43.53439 -71.98597,62.6967 l -7.42068,-4.41351 c -0.0579,0.0372 -0.11688,0.0786 -0.17473,0.11558 L 168.9037,326.7488 48.400094,379.73634 c 8.44659,37.30756 21.00825,101.08139 77.786086,84.13299 52.31513,-15.61629 96.19126,-46.80634 135.51971,-81.9206 l -0.009,-0.006 c 21.41516,-17.9596 41.50101,-37.33726 60.76333,-56.5922 l 0.003,0.003 0.15784,-0.15783 c 0.0516,-0.0518 0.10331,-0.10621 0.155,-0.15782 19.21912,-19.22647 38.55928,-39.27461 56.49074,-60.64496 l 0.006,0.009 C 414.38706,225.07347 445.57427,181.19733 461.19058,128.8822 478.13897,72.104238 414.36795,59.542578 377.06041,51.095968 Z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:17.3159;marker:none;filter:url(#filter4315);enable-background:accumulate"
-             inkscape:connector-curvature="0" />
-          <path
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e5f1d0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:12;marker:none;enable-background:accumulate"
-             d="m 400.08398,157.86914 c 1.49968,5.84872 1.34031,12.70746 -1.07617,20.80274 -15.7082,52.62299 -49.89392,96.6631 -86.52929,133.3125 l 0.002,0.002 c -0.0363,0.0361 -0.0732,0.0712 -0.10938,0.10742 l -0.10937,0.10937 c -15.30825,15.30239 -31.91257,30.16962 -49.88672,43.44922 l -5.14258,-3.05859 c -0.0401,0.0258 -0.081,0.0545 -0.12109,0.0801 L 227.70312,335.0293 144.19336,371.75 c 5.85354,25.85437 14.55885,70.05004 53.90625,58.30469 36.25471,-10.82219 66.66115,-32.43709 93.91601,-56.77149 l -0.006,-0.004 c 14.84084,-12.44612 28.76046,-25.87496 42.10937,-39.21875 l 0.002,0.002 0.10938,-0.10938 c 0.0358,-0.0359 0.0716,-0.0736 0.10742,-0.10937 36.63538,-36.64938 73.94415,-77.56842 89.65234,-130.19141 7.34223,-24.59674 -6.08826,-37.81376 -23.90625,-45.7832 z"
-             transform="matrix(1.4429883,0,0,1.4429883,-159.66924,-159.58063)"
-             id="path4341"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4421"
-             d="m 378.77734,181.50977 c -12.58725,20.968 -26.92112,40.7735 -42.28906,59.46875 l 23.56641,42.42578 c 19.40976,-21.24813 37.87044,-43.73219 53.67773,-68.02344 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient4432);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.32896;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4325"
-             d="M 377.06066,48.209688 324.07131,168.71216 349.533,211.15004 c -0.0369,0.0579 -0.0787,0.11725 -0.11594,0.17517 l 29.85642,50.18919 c 35.11426,-39.32844 66.30214,-83.20317 81.91844,-135.51831 16.9484,-56.77783 -46.82372,-69.339804 -84.13126,-77.786402 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f1f8e7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:11.5439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4349"
-             transform="matrix(1.4429883,0,0,1.4429883,-113.49361,-113.405)"
-             d="m 339.95703,112 -36.72265,83.50977 0.50781,0.8457 L 339.95703,114 c 22.61992,5.12126 59.27826,12.42563 60.23047,40.52344 C 400.94154,124.7708 363.10345,117.24046 339.95703,112 Z m -16.75976,119.07031 c -13.09464,17.59853 -27.69452,33.88407 -42.71875,48.91407 l 0.002,0.002 c -0.0363,0.0361 -0.0732,0.0712 -0.10938,0.10742 l -0.10937,0.10937 c -15.30825,15.30239 -31.91257,30.16962 -49.88672,43.44922 l -5.14258,-3.05859 c -0.0401,0.0258 -0.081,0.0545 -0.12109,0.0801 L 195.70312,303.0293 112.19336,339.75 c 0.13199,0.583 0.27494,1.21951 0.41016,1.82031 l 83.0996,-36.54101 29.40821,17.64453 c 0.0401,-0.0255 0.081,-0.0543 0.12109,-0.0801 l 5.14258,3.05859 c 17.97415,-13.2796 34.57847,-28.14683 49.88672,-43.44922 l 0.10937,-0.10937 c 0.0362,-0.0362 0.0731,-0.0713 0.10938,-0.10742 l -0.002,-0.002 c 15.27653,-15.28239 30.12221,-31.85579 43.38476,-49.79493 l -0.66601,-1.11914 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:12;marker:none;enable-background:accumulate" />
-        </g>
-      </g>
+         d="m 338.29498,203.25006 c 2.85799,0 5.20502,0.59934 5.20502,3.32129 0,2.72195 -2.31703,4.92865 -5.17503,4.92865 -2.85799,0 -5.17502,-2.2067 -5.17502,-4.92865 0,-2.72195 2.28703,-3.32129 5.14503,-3.32129 z m -9.69501,-9.56004 c 0,2.858 -0.44937,5.16003 -3.17132,5.16003 -2.72195,0 -4.92865,-2.31703 -4.92865,-5.17502 0,-2.858 2.2067,-5.17503 4.92865,-5.17503 2.72195,0 3.17132,2.33203 3.17132,5.19002 z"
+         fill="#2bb7f6"
+         id="path886"
+         style="fill-rule:nonzero;stroke-width:0.535605" />
       <path
-         id="rect4158-5"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;opacity:0.1"
-         d="m 40,160 v 71.00586 C 40,266.37439 43.625165,270 78.921875,270 H 225.07812 C 260.37486,270 264.17299,266.37398 264,231.00586 V 160 Z"
-         sodipodi:nodetypes="csssccc" />
-      <g
-         id="g1279-6"
-         style="display:inline;enable-background:new"
-         transform="matrix(0.09612643,0,0,0.09612643,320.87302,60.699351)">
-        <path
-           id="path4245-0"
-           d="m 115.84244,117.56027 c -13.92759,0 -20.894776,-2.5e-4 -20.894776,16.22309 v 19.48123 c 0,16.22333 6.967186,16.22309 20.894776,16.22309 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22309 v -19.48123 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m 64.90926,0 c -13.92759,0 -20.89478,-2.5e-4 -20.89478,16.22309 v 19.48123 c 0,16.22333 6.96719,16.22309 20.89478,16.22309 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22309 v -19.48123 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m 64.90926,0 c -13.92759,0 -20.89477,-2.5e-4 -20.89477,16.22309 v 19.48123 c 0,16.22333 6.96718,16.22309 20.89477,16.22309 h 10.14208 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22309 v -19.48123 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m -129.81852,64.90926 c -13.92759,0 -20.894776,-2.5e-4 -20.894776,16.22309 v 19.48124 c 0,16.22332 6.967186,16.22308 20.894776,16.22308 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22308 v -19.48124 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m 64.90926,0 c -13.92759,0 -20.89478,-2.5e-4 -20.89478,16.22309 v 19.48124 c 0,16.22332 6.96719,16.22308 20.89478,16.22308 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22308 v -19.48124 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m -64.90926,64.90927 c -13.92759,0 -20.894776,-2.5e-4 -20.894776,16.22308 v 19.48124 c 0,16.22332 6.967186,16.22309 20.894776,16.22309 h 10.14207 c 13.92759,0 20.89056,2.3e-4 20.89056,-16.22309 v -19.48124 c 0,-15.6439 -6.96297,-16.22308 -20.89056,-16.22308 z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#a4ff80;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.8182;marker:none;enable-background:accumulate"
-           inkscape:connector-curvature="0" />
-        <g
-           style="stroke-width:1.44299;enable-background:new"
-           transform="matrix(0.6930063,0,0,0.6930063,78.65179,78.59038)"
-           id="g4342-6">
-          <path
-             inkscape:connector-curvature="0"
-             id="path4277-2"
-             d="m 377.0604,51.095662 -52.99035,120.503618 25.46366,42.43569 c -0.0369,0.0579 -0.0783,0.11964 -0.11555,0.17756 l 4.41915,7.42913 c -19.13771,25.88597 -40.55985,49.80119 -62.6037,71.8535 l 0.003,0.003 c -0.0523,0.0521 -0.10561,0.10277 -0.15783,0.15501 l -0.15782,0.15782 c -22.08963,22.08117 -46.04947,43.53441 -71.98595,62.69671 l -7.42069,-4.41351 c -0.0579,0.0372 -0.11684,0.0787 -0.17473,0.11556 L 168.9037,326.74871 48.400091,379.73625 c 8.44659,37.30755 21.008251,101.08139 77.786089,84.13298 52.31512,-15.61629 96.19126,-46.80634 135.5197,-81.92059 l -0.008,-0.006 c 21.41516,-17.9596 41.50101,-37.33726 60.76333,-56.5922 l 0.003,0.003 0.15784,-0.15784 c 0.0517,-0.0517 0.10326,-0.10617 0.155,-0.15782 19.21912,-19.22646 38.55928,-39.2746 56.49074,-60.64496 l 0.006,0.008 C 414.38706,225.07303 445.57427,181.19689 461.19057,128.88175 478.13896,72.103926 414.36794,59.542266 377.0604,51.095662 Z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient4284-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:17.3159;marker:none;filter:url(#filter4300-9);enable-background:accumulate" />
-          <path
-             id="path4277-6-6"
-             d="m 377.06041,51.095748 -52.99036,120.503632 25.46366,42.43569 c -0.0369,0.0579 -0.0784,0.11962 -0.11558,0.17756 l 4.41915,7.42912 c -19.1377,25.88597 -40.55984,49.80119 -62.6037,71.8535 l 0.003,0.003 c -0.0524,0.0521 -0.10562,0.10274 -0.15783,0.15501 l -0.15782,0.15782 c -22.08964,22.08115 -46.04948,43.53439 -71.98597,62.6967 l -7.42068,-4.41351 c -0.0579,0.0372 -0.11688,0.0786 -0.17473,0.11558 L 168.9037,326.7488 48.400094,379.73634 c 8.44659,37.30756 21.00825,101.08139 77.786086,84.13299 52.31513,-15.61629 96.19126,-46.80634 135.51971,-81.9206 l -0.009,-0.006 c 21.41516,-17.9596 41.50101,-37.33726 60.76333,-56.5922 l 0.003,0.003 0.15784,-0.15783 c 0.0516,-0.0518 0.10331,-0.10621 0.155,-0.15782 19.21912,-19.22647 38.55928,-39.27461 56.49074,-60.64496 l 0.006,0.009 C 414.38706,225.07347 445.57427,181.19733 461.19058,128.8822 478.13897,72.104238 414.36795,59.542578 377.06041,51.095968 Z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:17.3159;marker:none;filter:url(#filter4315-2);enable-background:accumulate"
-             inkscape:connector-curvature="0" />
-          <path
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e5f1d0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:12;marker:none;enable-background:accumulate"
-             d="m 400.08398,157.86914 c 1.49968,5.84872 1.34031,12.70746 -1.07617,20.80274 -15.7082,52.62299 -49.89392,96.6631 -86.52929,133.3125 l 0.002,0.002 c -0.0363,0.0361 -0.0732,0.0712 -0.10938,0.10742 l -0.10937,0.10937 c -15.30825,15.30239 -31.91257,30.16962 -49.88672,43.44922 l -5.14258,-3.05859 c -0.0401,0.0258 -0.081,0.0545 -0.12109,0.0801 L 227.70312,335.0293 144.19336,371.75 c 5.85354,25.85437 14.55885,70.05004 53.90625,58.30469 36.25471,-10.82219 66.66115,-32.43709 93.91601,-56.77149 l -0.006,-0.004 c 14.84084,-12.44612 28.76046,-25.87496 42.10937,-39.21875 l 0.002,0.002 0.10938,-0.10938 c 0.0358,-0.0359 0.0716,-0.0736 0.10742,-0.10937 36.63538,-36.64938 73.94415,-77.56842 89.65234,-130.19141 7.34223,-24.59674 -6.08826,-37.81376 -23.90625,-45.7832 z"
-             transform="matrix(1.4429883,0,0,1.4429883,-159.66924,-159.58063)"
-             id="path4341-1"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4421-8"
-             d="m 378.77734,181.50977 c -12.58725,20.968 -26.92112,40.7735 -42.28906,59.46875 l 23.56641,42.42578 c 19.40976,-21.24813 37.87044,-43.73219 53.67773,-68.02344 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient4432-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.32896;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4325-7"
-             d="M 377.06066,48.209688 324.07131,168.71216 349.533,211.15004 c -0.0369,0.0579 -0.0787,0.11725 -0.11594,0.17517 l 29.85642,50.18919 c 35.11426,-39.32844 66.30214,-83.20317 81.91844,-135.51831 16.9484,-56.77783 -46.82372,-69.339804 -84.13126,-77.786402 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f1f8e7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:11.5439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4349-9"
-             transform="matrix(1.4429883,0,0,1.4429883,-113.49361,-113.405)"
-             d="m 339.95703,112 -36.72265,83.50977 0.50781,0.8457 L 339.95703,114 c 22.61992,5.12126 59.27826,12.42563 60.23047,40.52344 C 400.94154,124.7708 363.10345,117.24046 339.95703,112 Z m -16.75976,119.07031 c -13.09464,17.59853 -27.69452,33.88407 -42.71875,48.91407 l 0.002,0.002 c -0.0363,0.0361 -0.0732,0.0712 -0.10938,0.10742 l -0.10937,0.10937 c -15.30825,15.30239 -31.91257,30.16962 -49.88672,43.44922 l -5.14258,-3.05859 c -0.0401,0.0258 -0.081,0.0545 -0.12109,0.0801 L 195.70312,303.0293 112.19336,339.75 c 0.13199,0.583 0.27494,1.21951 0.41016,1.82031 l 83.0996,-36.54101 29.40821,17.64453 c 0.0401,-0.0255 0.081,-0.0543 0.12109,-0.0801 l 5.14258,3.05859 c 17.97415,-13.2796 34.57847,-28.14683 49.88672,-43.44922 l 0.10937,-0.10937 c 0.0362,-0.0362 0.0731,-0.0713 0.10938,-0.10742 l -0.002,-0.002 c 15.27653,-15.28239 30.12221,-31.85579 43.38476,-49.79493 l -0.66601,-1.11914 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:12;marker:none;enable-background:accumulate" />
-        </g>
-      </g>
-      <g
-         id="g1279-6-9"
-         style="display:inline;enable-background:new"
-         transform="matrix(0.05825844,0,0,0.05825844,322.07456,133.9693)">
-        <path
-           id="path4245-0-7"
-           d="m 105.4451,120.68123 c -13.927586,0 -20.894776,-2.5e-4 -20.894776,16.22309 v 19.48123 c 0,16.22333 6.96719,16.22309 20.894776,16.22309 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22309 v -19.48123 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m 64.90926,0 c -13.92759,0 -20.89478,-2.5e-4 -20.89478,16.22309 v 19.48123 c 0,16.22333 6.96719,16.22309 20.89478,16.22309 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22309 v -19.48123 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m 64.90926,0 c -13.92759,0 -20.89477,-2.5e-4 -20.89477,16.22309 v 19.48123 c 0,16.22333 6.96718,16.22309 20.89477,16.22309 h 10.14208 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22309 v -19.48123 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z M 105.4451,185.59049 c -13.927586,0 -20.894776,-2.5e-4 -20.894776,16.22309 v 19.48124 c 0,16.22332 6.96719,16.22308 20.894776,16.22308 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22308 v -19.48124 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m 64.90926,0 c -13.92759,0 -20.89478,-2.5e-4 -20.89478,16.22309 v 19.48124 c 0,16.22332 6.96719,16.22308 20.89478,16.22308 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22308 v -19.48124 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m -64.90926,64.90927 c -13.927586,0 -20.894776,-2.5e-4 -20.894776,16.22308 v 19.48124 c 0,16.22332 6.96719,16.22309 20.894776,16.22309 h 10.14207 c 13.92759,0 20.89056,2.3e-4 20.89056,-16.22309 v -19.48124 c 0,-15.6439 -6.96297,-16.22308 -20.89056,-16.22308 z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#a4ff80;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.8182;marker:none;enable-background:accumulate"
-           inkscape:connector-curvature="0" />
-        <g
-           style="stroke-width:1.44299;enable-background:new"
-           transform="matrix(0.6930063,0,0,0.6930063,78.65179,78.59038)"
-           id="g4342-6-3">
-          <path
-             inkscape:connector-curvature="0"
-             id="path4277-2-6"
-             d="m 377.0604,51.095662 -52.99035,120.503618 25.46366,42.43569 c -0.0369,0.0579 -0.0783,0.11964 -0.11555,0.17756 l 4.41915,7.42913 c -19.13771,25.88597 -40.55985,49.80119 -62.6037,71.8535 l 0.003,0.003 c -0.0523,0.0521 -0.10561,0.10277 -0.15783,0.15501 l -0.15782,0.15782 c -22.08963,22.08117 -46.04947,43.53441 -71.98595,62.69671 l -7.42069,-4.41351 c -0.0579,0.0372 -0.11684,0.0787 -0.17473,0.11556 L 168.9037,326.74871 48.400091,379.73625 c 8.44659,37.30755 21.008251,101.08139 77.786089,84.13298 52.31512,-15.61629 96.19126,-46.80634 135.5197,-81.92059 l -0.008,-0.006 c 21.41516,-17.9596 41.50101,-37.33726 60.76333,-56.5922 l 0.003,0.003 0.15784,-0.15784 c 0.0517,-0.0517 0.10326,-0.10617 0.155,-0.15782 19.21912,-19.22646 38.55928,-39.2746 56.49074,-60.64496 l 0.006,0.008 C 414.38706,225.07303 445.57427,181.19689 461.19057,128.88175 478.13896,72.103926 414.36794,59.542266 377.0604,51.095662 Z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient2563);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:17.3159;marker:none;filter:url(#filter4300-9-3);enable-background:accumulate" />
-          <path
-             id="path4277-6-6-1"
-             d="m 377.06041,51.095748 -52.99036,120.503632 25.46366,42.43569 c -0.0369,0.0579 -0.0784,0.11962 -0.11558,0.17756 l 4.41915,7.42912 c -19.1377,25.88597 -40.55984,49.80119 -62.6037,71.8535 l 0.003,0.003 c -0.0524,0.0521 -0.10562,0.10274 -0.15783,0.15501 l -0.15782,0.15782 c -22.08964,22.08115 -46.04948,43.53439 -71.98597,62.6967 l -7.42068,-4.41351 c -0.0579,0.0372 -0.11688,0.0786 -0.17473,0.11558 L 168.9037,326.7488 48.400094,379.73634 c 8.44659,37.30756 21.00825,101.08139 77.786086,84.13299 52.31513,-15.61629 96.19126,-46.80634 135.51971,-81.9206 l -0.009,-0.006 c 21.41516,-17.9596 41.50101,-37.33726 60.76333,-56.5922 l 0.003,0.003 0.15784,-0.15783 c 0.0516,-0.0518 0.10331,-0.10621 0.155,-0.15782 19.21912,-19.22647 38.55928,-39.27461 56.49074,-60.64496 l 0.006,0.009 C 414.38706,225.07347 445.57427,181.19733 461.19058,128.8822 478.13897,72.104238 414.36795,59.542578 377.06041,51.095968 Z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:17.3159;marker:none;filter:url(#filter4315-2-5);enable-background:accumulate"
-             inkscape:connector-curvature="0" />
-          <path
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e5f1d0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:12;marker:none;enable-background:accumulate"
-             d="m 400.08398,157.86914 c 1.49968,5.84872 1.34031,12.70746 -1.07617,20.80274 -15.7082,52.62299 -49.89392,96.6631 -86.52929,133.3125 l 0.002,0.002 c -0.0363,0.0361 -0.0732,0.0712 -0.10938,0.10742 l -0.10937,0.10937 c -15.30825,15.30239 -31.91257,30.16962 -49.88672,43.44922 l -5.14258,-3.05859 c -0.0401,0.0258 -0.081,0.0545 -0.12109,0.0801 L 227.70312,335.0293 144.19336,371.75 c 5.85354,25.85437 14.55885,70.05004 53.90625,58.30469 36.25471,-10.82219 66.66115,-32.43709 93.91601,-56.77149 l -0.006,-0.004 c 14.84084,-12.44612 28.76046,-25.87496 42.10937,-39.21875 l 0.002,0.002 0.10938,-0.10938 c 0.0358,-0.0359 0.0716,-0.0736 0.10742,-0.10937 36.63538,-36.64938 73.94415,-77.56842 89.65234,-130.19141 7.34223,-24.59674 -6.08826,-37.81376 -23.90625,-45.7832 z"
-             transform="matrix(1.4429883,0,0,1.4429883,-159.66924,-159.58063)"
-             id="path4341-1-2"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4421-8-9"
-             d="m 378.77734,181.50977 c -12.58725,20.968 -26.92112,40.7735 -42.28906,59.46875 l 23.56641,42.42578 c 19.40976,-21.24813 37.87044,-43.73219 53.67773,-68.02344 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient4432-0-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.32896;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4325-7-3"
-             d="M 377.06066,48.209688 324.07131,168.71216 349.533,211.15004 c -0.0369,0.0579 -0.0787,0.11725 -0.11594,0.17517 l 29.85642,50.18919 c 35.11426,-39.32844 66.30214,-83.20317 81.91844,-135.51831 16.9484,-56.77783 -46.82372,-69.339804 -84.13126,-77.786402 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f1f8e7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:11.5439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4349-9-1"
-             transform="matrix(1.4429883,0,0,1.4429883,-113.49361,-113.405)"
-             d="m 339.95703,112 -36.72265,83.50977 0.50781,0.8457 L 339.95703,114 c 22.61992,5.12126 59.27826,12.42563 60.23047,40.52344 C 400.94154,124.7708 363.10345,117.24046 339.95703,112 Z m -16.75976,119.07031 c -13.09464,17.59853 -27.69452,33.88407 -42.71875,48.91407 l 0.002,0.002 c -0.0363,0.0361 -0.0732,0.0712 -0.10938,0.10742 l -0.10937,0.10937 c -15.30825,15.30239 -31.91257,30.16962 -49.88672,43.44922 l -5.14258,-3.05859 c -0.0401,0.0258 -0.081,0.0545 -0.12109,0.0801 L 195.70312,303.0293 112.19336,339.75 c 0.13199,0.583 0.27494,1.21951 0.41016,1.82031 l 83.0996,-36.54101 29.40821,17.64453 c 0.0401,-0.0255 0.081,-0.0543 0.12109,-0.0801 l 5.14258,3.05859 c 17.97415,-13.2796 34.57847,-28.14683 49.88672,-43.44922 l 0.10937,-0.10937 c 0.0362,-0.0362 0.0731,-0.0713 0.10938,-0.10742 l -0.002,-0.002 c 15.27653,-15.28239 30.12221,-31.85579 43.38476,-49.79493 l -0.66601,-1.11914 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:12;marker:none;enable-background:accumulate" />
-        </g>
-      </g>
-      <g
-         id="g1279-6-9-6"
-         style="display:inline;enable-background:new"
-         transform="matrix(0.04660675,0,0,0.04660675,321.05964,188.97544)">
-        <path
-           id="path4245-0-7-3"
-           d="m 126.89573,120.68123 c -13.92759,0 -20.89478,-2.5e-4 -20.89478,16.22309 v 19.48123 c 0,16.22333 6.96719,16.22309 20.89478,16.22309 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22309 v -19.48123 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m 64.90926,0 c -13.92759,0 -20.89478,-2.5e-4 -20.89478,16.22309 v 19.48123 c 0,16.22333 6.96719,16.22309 20.89478,16.22309 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22309 v -19.48123 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m 64.90926,0 c -13.92759,0 -20.89477,-2.5e-4 -20.89477,16.22309 v 19.48123 c 0,16.22333 6.96718,16.22309 20.89477,16.22309 h 10.14208 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22309 v -19.48123 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m -129.81852,64.90926 c -13.92759,0 -20.89478,-2.5e-4 -20.89478,16.22309 v 19.48124 c 0,16.22332 6.96719,16.22308 20.89478,16.22308 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22308 v -19.48124 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m 64.90926,0 c -13.92759,0 -20.89478,-2.5e-4 -20.89478,16.22309 v 19.48124 c 0,16.22332 6.96719,16.22308 20.89478,16.22308 h 10.14207 c 13.92759,0 20.89056,2.4e-4 20.89056,-16.22308 v -19.48124 c 0,-15.6439 -6.96297,-16.22309 -20.89056,-16.22309 z m -64.90926,64.90927 c -13.92759,0 -20.89478,-2.5e-4 -20.89478,16.22308 v 19.48124 c 0,16.22332 6.96719,16.22309 20.89478,16.22309 h 10.14207 c 13.92759,0 20.89056,2.3e-4 20.89056,-16.22309 v -19.48124 c 0,-15.6439 -6.96297,-16.22308 -20.89056,-16.22308 z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#a4ff80;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.8182;marker:none;enable-background:accumulate"
-           inkscape:connector-curvature="0" />
-        <g
-           style="stroke-width:1.44299;enable-background:new"
-           transform="matrix(0.6930063,0,0,0.6930063,78.65179,78.59038)"
-           id="g4342-6-3-2">
-          <path
-             inkscape:connector-curvature="0"
-             id="path4277-2-6-0"
-             d="m 377.0604,51.095662 -52.99035,120.503618 25.46366,42.43569 c -0.0369,0.0579 -0.0783,0.11964 -0.11555,0.17756 l 4.41915,7.42913 c -19.13771,25.88597 -40.55985,49.80119 -62.6037,71.8535 l 0.003,0.003 c -0.0523,0.0521 -0.10561,0.10277 -0.15783,0.15501 l -0.15782,0.15782 c -22.08963,22.08117 -46.04947,43.53441 -71.98595,62.69671 l -7.42069,-4.41351 c -0.0579,0.0372 -0.11684,0.0787 -0.17473,0.11556 L 168.9037,326.74871 48.400091,379.73625 c 8.44659,37.30755 21.008251,101.08139 77.786089,84.13298 52.31512,-15.61629 96.19126,-46.80634 135.5197,-81.92059 l -0.008,-0.006 c 21.41516,-17.9596 41.50101,-37.33726 60.76333,-56.5922 l 0.003,0.003 0.15784,-0.15784 c 0.0517,-0.0517 0.10326,-0.10617 0.155,-0.15782 19.21912,-19.22646 38.55928,-39.2746 56.49074,-60.64496 l 0.006,0.008 C 414.38706,225.07303 445.57427,181.19689 461.19057,128.88175 478.13896,72.103926 414.36794,59.542266 377.0604,51.095662 Z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient2933);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:17.3159;marker:none;filter:url(#filter4300-9-3-4);enable-background:accumulate" />
-          <path
-             id="path4277-6-6-1-6"
-             d="m 377.06041,51.095748 -52.99036,120.503632 25.46366,42.43569 c -0.0369,0.0579 -0.0784,0.11962 -0.11558,0.17756 l 4.41915,7.42912 c -19.1377,25.88597 -40.55984,49.80119 -62.6037,71.8535 l 0.003,0.003 c -0.0524,0.0521 -0.10562,0.10274 -0.15783,0.15501 l -0.15782,0.15782 c -22.08964,22.08115 -46.04948,43.53439 -71.98597,62.6967 l -7.42068,-4.41351 c -0.0579,0.0372 -0.11688,0.0786 -0.17473,0.11558 L 168.9037,326.7488 48.400094,379.73634 c 8.44659,37.30756 21.00825,101.08139 77.786086,84.13299 52.31513,-15.61629 96.19126,-46.80634 135.51971,-81.9206 l -0.009,-0.006 c 21.41516,-17.9596 41.50101,-37.33726 60.76333,-56.5922 l 0.003,0.003 0.15784,-0.15783 c 0.0516,-0.0518 0.10331,-0.10621 0.155,-0.15782 19.21912,-19.22647 38.55928,-39.27461 56.49074,-60.64496 l 0.006,0.009 C 414.38706,225.07347 445.57427,181.19733 461.19058,128.8822 478.13897,72.104238 414.36795,59.542578 377.06041,51.095968 Z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:17.3159;marker:none;filter:url(#filter4315-2-5-0);enable-background:accumulate"
-             inkscape:connector-curvature="0" />
-          <path
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e5f1d0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:12;marker:none;enable-background:accumulate"
-             d="m 400.08398,157.86914 c 1.49968,5.84872 1.34031,12.70746 -1.07617,20.80274 -15.7082,52.62299 -49.89392,96.6631 -86.52929,133.3125 l 0.002,0.002 c -0.0363,0.0361 -0.0732,0.0712 -0.10938,0.10742 l -0.10937,0.10937 c -15.30825,15.30239 -31.91257,30.16962 -49.88672,43.44922 l -5.14258,-3.05859 c -0.0401,0.0258 -0.081,0.0545 -0.12109,0.0801 L 227.70312,335.0293 144.19336,371.75 c 5.85354,25.85437 14.55885,70.05004 53.90625,58.30469 36.25471,-10.82219 66.66115,-32.43709 93.91601,-56.77149 l -0.006,-0.004 c 14.84084,-12.44612 28.76046,-25.87496 42.10937,-39.21875 l 0.002,0.002 0.10938,-0.10938 c 0.0358,-0.0359 0.0716,-0.0736 0.10742,-0.10937 36.63538,-36.64938 73.94415,-77.56842 89.65234,-130.19141 7.34223,-24.59674 -6.08826,-37.81376 -23.90625,-45.7832 z"
-             transform="matrix(1.4429883,0,0,1.4429883,-159.66924,-159.58063)"
-             id="path4341-1-2-1"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4421-8-9-5"
-             d="m 378.77734,181.50977 c -12.58725,20.968 -26.92112,40.7735 -42.28906,59.46875 l 23.56641,42.42578 c 19.40976,-21.24813 37.87044,-43.73219 53.67773,-68.02344 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient4432-0-2-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.32896;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4325-7-3-5"
-             d="M 377.06066,48.209688 324.07131,168.71216 349.533,211.15004 c -0.0369,0.0579 -0.0787,0.11725 -0.11594,0.17517 l 29.85642,50.18919 c 35.11426,-39.32844 66.30214,-83.20317 81.91844,-135.51831 16.9484,-56.77783 -46.82372,-69.339804 -84.13126,-77.786402 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f1f8e7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:11.5439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4349-9-1-4"
-             transform="matrix(1.4429883,0,0,1.4429883,-113.49361,-113.405)"
-             d="m 339.95703,112 -36.72265,83.50977 0.50781,0.8457 L 339.95703,114 c 22.61992,5.12126 59.27826,12.42563 60.23047,40.52344 C 400.94154,124.7708 363.10345,117.24046 339.95703,112 Z m -16.75976,119.07031 c -13.09464,17.59853 -27.69452,33.88407 -42.71875,48.91407 l 0.002,0.002 c -0.0363,0.0361 -0.0732,0.0712 -0.10938,0.10742 l -0.10937,0.10937 c -15.30825,15.30239 -31.91257,30.16962 -49.88672,43.44922 l -5.14258,-3.05859 c -0.0401,0.0258 -0.081,0.0545 -0.12109,0.0801 L 195.70312,303.0293 112.19336,339.75 c 0.13199,0.583 0.27494,1.21951 0.41016,1.82031 l 83.0996,-36.54101 29.40821,17.64453 c 0.0401,-0.0255 0.081,-0.0543 0.12109,-0.0801 l 5.14258,3.05859 c 17.97415,-13.2796 34.57847,-28.14683 49.88672,-43.44922 l 0.10937,-0.10937 c 0.0362,-0.0362 0.0731,-0.0713 0.10938,-0.10742 l -0.002,-0.002 c 15.27653,-15.28239 30.12221,-31.85579 43.38476,-49.79493 l -0.66601,-1.11914 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:12;marker:none;enable-background:accumulate" />
-        </g>
-      </g>
-      <g
-         id="g1279-6-9-6-4"
-         style="display:inline;enable-background:new"
-         transform="matrix(0.02912922,0,0,0.02912922,320.53743,236.48466)">
-        <g
-           style="stroke-width:1.44299;enable-background:new"
-           transform="matrix(0.6930063,0,0,0.6930063,78.65179,78.59038)"
-           id="g4342-6-3-2-4">
-          <path
-             inkscape:connector-curvature="0"
-             id="path4277-2-6-0-4"
-             d="m 377.0604,51.095662 -52.99035,120.503618 25.46366,42.43569 c -0.0369,0.0579 -0.0783,0.11964 -0.11555,0.17756 l 4.41915,7.42913 c -19.13771,25.88597 -40.55985,49.80119 -62.6037,71.8535 l 0.003,0.003 c -0.0523,0.0521 -0.10561,0.10277 -0.15783,0.15501 l -0.15782,0.15782 c -22.08963,22.08117 -46.04947,43.53441 -71.98595,62.69671 l -7.42069,-4.41351 c -0.0579,0.0372 -0.11684,0.0787 -0.17473,0.11556 L 168.9037,326.74871 48.400091,379.73625 c 8.44659,37.30755 21.008251,101.08139 77.786089,84.13298 52.31512,-15.61629 96.19126,-46.80634 135.5197,-81.92059 l -0.008,-0.006 c 21.41516,-17.9596 41.50101,-37.33726 60.76333,-56.5922 l 0.003,0.003 0.15784,-0.15784 c 0.0517,-0.0517 0.10326,-0.10617 0.155,-0.15782 19.21912,-19.22646 38.55928,-39.2746 56.49074,-60.64496 l 0.006,0.008 C 414.38706,225.07303 445.57427,181.19689 461.19057,128.88175 478.13896,72.103926 414.36794,59.542266 377.0604,51.095662 Z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient3067);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:17.3159;marker:none;filter:url(#filter4300-9-3-4-9);enable-background:accumulate" />
-          <path
-             id="path4277-6-6-1-6-3"
-             d="m 377.06041,51.095748 -52.99036,120.503632 25.46366,42.43569 c -0.0369,0.0579 -0.0784,0.11962 -0.11558,0.17756 l 4.41915,7.42912 c -19.1377,25.88597 -40.55984,49.80119 -62.6037,71.8535 l 0.003,0.003 c -0.0524,0.0521 -0.10562,0.10274 -0.15783,0.15501 l -0.15782,0.15782 c -22.08964,22.08115 -46.04948,43.53439 -71.98597,62.6967 l -7.42068,-4.41351 c -0.0579,0.0372 -0.11688,0.0786 -0.17473,0.11558 L 168.9037,326.7488 48.400094,379.73634 c 8.44659,37.30756 21.00825,101.08139 77.786086,84.13299 52.31513,-15.61629 96.19126,-46.80634 135.51971,-81.9206 l -0.009,-0.006 c 21.41516,-17.9596 41.50101,-37.33726 60.76333,-56.5922 l 0.003,0.003 0.15784,-0.15783 c 0.0516,-0.0518 0.10331,-0.10621 0.155,-0.15782 19.21912,-19.22647 38.55928,-39.27461 56.49074,-60.64496 l 0.006,0.009 C 414.38706,225.07347 445.57427,181.19733 461.19058,128.8822 478.13897,72.104238 414.36795,59.542578 377.06041,51.095968 Z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:17.3159;marker:none;filter:url(#filter4315-2-5-0-7);enable-background:accumulate"
-             inkscape:connector-curvature="0" />
-          <path
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e5f1d0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:12;marker:none;enable-background:accumulate"
-             d="m 400.08398,157.86914 c 1.49968,5.84872 1.34031,12.70746 -1.07617,20.80274 -15.7082,52.62299 -49.89392,96.6631 -86.52929,133.3125 l 0.002,0.002 c -0.0363,0.0361 -0.0732,0.0712 -0.10938,0.10742 l -0.10937,0.10937 c -15.30825,15.30239 -31.91257,30.16962 -49.88672,43.44922 l -5.14258,-3.05859 c -0.0401,0.0258 -0.081,0.0545 -0.12109,0.0801 L 227.70312,335.0293 144.19336,371.75 c 5.85354,25.85437 14.55885,70.05004 53.90625,58.30469 36.25471,-10.82219 66.66115,-32.43709 93.91601,-56.77149 l -0.006,-0.004 c 14.84084,-12.44612 28.76046,-25.87496 42.10937,-39.21875 l 0.002,0.002 0.10938,-0.10938 c 0.0358,-0.0359 0.0716,-0.0736 0.10742,-0.10937 36.63538,-36.64938 73.94415,-77.56842 89.65234,-130.19141 7.34223,-24.59674 -6.08826,-37.81376 -23.90625,-45.7832 z"
-             transform="matrix(1.4429883,0,0,1.4429883,-159.66924,-159.58063)"
-             id="path4341-1-2-1-0"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4421-8-9-5-7"
-             d="m 378.77734,181.50977 c -12.58725,20.968 -26.92112,40.7735 -42.28906,59.46875 l 23.56641,42.42578 c 19.40976,-21.24813 37.87044,-43.73219 53.67773,-68.02344 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient4432-0-2-6-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.32896;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4325-7-3-5-8"
-             d="M 377.06066,48.209688 324.07131,168.71216 349.533,211.15004 c -0.0369,0.0579 -0.0787,0.11725 -0.11594,0.17517 l 29.85642,50.18919 c 35.11426,-39.32844 66.30214,-83.20317 81.91844,-135.51831 16.9484,-56.77783 -46.82372,-69.339804 -84.13126,-77.786402 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f1f8e7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:11.5439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path4349-9-1-4-6"
-             transform="matrix(1.4429883,0,0,1.4429883,-113.49361,-113.405)"
-             d="m 339.95703,112 -36.72265,83.50977 0.50781,0.8457 L 339.95703,114 c 22.61992,5.12126 59.27826,12.42563 60.23047,40.52344 C 400.94154,124.7708 363.10345,117.24046 339.95703,112 Z m -16.75976,119.07031 c -13.09464,17.59853 -27.69452,33.88407 -42.71875,48.91407 l 0.002,0.002 c -0.0363,0.0361 -0.0732,0.0712 -0.10938,0.10742 l -0.10937,0.10937 c -15.30825,15.30239 -31.91257,30.16962 -49.88672,43.44922 l -5.14258,-3.05859 c -0.0401,0.0258 -0.081,0.0545 -0.12109,0.0801 L 195.70312,303.0293 112.19336,339.75 c 0.13199,0.583 0.27494,1.21951 0.41016,1.82031 l 83.0996,-36.54101 29.40821,17.64453 c 0.0401,-0.0255 0.081,-0.0543 0.12109,-0.0801 l 5.14258,3.05859 c 17.97415,-13.2796 34.57847,-28.14683 49.88672,-43.44922 l 0.10937,-0.10937 c 0.0362,-0.0362 0.0731,-0.0713 0.10938,-0.10742 l -0.002,-0.002 c 15.27653,-15.28239 30.12221,-31.85579 43.38476,-49.79493 l -0.66601,-1.11914 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:12;marker:none;enable-background:accumulate" />
-        </g>
-      </g>
+         id="path888"
+         d="m 343.5,189.8796 c 0,-0.91958 10e-6,-1.3796 -1.07115,-1.3796 h -1.28627 c -1.07117,0 -1.07115,0.46002 -1.07115,1.3796 v 0.66965 c 0,0.91958 -2e-5,1.37932 1.07115,1.37932 h 1.28627 c 1.0329,0 1.07115,-0.45974 1.07115,-1.37932 z m 0,4.28572 c 0,-0.91959 10e-6,-1.3796 -1.07115,-1.3796 h -1.28627 c -1.07117,0 -1.07115,0.46001 -1.07115,1.3796 v 0.66964 c 0,0.91959 -2e-5,1.37932 1.07115,1.37932 h 1.28627 c 1.0329,0 1.07115,-0.45973 1.07115,-1.37932 z m 0,4.28571 c 0,-0.91959 10e-6,-1.3796 -1.07115,-1.3796 h -1.28627 c -1.07117,0 -1.07115,0.46001 -1.07115,1.3796 v 0.66964 c 0,0.91959 -2e-5,1.37933 1.07115,1.37933 h 1.28627 c 1.0329,0 1.07115,-0.45974 1.07115,-1.37933 z m -4.28572,-8.57143 c 0,-0.91958 2e-5,-1.3796 -1.07114,-1.3796 h -1.28628 c -1.07116,0 -1.07114,0.46002 -1.07114,1.3796 v 0.66965 c 0,0.91958 -2e-5,1.37932 1.07114,1.37932 h 1.28628 c 1.03291,0 1.07114,-0.45974 1.07114,-1.37932 z m 0,4.28572 c 0,-0.91959 2e-5,-1.3796 -1.07114,-1.3796 h -1.28628 c -1.07116,0 -1.07114,0.46001 -1.07114,1.3796 v 0.66964 c 0,0.91959 -2e-5,1.37932 1.07114,1.37932 h 1.28628 c 1.03291,0 1.07114,-0.45973 1.07114,-1.37932 z m -4.28571,-4.28572 c 0,-0.91958 2e-5,-1.3796 -1.07115,-1.3796 h -1.28627 c -1.07116,0 -1.07115,0.46002 -1.07115,1.3796 v 0.66965 c 0,0.91958 -10e-6,1.37932 1.07115,1.37932 h 1.28627 c 1.03291,0 1.07115,-0.45974 1.07115,-1.37932 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#0067bb;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.71428;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 320.75359,239.72272 c 3.5e-4,0.10269 -0.2522,0.0747 -0.24696,0.20609 0.0639,1.57398 0.55715,5.07964 3.52103,8.04352 3.01034,3.01034 6.57992,3.47213 8.11618,3.52382 0.10235,0.003 0.12296,-0.23194 0.20644,-0.23159 l 0.0845,-3.28629 c -0.81634,0.0175 -4.17284,0.83659 -6.70149,-1.69205 -2.52864,-2.52864 -1.62148,-5.89283 -1.60367,-6.70917 z"
+         fill="#0067bb"
+         id="path892"
+         style="fill-rule:nonzero;stroke-width:0.349308" />
+      <path
+         d="m 332.10542,246.1196 c 1.86391,0 3.39458,0.39088 3.39458,2.16606 0,1.77519 -1.51111,3.21434 -3.37502,3.21434 -1.86391,0 -3.37502,-1.43915 -3.37502,-3.21434 0,-1.77518 1.49155,-2.16606 3.35546,-2.16606 z m -6.32283,-6.23481 c 0,1.86391 -0.29307,3.36524 -2.06826,3.36524 -1.77518,0 -3.21433,-1.51111 -3.21433,-3.37502 0,-1.86391 1.43915,-3.37501 3.21433,-3.37501 1.77519,0 2.06826,1.52089 2.06826,3.38479 z"
+         fill="#2bb7f6"
+         id="path894"
+         style="fill-rule:nonzero;stroke-width:0.349308" />
+      <path
+         id="path896"
+         d="m 335.5,237.39974 c 0,-0.59973 10e-6,-0.89974 -0.69858,-0.89974 h -0.83887 c -0.69859,0 -0.69858,0.30001 -0.69858,0.89974 v 0.43672 c 0,0.59973 -10e-6,0.89956 0.69858,0.89956 h 0.83887 c 0.67363,0 0.69858,-0.29983 0.69858,-0.89956 z m 0,2.79503 c 0,-0.59973 10e-6,-0.89974 -0.69858,-0.89974 h -0.83887 c -0.69859,0 -0.69858,0.30001 -0.69858,0.89974 v 0.43672 c 0,0.59973 -10e-6,0.89956 0.69858,0.89956 h 0.83887 c 0.67363,0 0.69858,-0.29983 0.69858,-0.89956 z m 0,2.79503 c 0,-0.59973 10e-6,-0.89974 -0.69858,-0.89974 h -0.83887 c -0.69859,0 -0.69858,0.30001 -0.69858,0.89974 v 0.43672 c 0,0.59973 -10e-6,0.89956 0.69858,0.89956 h 0.83887 c 0.67363,0 0.69858,-0.29983 0.69858,-0.89956 z m -2.79504,-5.59006 c 0,-0.59973 2e-5,-0.89974 -0.69857,-0.89974 h -0.83887 c -0.69859,0 -0.69858,0.30001 -0.69858,0.89974 v 0.43672 c 0,0.59973 -10e-6,0.89956 0.69858,0.89956 h 0.83887 c 0.67364,0 0.69857,-0.29983 0.69857,-0.89956 z m 0,2.79503 c 0,-0.59973 2e-5,-0.89974 -0.69857,-0.89974 h -0.83887 c -0.69859,0 -0.69858,0.30001 -0.69858,0.89974 v 0.43672 c 0,0.59973 -10e-6,0.89956 0.69858,0.89956 h 0.83887 c 0.67364,0 0.69857,-0.29983 0.69857,-0.89956 z m -2.79502,-2.79503 c 0,-0.59973 10e-6,-0.89974 -0.69858,-0.89974 h -0.83887 c -0.69859,0 -0.69858,0.30001 -0.69858,0.89974 v 0.43672 c 0,0.59973 -10e-6,0.89956 0.69858,0.89956 h 0.83887 c 0.67363,0 0.69858,-0.29983 0.69858,-0.89956 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#0067bb;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.465835;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms and folds"
+       inkscape:label="Pictogram"
        style="display:inline" />
-    <g
-       inkscape:groupmode="layer"
-       id="layer4"
-       inkscape:label="Borders"
-       style="display:inline;opacity:1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92188,43.999698 c -35.296728,0 -39.09487,3.62603 -38.92188,38.99414 v 2 c -0.17299,-35.36811 3.625152,-38.99414 38.92188,-38.99414 h 146.15624 c 35.29673,0 38.92188,3.62561 38.92188,38.99414 v -2 c 0,-35.36853 -3.62515,-38.99414 -38.92188,-38.99414 z"
-         id="path931"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92728,267.9997 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 c -0.17299,35.36811 3.625154,38.99414 38.921885,38.99414 h 146.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 c 0,35.36853 -3.62515,38.99414 -38.92188,38.99414 z"
-         id="path931-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500047 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 V 84 96.75181 c -0.0527,8.84203 1.82291,9.74838 11.83407,9.74838 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 337.97659,211.50015 c 4.67187,0 5.5471,-0.42296 5.52255,-4.54923 v -7.95037 -5.95084 c 0.0245,-4.12627 -0.85068,-4.54923 -5.52255,-4.54923 h -11.95364 c -4.67071,0 -5.52256,0.42291 -5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 0.85185,4.54923 5.52256,4.54923 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.55494,251.5 c 3.33705,0 3.96221,-0.30212 3.94468,-3.24946 v -4.2505 -4.25059 c 0.0175,-2.94734 -0.60763,-3.24945 -3.94468,-3.24945 h -7.11025 c -3.33622,0 -3.94469,0.30208 -3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 0.60847,3.24946 3.94469,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="opacity:0.7">
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 324.44531,237 c -1.65302,0 -2.54604,0.12548 -2.91601,0.41406 -0.18499,0.14429 -0.30479,0.33122 -0.39649,0.70313 C 321.0411,238.4891 321,239.03036 321,239.75 v 4.25 4.25 c 0,0.71964 0.0411,1.26082 0.13281,1.63281 0.0917,0.37191 0.2115,0.55884 0.39649,0.70313 0.36997,0.28858 1.26299,0.41406 2.91601,0.41406 h 7.10938 c 1.65343,0 2.55203,-0.12511 2.92383,-0.41406 0.18589,-0.14448 0.30578,-0.33208 0.39648,-0.70313 0.0907,-0.37105 0.129,-0.90979 0.125,-1.6289 v -0.002 V 244 v -4.25195 -0.002 c 0.004,-0.71911 -0.0343,-1.25785 -0.125,-1.6289 -0.0907,-0.37105 -0.21059,-0.55865 -0.39648,-0.70313 C 334.10673,237.12512 333.20812,237 331.55469,237 Z m 5.32813,1.04688 c 1.10767,-3.4e-4 2.21363,0.008 3.32031,0.0449 0.26616,0.0599 0.75737,-0.0208 0.79297,0.3457 0.13405,1.84438 0.0662,3.68774 0.10156,5.53906 -0.0126,1.86745 0.0543,3.67031 -0.10351,5.49805 0.0642,0.42314 -0.43946,0.35577 -0.70313,0.42187 -3.43277,0.0703 -6.87577,0.0589 -10.29883,0.002 -0.22288,-0.0398 -0.55622,-3.2e-4 -0.71093,-0.1875 -0.19863,-1.12995 -0.12696,-2.26946 -0.16016,-3.41992 0.0138,-2.55648 -0.029,-5.10728 0.0898,-7.65625 -0.03,-0.2727 0.10944,-0.49629 0.40039,-0.48829 1.30659,-0.161 2.63265,-0.0636 3.94727,-0.0976 1.10718,0.006 2.21655,-0.002 3.32422,-0.002 z"
-         id="path918-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none"
-         d="m 326.02383,189.00048 c -2.32027,0 -3.60941,0.15494 -4.20703,0.62109 -0.29882,0.23308 -0.48964,0.54668 -0.625,1.09571 -0.13541,0.54902 -0.19141,1.31765 -0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 0.056,1.783 0.19141,2.33203 0.13536,0.54903 0.32618,0.86263 0.625,1.09571 0.59762,0.46615 1.88676,0.62109 4.20703,0.62109 h 11.9524 c 2.32085,0 3.61652,-0.15457 4.2168,-0.62109 0.30014,-0.23327 0.49095,-0.54754 0.625,-1.09571 0.13404,-0.54816 0.18764,-1.31623 0.18164,-2.33008 v -7.95279 -5.95312 c 0.006,-1.01386 -0.0476,-1.78191 -0.18164,-2.33008 -0.13406,-0.54817 -0.32486,-0.86244 -0.625,-1.09571 -0.60028,-0.46652 -1.89595,-0.62109 -4.2168,-0.62109 z m 4.95859,1.00977 c 1.5798,-0.002 4.16014,-3.9e-4 5.73991,0.0117 1.50021,0.0511 3.02236,-0.0712 4.5,0.28321 0.55111,0.0919 0.61303,0.71807 0.67773,1.16601 0.1117,4.30832 0.075,10.62608 0.0508,14.94108 -0.0716,0.99089 0.13687,2.07606 -0.30078,3.01366 -0.34356,0.40964 -0.9694,0.35958 -1.45117,0.45509 -3.95407,0.0823 -9.92936,0.0499 -13.89381,0.0371 -1.16908,-0.0622 -2.37292,0.11291 -3.51758,-0.22266 -0.57935,-0.098 -0.6137,-0.75914 -0.6875,-1.2207 -0.1146,-4.11835 -0.0751,-10.24472 -0.0547,-14.36881 0.0572,-1.06305 -0.0797,-2.16734 0.18164,-3.21485 0.10495,-0.6386 0.8614,-0.66043 1.36719,-0.74023 2.1305,-0.19658 5.24071,-0.10662 7.38828,-0.14062 z"
-         id="path914-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 329.12695,134 c -3.21072,0 -5.03255,0.19514 -5.9375,0.89844 -0.45247,0.35165 -0.74178,0.83286 -0.93359,1.61718 -0.19176,0.78433 -0.26386,1.85686 -0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c -0.008,1.40682 0.0641,2.47935 0.25586,3.26368 0.1918,0.78431 0.48112,1.26553 0.93359,1.61718 0.90496,0.7033 2.72678,0.89844 5.9375,0.89844 h 13.7461 c 3.20992,0 5.02461,-0.19551 5.92578,-0.89844 0.45058,-0.35146 0.73805,-0.83201 0.93164,-1.61718 C 349.9241,158.69918 350,157.62415 350,156.2168 V 148 139.7832 c 0,-1.40735 -0.0759,-2.48237 -0.26953,-3.26758 -0.19359,-0.78517 -0.48106,-1.26572 -0.93164,-1.61718 C 347.89766,134.19551 346.08297,134 342.87305,134 Z m 6.49805,1.04688 c 3.45647,0.0171 6.9142,-0.0268 10.36133,0.0918 0.8211,0.13276 1.80664,0.14835 2.39062,0.82617 0.67884,1.16473 0.51296,2.58781 0.56446,3.87305 0.0431,6.02893 0.0678,12.06719 -0.0332,18.08789 -0.0775,0.77792 -0.12055,1.67263 -0.67968,2.27539 -0.70249,0.51038 -1.61833,0.59683 -2.45899,0.67383 -4.04742,0.0864 -8.16222,0.0456 -12.24023,0.0606 -2.45188,-0.0199 -4.91402,0.0317 -7.35352,-0.0606 -0.87784,-0.12055 -1.915,-0.14021 -2.56055,-0.83398 -0.64775,-1.02591 -0.50264,-2.30525 -0.56054,-3.46485 -0.035,-5.65575 -0.0351,-11.35518 0,-17.00976 0.0632,-1.22153 -0.10864,-2.57724 0.59179,-3.65235 0.6025,-0.62665 1.55621,-0.63986 2.35938,-0.77344 2.73743,-0.10739 5.48083,-0.0704 8.22656,-0.0918 0.46403,-2.9e-4 0.92855,-0.002 1.39258,-0.002 z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 333.33594,62 c -4.99049,0 -7.87051,0.276282 -9.38477,1.453125 -0.75713,0.588421 -1.23761,1.403518 -1.54492,2.660156 -0.3073,1.256638 -0.4173,2.940031 -0.4043,5.132813 V 84 96.753906 c -0.0131,2.19278 0.097,3.876174 0.4043,5.132814 0.30731,1.25663 0.78779,2.07172 1.54492,2.66016 1.51427,1.17683 4.39428,1.45312 9.38477,1.45312 h 21.33008 c 4.98923,0 7.85502,-0.27668 9.36328,-1.45312 0.75412,-0.58824 1.23293,-1.40461 1.54297,-2.66211 C 365.8823,100.62727 366,98.945281 366,96.751953 V 84 71.248047 c 0,-2.193329 -0.1177,-3.875313 -0.42773,-5.132813 -0.31004,-1.257499 -0.78884,-2.073874 -1.54297,-2.662109 C 362.52104,62.276656 359.65526,62 354.66602,62 Z m 2.40234,1.097656 c 6.94737,8.3e-4 13.91063,0.0034 20.84961,0.05469 2.14296,0.08293 4.46431,-0.147701 6.42383,0.93164 1.29609,0.695228 1.54862,2.250325 1.76953,3.564454 0.17551,2.202888 0.0915,4.442228 0.13867,6.669921 0.0227,8.479532 0.077,16.968993 -0.0801,25.447266 -0.16151,1.483233 -0.38135,3.305793 -1.79882,4.142573 -1.6055,0.82871 -3.47551,0.90643 -5.24805,0.95313 -9.49974,0.0678 -19.0243,0.0843 -28.52344,-0.0176 -1.57816,-0.11413 -3.27053,-0.24014 -4.63281,-1.12109 -1.22952,-0.99538 -1.36082,-2.72739 -1.50391,-4.193361 -0.1272,-8.998585 -0.0836,-18.004484 -0.0527,-27.007813 0.0997,-2.381275 -0.24538,-4.900002 0.70508,-7.160156 0.67165,-1.50972 2.46573,-1.859954 3.93945,-2.05664 2.66168,-0.316582 5.34184,-0.147022 8.01367,-0.207032 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
-    </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/clock-app.svg
+++ b/icons/src/fullcolor/default/apps/clock-app.svg
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="clock-app.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\preferences-system-network.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="105.91087"
-     inkscape:cy="91.478237"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="2"
+     inkscape:cx="357.5"
+     inkscape:cy="95.5"
+     inkscape:current-layer="layer2"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,204 +93,89 @@
   <defs
      id="defs3">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="b"
+       x2="1"
+       gradientTransform="matrix(-3.8470307,-101.93801,101.93801,-3.8470307,2016.2509,114.18059)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#b3b3b3"
          offset="0"
-         id="stop923" />
+         id="stop7" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#fff"
          offset="1"
-         id="stop925" />
+         id="stop9" />
+    </linearGradient>
+    <linearGradient
+       id="a"
+       x2="1"
+       gradientTransform="matrix(-1.116679,-220.93284,220.93284,-1.116679,426.18993,265.4539)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#1e2023"
+         offset="0"
+         id="stop2" />
+      <stop
+         stop-color="#404447"
+         offset="1"
+         id="stop4" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4239"
-       id="linearGradient11065"
-       x1="104"
-       y1="44"
-       x2="200"
-       y2="268"
+       xlink:href="#b"
+       id="linearGradient455"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,-5.6126213e-6)" />
+       gradientTransform="matrix(-0.79001353,-20.933653,20.933653,-0.79001353,726.83641,75.412097)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient8590"
+       xlink:href="#a"
+       id="linearGradient457"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.23913043,0,0,0.23913032,321.04348,61.043494)"
-       x1="96"
-       y1="4.0000062"
-       x2="96"
-       y2="188" />
+       gradientTransform="matrix(-0.22931751,-45.370039,45.370039,-0.22931751,400.30673,106.47709)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4239"
-       id="linearGradient8588"
+       xlink:href="#b"
+       id="linearGradient475"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.94488193,0,0,0.94488229,320.50001,-173.12993)"
-       x1="13.735326"
-       y1="249.69423"
-       x2="38.099998"
-       y2="292.76666" />
+       gradientTransform="matrix(-0.51522727,-13.65241,13.65241,-0.51522727,585.67643,142.41961)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient8590-3"
+       xlink:href="#a"
+       id="linearGradient477"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.15217394,0,0,0.15217387,321.3913,133.39129)"
-       x1="96"
-       y1="4.0000062"
-       x2="96"
-       y2="188" />
+       gradientTransform="matrix(-0.1495552,-29.589217,29.589217,-0.1495552,372.72185,162.67943)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4239"
-       id="linearGradient8588-0"
+       xlink:href="#b"
+       id="linearGradient495"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.60892393,0,0,0.60892417,320.85556,-17.70596)"
-       x1="13.735326"
-       y1="249.69423"
-       x2="38.099998"
-       y2="292.76666" />
+       gradientTransform="matrix(-0.39500758,-10.466848,10.466848,-0.39500758,523.4186,195.72125)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient8590-3-3"
+       xlink:href="#a"
+       id="linearGradient497"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.11956515,0,0,0.11956513,320.52176,188.52174)"
-       x1="95.999878"
-       y1="3.9999957"
-       x2="95.999878"
-       y2="188.00014" />
+       gradientTransform="matrix(-0.11465899,-22.685067,22.685067,-0.11465899,360.15342,211.25378)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4239"
-       id="linearGradient8588-0-1"
+       xlink:href="#b"
+       id="linearGradient515"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48293959,0,0,0.48293984,319.98888,68.578027)"
-       x1="13.735326"
-       y1="249.69423"
-       x2="38.099998"
-       y2="292.76666" />
+       gradientTransform="matrix(-0.25761361,-6.8262046,6.8262046,-0.25761361,452.8382,241.207)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient8590-3-3-4"
+       xlink:href="#a"
+       id="linearGradient517"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.0760869,0,0,0.07608688,320.69566,236.69567)"
-       x1="96"
-       y1="4.0000062"
-       x2="96"
-       y2="188" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4239"
-       id="linearGradient8588-0-1-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.31496064,0,0,0.31496077,320.16669,158.29007)"
-       x1="13.735326"
-       y1="249.69423"
-       x2="38.099998"
-       y2="292.76666" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter48952"
-       x="-0.048"
-       width="1.096"
-       y="-0.048"
-       height="1.096">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.48"
-         id="feGaussianBlur48954" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter48967"
-       x="-0.012"
-       width="1.024"
-       y="-0.012"
-       height="1.024">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.12"
-         id="feGaussianBlur48969" />
-    </filter>
-    <linearGradient
-       id="linearGradient4239"
-       inkscape:collect="always">
-      <stop
-         id="stop4241"
-         offset="0"
-         style="stop-color:#666666;stop-opacity:1" />
-      <stop
-         id="stop4243"
-         offset="1"
-         style="stop-color:#666666;stop-opacity:1" />
-    </linearGradient>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4278"
-       x="-0.01176097"
-       width="1.0235219"
-       y="-0.012248948"
-       height="1.0244979">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.3835888"
-         id="feGaussianBlur4280" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4292"
-       id="linearGradient4290"
-       x1="226.83955"
-       y1="429.51562"
-       x2="406.44754"
-       y2="146.70312"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4292"
-       inkscape:collect="always">
-      <stop
-         id="stop4294"
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.495801"
-         id="stop4296" />
-      <stop
-         id="stop4298"
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0" />
-    </linearGradient>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4300"
-       x="-0.094087757"
-       width="1.1881756"
-       y="-0.097991586"
-       height="1.1959832">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="11.068711"
-         id="feGaussianBlur4302" />
-    </filter>
+       gradientTransform="matrix(-0.07477759,-14.794607,14.794607,-0.07477759,346.36092,251.33691)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -301,13 +187,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -389,7 +275,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">clock-app</tspan></text>
+           id="tspan924">clock-app</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -424,327 +310,249 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline">
-      <circle
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter48967);enable-background:new"
-         id="path11042-4"
-         r="112"
-         cy="157"
-         cx="152" />
-      <circle
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter48952);enable-background:new"
-         id="path11042-9"
-         r="112"
-         cy="157"
-         cx="152" />
-      <circle
-         style="display:inline;opacity:1;fill:url(#linearGradient11065);fill-opacity:1.0;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042"
-         r="112"
-         cy="155.99998"
-         cx="152" />
-      <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
-      <circle
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-0-0"
-         cx="-344"
-         cy="-85.000015"
-         transform="scale(-1)"
-         r="23" />
-      <circle
-         style="display:inline;opacity:1;fill:url(#linearGradient8588);fill-opacity:1.0;stroke:none;stroke-width:1.86940372;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-6"
-         cx="344"
-         cy="84"
-         r="22.5" />
-      <circle
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-0-0-2"
-         cx="-336"
-         cy="-149"
-         transform="scale(-1)"
-         r="14.999996" />
-      <circle
-         style="display:inline;opacity:1;fill:url(#linearGradient8588-0);fill-opacity:1.0;stroke:none;stroke-width:1.86940372;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-6-5"
-         cx="336"
-         cy="148"
-         r="14.5" />
-      <ellipse
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-0-0-2-3"
-         cx="-332"
-         cy="-200.52327"
-         transform="scale(-1)"
-         rx="11.999997"
-         ry="11.476745" />
-      <ellipse
-         style="display:inline;opacity:1;fill:url(#linearGradient8588-0-1);fill-opacity:1.0;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-6-5-6"
-         cx="332"
-         cy="200"
-         rx="11.499999"
-         ry="11.5" />
-      <ellipse
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437706;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-0-0-2-3-3"
-         cx="-328"
-         cy="-244.5"
-         transform="scale(-1)"
-         rx="6.9999981"
-         ry="6.5" />
-      <circle
-         style="display:inline;opacity:1;fill:url(#linearGradient8588-0-1-5);fill-opacity:1.0;stroke:none;stroke-width:1.86940384;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-6-5-6-8"
-         cx="328"
-         cy="244"
-         r="7.5" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer6"
-       inkscape:label="Pictograms and folds"
-       style="display:inline">
-      <g
-         transform="translate(0,10e-6)"
-         style="display:inline;enable-background:new"
-         id="g905">
-        <path
-           transform="matrix(0.5,0,0,0.5,24,28)"
-           inkscape:connector-curvature="0"
-           id="circle4261"
-           d="M 418.56445,154.90625 267.85352,241.91992 A 20,20 0 0 0 262,238.92578 V 218 h -12 v 20.94531 a 20,20 0 0 0 -5.85352,2.97461 l -91.92382,-53.07422 -8,13.85742 91.91211,53.06641 A 20,20 0 0 0 236,258 20,20 0 0 0 250,277.07422 V 426 h 12 V 277.05469 A 20,20 0 0 0 276,258 a 20,20 0 0 0 -0.14844,-2.22266 l 150.71289,-87.01562 z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter4278);enable-background:accumulate" />
-        <path
-           transform="matrix(0.5,0,0,0.5,24,28)"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#linearGradient4290);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter4300);enable-background:accumulate"
-           d="M 418.56445,154.90625 267.85352,241.91992 A 20,20 0 0 0 262,238.92578 V 218 h -12 v 20.94531 a 20,20 0 0 0 -5.85352,2.97461 l -91.92382,-53.07422 -8,13.85742 91.91211,53.06641 A 20,20 0 0 0 236,258 20,20 0 0 0 250,277.07422 V 426 h 12 V 277.05469 A 20,20 0 0 0 276,258 a 20,20 0 0 0 -0.14844,-2.22266 l 150.71289,-87.01562 z"
-           id="path4282"
-           inkscape:connector-curvature="0" />
-        <circle
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate"
-           id="circle4527"
-           cx="152"
-           cy="156.3176"
-           r="3.1460993" />
-        <path
-           inkscape:transform-center-y="-31.112701"
-           inkscape:transform-center-x="53.888775"
-           sodipodi:nodetypes="ccc"
-           inkscape:connector-curvature="0"
-           id="path4219"
-           d="M 98.111225,124.8873 152,156 235.28265,107.91674"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#f1f0e9;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <circle
-           r="10"
-           cy="156"
-           cx="152"
-           id="path4221"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f22c42;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path4223"
-           d="M 152,136 V 240"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#f22c42;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      </g>
-      <g
-         style="display:inline;enable-background:new"
-         id="g936"
-         transform="translate(1,10e-6)">
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#f1f0e9;stroke-width:1.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 331.88535,77.40342 10.77775,6.22254 16.65653,-9.616652"
-           id="path914"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccc"
-           inkscape:transform-center-x="53.888775"
-           inkscape:transform-center-y="-31.112701" />
-        <circle
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f22c42;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           id="circle916"
-           cx="342.66309"
-           cy="83.625961"
-           r="2" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#f22c42;stroke-width:1.20000005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 342.6631,79.62596 v 20.8"
-           id="path919"
-           inkscape:connector-curvature="0" />
-      </g>
-      <g
-         style="display:inline;enable-background:new"
-         id="g945"
-         transform="matrix(0.5,0,0,0.5,160.66845,158.18702)">
-        <path
-           inkscape:transform-center-y="-31.112701"
-           inkscape:transform-center-x="53.888775"
-           sodipodi:nodetypes="ccc"
-           inkscape:connector-curvature="0"
-           id="path938"
-           d="m 331.88535,77.40342 10.77775,6.22254 16.65653,-9.616652"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#f1f0e9;stroke-width:1.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <circle
-           r="2"
-           cy="83.625961"
-           cx="342.66309"
-           id="circle940"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f22c42;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path943"
-           d="m 342.6631,79.62596 v 20.8"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#f22c42;stroke-width:1.20000005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      </g>
-      <g
-         style="display:inline;enable-background:new"
-         transform="matrix(0.75,0,0,0.75,78.51689,84.80554)"
-         id="g953">
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#f1f0e9;stroke-width:1.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 334.52482,78.927318 8.13828,4.698642 14.33225,-8.274728"
-           id="path947"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccc"
-           inkscape:transform-center-x="53.888775"
-           inkscape:transform-center-y="-31.112701" />
-        <circle
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f22c42;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           id="circle949"
-           cx="342.66309"
-           cy="83.625961"
-           r="2" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#f22c42;stroke-width:1.20000005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 342.6631,79.62596 v 18.05"
-           id="path951"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-      </g>
-      <g
-         id="g962"
-         transform="matrix(0.36164918,0,0,0.36336234,204.07967,213.66399)"
-         style="display:inline;stroke-width:2.06893849;enable-background:new">
-        <path
-           inkscape:transform-center-y="-31.112701"
-           inkscape:transform-center-x="53.888775"
-           sodipodi:nodetypes="ccc"
-           inkscape:connector-curvature="0"
-           id="path956"
-           d="m 334.52482,78.927318 8.13828,4.698642 14.33225,-8.274728"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#f1f0e9;stroke-width:3.31030154;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <circle
-           r="2"
-           cy="83.625961"
-           cx="342.66309"
-           id="circle958"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f22c42;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.31030154;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path960"
-           d="m 342.6631,79.62596 v 18.05"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#f22c42;stroke-width:2.48272634;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      </g>
-      <path
-         style="display:inline;opacity:0.05;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 55.58594,99.246099 A 112,112 0 0 0 40,156 112,112 0 0 0 152,268 112,112 0 0 0 246.63086,215.66407 Z"
-         id="path958"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;opacity:0.05;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 324.63477,72.593755 A 22.5,22.5 0 0 0 321.5,84.000005 22.5,22.5 0 0 0 337.375,105.5 h 13.18555 a 22.5,22.5 0 0 0 12.90429,-10.255854 z"
-         id="path964"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;opacity:0.05;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 323.56055,140.58594 A 14.5,14.5 0 0 0 321.5,148 a 14.5,14.5 0 0 0 14.5,14.5 14.5,14.5 0 0 0 12.58398,-7.31836 z"
-         id="path975"
-         inkscape:connector-curvature="0" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer2"
-       inkscape:label="Borders"
+       inkscape:label="Background"
        style="display:inline">
       <circle
-         style="display:inline;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path1377"
-         cx="328.00003"
-         cy="244.00002"
-         r="7.5000005" />
-      <ellipse
-         style="display:inline;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path1384"
-         cx="332"
-         cy="199.97676"
-         rx="11.454546"
-         ry="11.476745" />
+         cx="152.00002"
+         cy="156.00003"
+         r="112"
+         fill="url(#a)"
+         id="circle12"
+         style="display:inline;fill:url(#a);stroke-width:4.92005;enable-background:new" />
+      <path
+         d="m 152.00001,44.000026 c -61.96521,0 -111.999995,50.03478 -111.999995,111.999994 0,61.96517 50.034785,111.99995 111.999995,111.99995 61.96519,0 111.99998,-50.03478 111.99998,-111.99995 0,-61.965214 -50.03479,-111.999994 -111.99998,-111.999994 z m 0,10.48905 c 56.3165,0 101.51092,45.19439 101.51092,101.510944 0,56.31651 -45.19442,101.51095 -101.51092,101.51095 -56.316551,0 -101.510945,-45.19444 -101.510945,-101.51095 0,-56.316554 45.194394,-101.510944 101.510945,-101.510944 z"
+         fill="#808080"
+         fill-opacity="0.5"
+         fill-rule="nonzero"
+         id="path14"
+         style="display:inline;stroke-width:4.86956;enable-background:new" />
+      <path
+         d="m 151.80321,239.94098 v 27.754 h 0.96433 v -27.754 z m 4.00492,27.73924 -0.18204,-5.7663 -0.49201,0.0148 0.18204,5.7663 z m -7.69004,0 0.21156,-5.7663 -0.48708,-0.0197 -0.21648,5.7663 z m 11.59164,-0.20172 -0.38377,-5.75646 -0.492,0.0344 0.38376,5.75646 z m -15.49324,-0.005 0.41821,-5.75646 -0.49201,-0.0344 -0.41328,5.75645 z m 19.73432,-0.10825 -1.10209,-10.48462 -0.48709,0.0492 1.10209,10.48462 z m -23.41452,0.0492 1.1021,-10.48462 -0.48709,-0.0492 -1.10209,10.48462 z m 26.82411,-0.72816 -0.48708,0.0689 -0.78229,-5.72202 0.48709,-0.064 z m -30.78966,-0.01 0.80688,-5.71218 -0.48708,-0.0689 -0.80689,5.71218 z m 34.64698,-0.59533 -0.97909,-5.68266 -0.48216,0.0836 0.97909,5.68265 z m -38.5043,-0.01 -0.48709,-0.0886 1.00861,-5.67774 0.48217,0.0836 z m 42.81427,-0.5658 -2.18943,-10.31243 -0.48216,0.10332 2.18942,10.31243 z m -46.57319,0.10332 2.18942,-10.31243 -0.48216,-0.10332 -2.18943,10.31243 z m 49.7909,-1.10701 -1.36778,-5.60394 -0.47724,0.11316 1.36777,5.60886 z m -53.55966,-0.0148 1.3973,-5.59902 -0.47725,-0.11808 -1.39729,5.59901 z m 57.33333,-0.98401 -1.55965,-5.55474 -0.47233,0.13284 1.55966,5.55474 z m -61.10701,-0.0197 1.58918,-5.5449 -0.47233,-0.13776 -1.58917,5.54981 z m -3.78843,-0.88561 3.25707,-10.02706 -0.46741,-0.15253 -3.25707,10.02706 z m 69.22017,-0.15253 -3.25707,-10.02706 -0.46741,0.15253 3.25707,10.02706 z m -72.96433,-1.39237 1.97786,-5.42189 -0.46249,-0.16729 -1.97786,5.41698 z m 76.80197,-0.20664 -1.98278,-5.41698 -0.46249,0.16729 1.98278,5.42189 z m -80.45265,-1.19065 -0.45756,-0.18204 2.16974,-5.3481 0.45264,0.18204 z m 84.0984,-0.22141 -0.46248,0.18697 -2.16974,-5.3481 0.45264,-0.18696 z m -87.66051,-1.01353 4.29028,-9.62853 -0.45265,-0.20172 -4.28536,9.62853 z m 91.11439,-0.20172 -0.44773,0.20172 -4.29028,-9.62853 0.45264,-0.20172 z m -94.57319,-1.67281 2.52399,-5.18574 -0.44281,-0.21648 -2.52398,5.18573 z m 98.2337,-0.31489 -0.44772,0.21648 -2.53383,-5.18081 0.43789,-0.21648 z m -101.722008,-1.44649 -0.432964,-0.23124 2.706022,-5.09718 0.43788,0.23125 z m 105.190648,-0.33949 -2.71587,-5.08733 -0.43296,0.23125 2.71586,5.08733 z m -99.20787,-19.00123 -9.997538,17.31858 0.428044,0.24108 9.997534,-17.31365 z m 92.1968,0.46741 9.82534,17.00369 0.42804,-0.24108 -9.82042,-17.00861 z m 13.59409,14.71095 -3.05535,-4.89545 -0.4182,0.26076 3.05535,4.89545 z m -119.109461,-0.0787 3.084871,-4.87577 -0.418204,-0.26569 -3.084871,4.87577 z m 122.381301,-2.05658 -3.22755,-4.78721 -0.40837,0.27552 3.22755,4.78721 z m -125.653134,-0.0837 -0.403444,-0.27552 3.252153,-4.76753 0.408364,0.27553 z m 128.920044,-1.93358 -6.19434,-8.52644 -0.39853,0.28536 6.19435,8.52645 z m -131.665431,0.28537 6.194342,-8.52645 -0.398524,-0.28536 -6.194342,8.52644 z m 134.715861,-2.87823 -3.55227,-4.54613 -0.38869,0.30013 3.55228,4.55104 z m -138.022134,0.11316 -0.383764,-0.30504 3.562115,-4.53629 0.388684,0.30504 z m 141.052884,-2.57811 -3.70972,-4.4182 -0.37884,0.31488 3.70972,4.41821 z m -144.083635,0.11809 3.719558,-4.40837 -0.373924,-0.3198 -3.724477,4.40836 z m 147.099625,-2.46003 -0.369,0.32964 -7.05043,-7.83271 0.36408,-0.32965 z m -149.889293,0.32964 -0.369003,-0.32964 7.05535,-7.83272 0.364084,0.32965 z m -2.784747,-2.87822 4.00984,-4.15253 -0.354244,-0.33948 -4.00984,4.15252 z m 155.57195,-0.46249 -4.01476,-4.1476 -0.35424,0.3444 4.01476,4.14268 z m -158.337018,-2.29274 -0.344404,-0.35425 4.152522,-4.00984 0.339483,0.35425 z m 161.087328,-0.48217 -4.15744,-4 -0.33949,0.35425 4.15744,4 z m -163.847476,-2.15498 -0.329643,-0.369 7.832718,-7.05043 0.329644,0.36408 z m 166.469856,-0.369 -0.32964,0.369 -7.83272,-7.05535 0.32965,-0.36408 z m -168.747838,-2.53875 4.413284,-3.72447 -0.319804,-0.37393 -4.408364,3.71956 z m 171.178348,-0.57564 -0.31489,0.37884 -4.42312,-3.71464 0.3198,-0.37392 z m -173.643295,-2.45019 4.536287,-3.56703 -0.305043,-0.38377 -4.536284,3.56704 z m 176.098395,-0.58548 -4.5412,-3.5572 -0.30505,0.38868 4.54613,3.55228 z m -178.755215,-2.57811 8.526441,-6.19434 -0.285363,-0.39853 -8.526448,6.19435 z m 181.225085,-0.39852 -8.52645,-6.19435 -0.28536,0.39853 8.52644,6.19434 z m -183.202945,-2.74539 4.77244,-3.24231 -0.27552,-0.40345 -4.77245,3.2374 z m 185.180805,-0.40344 -4.77245,-3.24232 -0.27552,0.40837 4.77244,3.23739 z m 2.13038,-3.27676 -4.88561,-3.07011 -0.26076,0.41329 4.88561,3.07503 z m -189.456335,0.41329 4.88561,-3.07011 -0.26076,-0.41821 -4.88561,3.07503 z m 174.179585,-13.38746 17.01353,9.82042 0.24108,-0.42312 -17.01353,-9.82042 z m -159.562115,-0.42312 -17.00861,9.82042 0.246,0.42312 17.008613,-9.82042 z m 178.637145,6.84871 -5.08241,-2.73555 -0.23617,0.43296 5.08241,2.73555 z m -197.200495,0.20664 5.08734,-2.72571 -0.23125,-0.43296 -5.08733,2.7257 z m 198.981545,-3.6802 -5.17589,-2.55842 -0.21648,0.4428 5.17589,2.55351 z m -200.772435,0.20664 5.18081,-2.54366 -0.21648,-0.44281 -5.18082,2.54367 z m -1.8893,-3.61131 -0.20172,-0.44773 9.62853,-4.29028 0.20172,0.45265 z m 204.639595,-0.44773 -9.62853,-4.29028 -0.20172,0.45265 9.62853,4.28536 z m 1.1267,-3.05043 -0.18697,0.45265 -5.33333,-2.19926 0.18696,-0.45757 z m -207.094715,-0.0246 -0.18696,-0.45264 5.34318,-2.17958 0.18696,0.45756 z m 208.511685,-3.61623 -0.16728,0.46248 -5.41206,-2.0123 0.17221,-0.46248 z m -209.928655,-0.0246 5.41697,-1.9877 -0.1722,-0.46249 -5.41697,1.9877 z m -1.48093,-3.77368 -0.15253,-0.46741 10.02706,-3.25707 0.15253,0.46741 z m 213.043045,-0.46741 -10.02706,-3.25707 -0.15253,0.46741 10.02706,3.25707 z m 0.75276,-2.91759 -0.14268,0.46741 -5.53013,-1.63838 0.13776,-0.47232 z m -214.769975,-0.2706 -0.13777,-0.47232 5.5449,-1.60394 0.13776,0.47233 z m 215.808105,-3.49815 -5.58917,-1.4465 -0.123,0.47725 5.58917,1.44649 z m -216.836395,-0.27061 5.59409,-1.41205 -0.11808,-0.47724 -5.5941,1.41205 z m 218.056575,-4.37392 -10.31243,-2.18942 -0.10332,0.48216 10.31242,2.18943 z m -219.114395,0.48217 10.31243,-2.18943 -0.10332,-0.48216 -10.31243,2.18942 z m 219.704795,-4.20665 -5.67773,-1.01845 -0.0935,0.48217 5.68757,1.01845 z m -220.309955,0.44773 -0.0836,-0.48217 5.67773,-1.01353 0.0886,0.48217 z m 220.920045,-4.30505 -0.0738,0.48709 -5.70726,-0.82165 0.0738,-0.48708 z m -221.544895,0.45265 -0.0738,-0.48709 5.71218,-0.81672 0.0738,0.48708 z m 222.150055,-4.45265 -10.48462,-1.10209 -0.0492,0.48709 10.48462,1.10209 z m -222.779815,0.48709 10.48462,-1.10209 -0.0492,-0.48709 -10.48462,1.10209 z m 222.986465,-4.11808 -5.75154,-0.42313 -0.0394,0.49201 5.75646,0.42312 z m -223.212795,0.30012 -0.0344,-0.48708 5.75646,-0.41821 0.0344,0.49201 z m 223.424355,-4.20172 -5.7663,-0.2214 -0.0197,0.492 5.7663,0.2214 z m -223.645755,0.30504 -0.0148,-0.492 5.7663,-0.21648 0.0148,0.492 z m 196.059035,-3.62558 h 27.754 v -0.96925 h -27.754 z M 67.754013,155.51786 H 40.000015 v 0.96432 h 27.753998 z m -27.601478,-3.10948 0.0197,-0.492 5.7663,0.19188 -0.0148,0.49201 z m 223.680195,-0.61992 -5.7663,0.1968 0.0197,0.492 5.7663,-0.1968 z m -223.488315,-3.28167 5.75646,0.3936 0.0344,-0.49201 -5.76138,-0.3936 z m 223.281675,-0.61993 -5.75645,0.39852 0.0295,0.49201 5.76138,-0.39853 z m -223.040585,-3.35055 10.48462,1.10209 0.0492,-0.48709 -10.48462,-1.10209 z m 222.779815,-0.48709 -10.48462,1.10209 0.0492,0.48709 10.48462,-1.10209 z m -0.52152,-3.6064 0.064,0.48709 -5.71711,0.78229 -0.064,-0.49201 z m -221.717095,0.27553 0.0689,-0.48709 5.7171,0.79213 -0.0689,0.48709 z m 221.111935,-4.13776 -5.68758,0.98401 0.0836,0.48216 5.68756,-0.97909 z m -220.516605,0.28044 0.0886,-0.48709 5.68265,0.99385 -0.0836,0.48217 z m 219.783505,-4.38869 -10.31242,2.18943 0.10332,0.48216 10.31243,-2.18942 z m -219.114385,0.48217 10.31243,2.18942 0.10332,-0.48216 -10.31243,-2.18943 z m 0.92989,-3.75892 0.11808,-0.47724 5.59902,1.38745 -0.11808,0.47725 z m 217.225105,-0.58548 0.11808,0.47724 -5.59902,1.39237 -0.123,-0.47724 z m -216.231255,-3.1882 5.54982,1.57934 0.13776,-0.47232 -5.54982,-1.57934 z m 215.212795,-0.58056 -5.54982,1.58425 0.13776,0.47233 5.54982,-1.58426 z m -214.125465,-3.21771 0.15253,-0.46741 10.02706,3.25707 -0.15253,0.46741 z m 213.043055,-0.46741 -10.02707,3.25707 0.15254,0.46741 10.02705,-3.25707 z m -1.29398,-3.61131 -5.4268,1.9631 0.16728,0.46248 5.4268,-1.9631 z m -210.445255,0.42312 5.42681,1.9631 0.16728,-0.46249 -5.42681,-1.96309 z m 209.043045,-4.06888 -5.35301,2.15006 0.18205,0.45757 5.35793,-2.15007 z m -207.655595,0.4182 0.18204,-0.45756 5.35302,2.15498 -0.18205,0.45264 z m 206.125465,-4.0984 -9.62854,4.28537 0.20172,0.45264 9.62854,-4.29028 z m -204.639605,0.44773 0.20172,-0.44773 9.62853,4.28537 -0.20172,0.45264 z m 22.583022,-1.07749 -17.008612,-9.820414 -0.246,0.423114 17.008609,9.82042 z m 180.472333,-2.70111 -5.19558,2.51414 0.21157,0.44281 5.19557,-2.51415 z m -20.55105,2.93727 17.00861,-9.82533 -0.246,-0.423124 -17.00862,9.820404 z m -180.836415,-2.67159 0.21648,-0.4428 5.19066,2.52398 -0.21649,0.44281 z m 199.616245,-3.74416 -5.10209,2.69127 0.22631,0.43297 5.10701,-2.69127 z m -197.854865,0.25585 5.10209,2.7011 0.22632,-0.43296 -5.09717,-2.70111 z m 194.027065,-6.907744 -4.90529,3.03567 0.26076,0.418194 4.90529,-3.035664 z m -190.135305,0.11808 4.89545,3.05043 0.26076,-0.4182 -4.89545,-3.05044 z m 188.019685,-3.39976 -4.80198,3.20788 0.27552,0.40836 4.79706,-3.20787 z m -185.904065,0.11809 4.78721,3.21771 0.27552,-0.40837 -4.78721,-3.21771 z m 183.453875,-3.62608 -8.52644,6.19434 0.28536,0.39853 8.52645,-6.19435 z m -181.225095,0.39852 8.526448,6.19435 0.285363,-0.39853 -8.526441,-6.19434 z m 179.183275,-3.10947 0.30013,0.38869 -4.56581,3.52767 -0.30504,-0.38868 z m -176.836405,-0.0148 4.551041,3.54736 0.305044,-0.38869 -4.551045,-3.54735 z m 5.008606,-6.00246 0.329643,-0.369 7.832719,7.05535 -0.329644,0.36408 z m 166.469869,-0.369 -7.83272,7.05535 0.32965,0.36408 7.83271,-7.05043 z m 2.90775,3.34071 -4.43788,3.68512 0.30996,0.37884 4.4428,-3.68511 z m -171.936045,-0.01 4.423125,3.7048 0.314883,-0.37884 -4.423124,-3.7048 z m 166.829035,-5.71218 -4.18204,3.98032 0.33948,0.35917 4.18204,-3.98032 z m -161.608862,-0.123 4.152521,4.00492 0.339484,-0.35424 -4.152522,-4.00492 z m 5.608856,-5.43665 7.05535,7.83272 0.364084,-0.32965 -7.050431,-7.83271 z m 149.889306,-0.32964 0.369,0.32964 -7.05535,7.83272 -0.36408,-0.32965 z m 3.36039,3.11439 0.34932,0.3444 -4.03444,4.123 -0.35424,-0.3444 z m -156.108245,-0.11808 0.354244,-0.34441 4.01476,4.1476 -0.354244,0.34441 z m 124.191885,0.65436 9.82042,-17.00861 -0.42804,-0.246 -9.82042,17.00861 z m -92.08856,-0.246 -9.820422,-17.00861 -0.428044,0.246 9.820426,17.00861 z m 118.3321,-5.45141 -3.74415,4.38868 0.37392,0.3198 3.74416,-4.38868 z m -144.634687,-0.21157 0.373924,-0.3198 3.714637,4.4182 -0.373924,0.31489 z m 137.820427,-5.09717 -6.19435,8.52645 0.39852,0.28536 6.19435,-8.52644 z m -131.665445,0.28537 6.194342,8.52644 0.398524,-0.28536 -6.194342,-8.52645 z m 135.458795,2.54366 -3.59163,4.52153 0.38868,0.30504 3.58672,-4.51661 z m -138.587947,-0.20172 3.557196,4.54612 0.388684,-0.30504 -3.557196,-4.5412 z m 70.228787,4.15744 v -27.754 h -0.96433 v 27.754 z m 61.6925,-8.83641 -3.24724,4.76753 0.40837,0.27552 3.24231,-4.76753 z m -125.599023,0.059 3.227552,4.78229 0.408364,-0.27552 -3.232472,-4.78229 z m 122.327183,-2.19434 -3.07995,4.88069 0.41821,0.26076 3.07503,-4.88069 z m -119.060271,0.059 3.060271,4.89053 0.418204,-0.26076 -3.06027,-4.89053 z m 13.790901,-7.33579 0.44773,-0.20172 4.29028,9.62853 -0.45265,0.20172 z m 91.11439,-0.20172 0.44773,0.20172 -4.28537,9.62853 -0.45264,-0.20172 z m -98.135303,3.60639 2.710953,5.09225 0.43296,-0.23124 -2.710949,-5.09225 z m 105.131613,-0.26076 -2.71094,5.09717 0.43296,0.23124 2.71095,-5.09717 z m -101.65805,-1.52522 0.4428,-0.21648 2.52891,5.18573 -0.43789,0.21649 z m 98.17466,-0.24108 0.4428,0.21648 -2.53382,5.18574 -0.43789,-0.21649 z m -14.46987,-5.75646 -3.25707,10.02706 0.46741,0.15253 3.25707,-10.02706 z m -69.22017,0.15253 0.46741,-0.15253 3.25707,10.02706 -0.46741,0.15253 z m 76.80197,2.54858 0.45756,0.18204 -2.17466,5.3481 -0.45756,-0.18697 z m -84.1476,0.0935 2.16482,5.35302 0.45756,-0.18697 -2.16482,-5.34809 z m 18.66174,-5.70234 2.18942,10.31243 0.48216,-0.10332 -2.18942,-10.31243 z m 46.57319,-0.10332 -2.18942,10.31243 0.48215,0.10332 2.18943,-10.31243 z m 15.26691,4.30997 -1.9877,5.41697 0.46249,0.16728 1.9877,-5.41697 z m -76.85609,0.0886 0.46249,-0.16728 1.97294,5.42189 -0.46249,0.16728 z m 26.59287,-6.15498 0.48708,-0.0492 1.1021,10.48462 -0.48709,0.0492 z m 23.41451,-0.0492 0.48709,0.0492 -1.10209,10.48462 -0.48709,-0.0492 z m 19.69004,3.77859 -1.61869,5.53506 0.47232,0.13776 1.6187,-5.53505 z m -62.26322,-0.0148 1.59409,5.54982 0.47233,-0.13776 -1.58918,-5.5449 z m 58.48954,-1.00861 0.47725,0.123 -1.4219,5.58918 -0.47724,-0.123 z m -54.71586,-0.01 0.47724,-0.11808 1.3973,5.59902 -0.47725,0.11808 z m 47.35547,-1.58917 0.48217,0.0935 -1.04306,5.67282 -0.48216,-0.0886 z m -39.7048,-0.0541 1.00369,5.68265 0.48217,-0.0886 -0.99877,-5.68265 z m 35.8524,-0.57565 -0.84625,5.70726 0.48709,0.0738 0.84133,-5.70726 z m -31.99508,-0.0443 0.48709,-0.0689 0.80196,5.71218 -0.48708,0.0689 z m 24.50677,-0.79213 -0.46249,5.75154 0.49201,0.0394 0.45756,-5.75154 z m -16.72325,-0.0443 0.48708,-0.0344 0.40345,5.75646 -0.49201,0.0344 z m 12.82165,-0.19188 -0.25584,5.7663 0.492,0.0246 0.25584,-5.7663 z m -8.92497,-0.0246 0.492,-0.0148 0.20173,5.7663 -0.49201,0.0148 z"
+         fill="#ffffff"
+         id="path26"
+         style="display:inline;stroke-width:4.92005;enable-background:new" />
       <circle
-         style="display:inline;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path1389"
-         cx="336"
-         cy="148"
-         r="14.5" />
-      <circle
-         style="display:inline;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path1389-3"
          cx="344"
          cy="84"
-         r="22.5" />
+         r="22.99995"
+         fill="url(#a)"
+         id="circle439"
+         style="display:inline;fill:url(#linearGradient457);stroke-width:1.01037;enable-background:new" />
       <path
-         inkscape:connector-curvature="0"
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 152,267.99999 a 112,112 0 0 1 -112,-112 112,112 0 0 1 0.04102,-1.16992 A 112,112 0 0 0 152,265.99999 112,112 0 0 0 263.95898,155.16991 a 112,112 0 0 1 0.041,0.83008 112,112 0 0 1 -112,112 z"
-         id="path11042-1-7" />
+         d="m 344,61.000049 c -12.72497,0 -22.99995,10.274977 -22.99995,22.999949 0,12.724962 10.27498,22.999942 22.99995,22.999942 12.72497,0 22.99994,-10.27498 22.99994,-22.999942 0,-12.724972 -10.27497,-22.999949 -22.99994,-22.999949 z m 0,2.153996 c 11.56497,0 20.84595,9.280971 20.84595,20.845953 0,11.564972 -9.28098,20.845952 -20.84595,20.845952 -11.56498,0 -20.84595,-9.28098 -20.84595,-20.845952 0,-11.564982 9.28097,-20.845953 20.84595,-20.845953 z"
+         fill="#808080"
+         fill-opacity="0.5"
+         fill-rule="nonzero"
+         id="path441"
+         style="display:inline;stroke-width:0.999997;enable-background:new" />
       <path
-         style="display:inline;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="M 152,43.999994 A 112,112 0 0 0 40,155.99999 112,112 0 0 0 40.04102,157.16991 112,112 0 0 1 152,45.999994 112,112 0 0 1 263.95898,156.83007 a 112,112 0 0 0 0.041,-0.83008 112,112 0 0 0 -112,-111.999996 z"
-         id="path11042-1"
-         inkscape:connector-curvature="0" />
+         d="m 343.95958,101.23784 v 5.69947 h 0.19804 v -5.69947 z m 0.82244,5.69644 -0.0374,-1.18415 -0.10104,0.003 0.0374,1.18414 z m -1.5792,0 0.0434,-1.18415 -0.10002,-0.004 -0.0445,1.18414 z m 2.38042,-0.0414 -0.0788,-1.18213 -0.10103,0.007 0.0788,1.18213 z m -3.18164,-0.001 0.0859,-1.18213 -0.10104,-0.007 -0.0849,1.18212 z m 4.05258,-0.0222 -0.22633,-2.15309 -0.10002,0.0101 0.22632,2.15309 z m -4.80833,0.0101 0.22632,-2.15309 -0.10003,-0.0101 -0.22632,2.15309 z m 5.50851,-0.14954 -0.10003,0.0142 -0.16065,-1.17505 0.10003,-0.0131 z m -6.32287,-0.002 0.1657,-1.17303 -0.10002,-0.0142 -0.1657,1.17303 z m 7.11499,-0.12225 -0.20106,-1.16697 -0.099,0.0172 0.20106,1.16697 z m -7.90711,-0.002 -0.10003,-0.0182 0.20713,-1.16596 0.099,0.0172 z m 8.7922,-0.11619 -0.44962,-2.11773 -0.099,0.0212 0.44961,2.11773 z m -9.56412,0.0212 0.44961,-2.11773 -0.099,-0.0212 -0.44961,2.11773 z m 10.22489,-0.22733 -0.28088,-1.15081 -0.098,0.0232 0.28088,1.15182 z m -10.99883,-0.003 0.28694,-1.1498 -0.098,-0.0243 -0.28694,1.14979 z m 11.77378,-0.20208 -0.32028,-1.1407 -0.097,0.0273 0.32028,1.1407 z m -12.54873,-0.004 0.32635,-1.13868 -0.097,-0.0283 -0.32635,1.13969 z m -0.77798,-0.18186 0.66886,-2.05913 -0.096,-0.0313 -0.66886,2.05913 z m 14.21482,-0.0313 -0.66886,-2.05913 -0.096,0.0313 0.66886,2.05913 z m -14.98371,-0.28593 0.40617,-1.11343 -0.095,-0.0343 -0.40617,1.11242 z m 15.7718,-0.0424 -0.40718,-1.11242 -0.095,0.0343 0.40718,1.11342 z m -16.52149,-0.24451 -0.094,-0.0374 0.44557,-1.09827 0.0929,0.0374 z m 17.27017,-0.0455 -0.095,0.0384 -0.44557,-1.09827 0.0929,-0.0384 z m -18.00167,-0.20814 0.88103,-1.97728 -0.093,-0.0414 -0.88002,1.97728 z m 18.71095,-0.0414 -0.0919,0.0414 -0.88104,-1.97728 0.0929,-0.0414 z m -19.42124,-0.34352 0.51832,-1.06493 -0.0909,-0.0445 -0.51832,1.06493 z m 20.17295,-0.0647 -0.0919,0.0444 -0.52034,-1.06391 0.0899,-0.0444 z m -20.8893,-0.29705 -0.0889,-0.0475 0.5557,-1.04674 0.0899,0.0475 z m 21.6016,-0.0697 -0.55772,-1.04472 -0.0889,0.0475 0.55772,1.04472 z m -20.373,-3.90203 -2.05306,3.55649 0.0879,0.0495 2.05306,-3.55548 z m 18.93323,0.096 2.0177,3.49182 0.0879,-0.0495 -2.01669,-3.49283 z m 2.79164,3.02099 -0.62743,-1.00531 -0.0859,0.0536 0.62743,1.00531 z m -24.45992,-0.0162 0.6335,-1.00127 -0.0859,-0.0546 -0.6335,1.00127 z m 25.13182,-0.42233 -0.6628,-0.98308 -0.0839,0.0566 0.6628,0.98308 z m -25.80372,-0.0172 -0.0829,-0.0566 0.66785,-0.97904 0.0839,0.0566 z m 26.4746,-0.39707 -1.27205,-1.75096 -0.0818,0.0586 1.27205,1.75096 z m -27.03838,0.0586 1.27205,-1.75096 -0.0818,-0.0586 -1.27205,1.75096 z m 27.6648,-0.59106 -0.72948,-0.93358 -0.0798,0.0616 0.72949,0.93458 z m -28.34377,0.0232 -0.0788,-0.0626 0.73151,-0.93156 0.0798,0.0626 z m 28.96616,-0.52944 -0.76182,-0.9073 -0.0778,0.0647 0.76182,0.90731 z m -29.58854,0.0242 0.76384,-0.90528 -0.0768,-0.0657 -0.76485,0.90528 z m 30.20789,-0.50518 -0.0758,0.0677 -1.44785,-1.608498 0.0748,-0.0677 z m -30.78077,0.0677 -0.0758,-0.0677 1.44887,-1.608501 0.0748,0.0677 z m -0.57186,-0.59106 0.82344,-0.85275 -0.0728,-0.06972 -0.82344,0.85275 z m 31.94774,-0.095 -0.82446,-0.851737 -0.0727,0.07073 0.82446,0.850727 z m -32.51557,-0.470829 -0.0707,-0.07275 0.85275,-0.823448 0.0697,0.07275 z m 33.08036,-0.09902 -0.85376,-0.821427 -0.0697,0.07275 0.85376,0.821426 z m -33.64717,-0.44254 -0.0677,-0.07578 1.6085,-1.447853 0.0677,0.07477 z m 34.1857,-0.07578 -0.0677,0.07578 -1.60851,-1.448863 0.0677,-0.07477 z m -34.6535,-0.52135 0.90629,-0.764845 -0.0657,-0.07679 -0.90528,0.763837 z m 35.15262,-0.118211 -0.0647,0.0778 -0.90832,-0.762826 0.0657,-0.07679 z m -35.65882,-0.503163 0.93156,-0.732514 -0.0626,-0.07881 -0.93156,0.732515 z m 36.16299,-0.120232 -0.93257,-0.730495 -0.0626,0.07982 0.93358,0.729484 z m -36.70858,-0.529433 1.75096,-1.272049 -0.0586,-0.08184 -1.75096,1.272052 z m 37.21578,-0.08184 -1.75096,-1.272052 -0.0586,0.08184 1.75096,1.272049 z m -37.62195,-0.563785 0.98005,-0.66583 -0.0566,-0.08285 -0.98005,0.664822 z m 38.02812,-0.08285 -0.98005,-0.665832 -0.0566,0.08386 0.98005,0.664819 z m 0.43749,-0.672904 -1.00329,-0.630468 -0.0535,0.08487 1.00329,0.631478 z m -38.90613,0.08487 1.00329,-0.630468 -0.0536,-0.08588 -1.00329,0.631478 z m 35.76894,-2.749205 3.49385,2.016689 0.0495,-0.08689 -3.49384,-2.016689 z m -32.76714,-0.08689 -3.49284,2.016689 0.0505,0.08689 3.49284,-2.016689 z m 36.68433,1.406429 -1.04371,-0.561764 -0.0485,0.08891 1.04371,0.561763 z m -40.49644,0.04244 1.04472,-0.559743 -0.0475,-0.08891 -1.04472,0.559741 z m 40.86219,-0.755754 -1.0629,-0.525389 -0.0444,0.09093 1.0629,0.524381 z m -41.22996,0.04243 1.06391,-0.522358 -0.0445,-0.09093 -1.06392,0.52236 z m -0.38798,-0.741607 -0.0414,-0.09194 1.97728,-0.881038 0.0414,0.09295 z m 42.02411,-0.09194 -1.97729,-0.881038 -0.0414,0.09295 1.97729,0.880027 z m 0.23137,-0.626426 -0.0384,0.09295 -1.09523,-0.451632 0.0384,-0.09396 z m -42.52828,-0.0051 -0.0384,-0.09295 1.09725,-0.447591 0.0384,0.09396 z m 42.81927,-0.742617 -0.0344,0.09497 -1.1114,-0.413239 0.0354,-0.09497 z m -43.11026,-0.0051 1.11241,-0.408187 -0.0354,-0.09498 -1.11241,0.408188 z m -0.30412,-0.77495 -0.0313,-0.09599 2.05913,-0.668861 0.0313,0.09599 z m 43.74982,-0.09599 -2.05912,-0.668861 -0.0313,0.09599 2.05912,0.668861 z m 0.15458,-0.599147 -0.0293,0.09599 -1.13565,-0.336452 0.0283,-0.09699 z m -44.10445,-0.05557 -0.0283,-0.09699 1.13868,-0.32938 0.0283,0.097 z m 44.31764,-0.718369 -1.14777,-0.297048 -0.0253,0.09801 1.14777,0.297047 z m -44.52881,-0.05557 1.14879,-0.289974 -0.0242,-0.09801 -1.14879,0.289974 z m 44.77938,-0.898214 -2.11772,-0.449612 -0.0212,0.09901 2.11772,0.449614 z m -44.99661,0.09902 2.11773,-0.449614 -0.0212,-0.09901 -2.11773,0.449612 z m 45.11785,-0.863864 -1.16595,-0.209146 -0.0192,0.09902 1.16798,0.209146 z m -45.24212,0.09194 -0.0172,-0.09902 1.16596,-0.208135 0.0182,0.09902 z m 45.36741,-0.884071 -0.0152,0.100028 -1.17202,-0.168732 0.0152,-0.100025 z m -45.49573,0.09296 -0.0152,-0.100027 1.17304,-0.167719 0.0152,0.100025 z m 45.62,-0.914381 -2.15308,-0.226322 -0.0101,0.100027 2.15308,0.226322 z m -45.74932,0.100027 2.15308,-0.226322 -0.0101,-0.100027 -2.15308,0.226322 z m 45.79176,-0.845676 -1.18112,-0.08689 -0.008,0.101037 1.18213,0.08689 z m -45.83824,0.06163 -0.007,-0.100025 1.18213,-0.08588 0.007,0.101037 z m 45.88169,-0.862851 -1.18415,-0.04547 -0.004,0.101035 1.18415,0.04547 z m -45.92716,0.06264 -0.003,-0.101036 1.18415,-0.04445 0.003,0.101035 z m 40.26204,-0.744453 h 5.69947 v -0.199042 h -5.69947 z m -34.60096,-0.224301 h -5.69947 v 0.198029 h 5.69947 z m -5.66815,-0.638553 0.004,-0.101035 1.18415,0.0394 -0.003,0.101037 z m 45.93423,-0.127304 -1.18415,0.04041 0.004,0.101035 1.18415,-0.04041 z m -45.89483,-0.673913 1.18213,0.08083 0.007,-0.101038 -1.18314,-0.08083 z m 45.85239,-0.127307 -1.18212,0.08184 0.006,0.101037 1.18313,-0.08184 z m -45.80288,-0.688058 2.15309,0.226322 0.0101,-0.100028 -2.15309,-0.226321 z m 45.74933,-0.100027 -2.15309,0.226321 0.0101,0.100028 2.15309,-0.226322 z m -0.1071,-0.740599 0.0131,0.100028 -1.17404,0.160648 -0.0131,-0.101038 z m -45.53109,0.05658 0.0141,-0.100027 1.17405,0.162669 -0.0142,0.100027 z m 45.40682,-0.849716 -1.16798,0.202073 0.0172,0.09901 1.16798,-0.201062 z m -45.28456,0.05759 0.0182,-0.100027 1.16697,0.204093 -0.0172,0.09902 z m 45.13401,-0.901247 -2.11772,0.449614 0.0212,0.09902 2.11773,-0.449612 z m -44.9966,0.09902 2.11772,0.449612 0.0212,-0.09902 -2.11772,-0.449614 z m 0.19096,-0.77192 0.0242,-0.098 1.14979,0.284922 -0.0242,0.09801 z m 44.60863,-0.120232 0.0242,0.09801 -1.1498,0.285932 -0.0253,-0.098 z m -44.40454,-0.654718 1.13969,0.324328 0.0283,-0.09699 -1.13969,-0.324328 z m 44.19539,-0.119222 -1.13969,0.325336 0.0283,0.097 1.13969,-0.325338 z m -43.9721,-0.660778 0.0313,-0.09599 2.05912,0.668861 -0.0313,0.09599 z m 43.74982,-0.09599 -2.05913,0.668861 0.0313,0.09599 2.05912,-0.668861 z m -0.26573,-0.741607 -1.11443,0.403136 0.0344,0.09497 1.11443,-0.403135 z m -43.21634,0.08689 1.11443,0.403135 0.0344,-0.09497 -1.11443,-0.403134 z m 42.92839,-0.835572 -1.09928,0.441529 0.0374,0.09397 1.10029,-0.441531 z m -42.64347,0.08588 0.0374,-0.09396 1.09928,0.44254 -0.0374,0.09295 z m 42.32924,-0.841634 -1.97728,0.88003 0.0414,0.09295 1.97728,-0.881037 z m -42.02411,0.09195 0.0414,-0.09195 1.97728,0.88003 -0.0414,0.09295 z m 4.63758,-0.22127 -3.49284,-2.016688 -0.0505,0.08689 3.49284,2.016689 z m 37.0612,-0.554691 -1.06695,0.516295 0.0435,0.09093 1.06695,-0.516297 z m -4.2203,0.603188 3.49283,-2.017697 -0.0505,-0.08689 -3.49283,2.016686 z m -37.13597,-0.548629 0.0445,-0.09093 1.06594,0.518316 -0.0445,0.09093 z m 40.99254,-0.768888 -1.04775,0.55267 0.0465,0.08891 1.04876,-0.55267 z m -40.63083,0.05254 1.04775,0.554689 0.0465,-0.08891 -1.04673,-0.554691 z m 39.84476,-1.418551 -1.00733,0.623395 0.0536,0.08588 1.00733,-0.623394 z m -39.04556,0.02425 1.00532,0.626426 0.0535,-0.08588 -1.00532,-0.626428 z m 38.61111,-0.698163 -0.98612,0.658759 0.0566,0.08386 0.98511,-0.658758 z m -38.17665,0.02425 0.98309,0.660779 0.0566,-0.08386 -0.98309,-0.660778 z m 37.67348,-0.74464 -1.75096,1.27205 0.0586,0.08184 1.75096,-1.272051 z m -37.21578,0.08184 1.75096,1.272051 0.0586,-0.08184 -1.75096,-1.27205 z m 36.79648,-0.63855 0.0616,0.07982 -0.93762,0.72443 -0.0626,-0.07982 z m -36.31454,-0.003 0.93459,0.728475 0.0626,-0.07982 -0.93459,-0.728472 z m 1.02855,-1.232645 0.0677,-0.07578 1.6085,1.448864 -0.0677,0.07477 z m 34.1857,-0.07578 -1.6085,1.448864 0.0677,0.07477 1.6085,-1.447853 z m 0.59713,0.686038 -0.91135,0.756764 0.0636,0.0778 0.91236,-0.756762 z m -35.30822,-0.0021 0.90832,0.760805 0.0647,-0.0778 -0.90832,-0.760805 z m 34.25946,-1.173034 -0.85881,0.817385 0.0697,0.07376 0.85881,-0.817385 z m -33.18746,-0.02526 0.85275,0.822437 0.0697,-0.07275 -0.85275,-0.822437 z m 1.15182,-1.116453 1.44886,1.608502 0.0748,-0.0677 -1.44785,-1.6085 z m 30.78077,-0.06769 0.0758,0.06769 -1.44886,1.608502 -0.0748,-0.0677 z m 0.69008,0.639561 0.0717,0.07073 -0.8285,0.846686 -0.0727,-0.07073 z m -32.05788,-0.02425 0.0728,-0.07073 0.82446,0.851737 -0.0727,0.07073 z m 25.50364,0.134377 2.01669,-3.492832 -0.0879,-0.05052 -2.01669,3.492832 z m -18.911,-0.05052 -2.01669,-3.492832 -0.0879,0.05052 2.01669,3.492832 z m 24.30029,-1.119483 -0.76889,0.901244 0.0768,0.06567 0.76889,-0.901245 z m -29.70171,-0.04345 0.0768,-0.06567 0.76283,0.907307 -0.0768,0.06466 z m 28.30235,-1.046738 -1.27205,1.750964 0.0818,0.0586 1.27205,-1.750962 z m -27.03838,0.0586 1.27205,1.750962 0.0818,-0.0586 -1.27205,-1.750964 z m 27.81737,0.522358 -0.73756,0.928526 0.0798,0.06264 0.73655,-0.927516 z m -28.45996,-0.04142 0.73049,0.933576 0.0798,-0.06264 -0.73049,-0.932566 z m 14.42195,0.853758 v -5.69947 h -0.19803 v 5.69947 z m 12.66897,-1.814616 -0.66684,0.979044 0.0839,0.05658 0.66583,-0.979044 z m -25.7926,0.01212 0.6628,0.982076 0.0839,-0.05658 -0.66381,-0.982076 z m 25.1207,-0.450622 -0.63248,1.002282 0.0859,0.05355 0.63147,-1.002282 z m -24.44982,0.01212 0.62845,1.004303 0.0859,-0.05355 -0.62845,-1.004303 z m 2.83205,-1.506454 0.0919,-0.04142 0.88104,1.977283 -0.0929,0.04142 z m 18.71095,-0.04142 0.0919,0.04142 -0.88003,1.977283 -0.093,-0.04142 z m -20.15274,0.740596 0.55671,1.045728 0.0889,-0.04749 -0.55671,-1.045728 z m 21.58948,-0.05355 -0.55671,1.046738 0.0889,0.04749 0.55672,-1.046738 z m -20.87616,-0.313214 0.0909,-0.04446 0.51933,1.064925 -0.0899,0.04446 z m 20.16083,-0.04951 0.0909,0.04445 -0.52034,1.064927 -0.0899,-0.04446 z m -2.97149,-1.182128 -0.66886,2.059124 0.096,0.03132 0.66886,-2.059124 z m -14.21482,0.03132 0.096,-0.03132 0.66886,2.059124 -0.096,0.03132 z m 15.77179,0.523368 0.094,0.03738 -0.44658,1.098268 -0.094,-0.0384 z m -17.28027,0.0192 0.44456,1.099278 0.094,-0.0384 -0.44456,-1.098266 z m 3.83231,-1.171014 0.44962,2.117727 0.099,-0.02122 -0.44962,-2.117726 z m 9.56412,-0.02122 -0.44961,2.117726 0.099,0.02122 0.44961,-2.117727 z m 3.13516,0.885081 -0.40818,1.112411 0.095,0.03435 0.40818,-1.112411 z m -15.78291,0.01819 0.095,-0.03435 0.40516,1.113421 -0.095,0.03435 z m 5.46102,-1.263967 0.10003,-0.0101 0.22632,2.153087 -0.10002,0.0101 z m 4.80833,-0.0101 0.10003,0.0101 -0.22632,2.153087 -0.10003,-0.0101 z m 4.04348,0.775958 -0.33241,1.136662 0.097,0.02829 0.33241,-1.13666 z m -12.78617,-0.003 0.32736,1.139693 0.097,-0.02829 -0.32635,-1.138682 z m 12.01122,-0.207125 0.098,0.02526 -0.292,1.147776 -0.098,-0.02526 z m -11.23627,-0.0021 0.098,-0.02425 0.28695,1.149797 -0.098,0.02425 z m 9.72477,-0.326347 0.099,0.0192 -0.2142,1.164952 -0.099,-0.01819 z m -8.15365,-0.01111 0.20611,1.166971 0.099,-0.01819 -0.2051,-1.16697 z m 7.36253,-0.118213 -0.17378,1.172024 0.10002,0.01516 0.17278,-1.172024 z m -6.5704,-0.0091 0.10002,-0.01415 0.16469,1.173035 -0.10002,0.01415 z m 5.03263,-0.162669 -0.095,1.181117 0.10103,0.0081 0.094,-1.181118 z m -3.43424,-0.0091 0.10003,-0.0071 0.0829,1.182127 -0.10104,0.0071 z m 2.63302,-0.0394 -0.0525,1.184148 0.10103,0.0051 0.0525,-1.184148 z m -1.83281,-0.0051 0.10104,-0.003 0.0414,1.184148 -0.10104,0.003 z"
+         fill="#ffffff"
+         id="path453"
+         style="display:inline;stroke-width:1.01037;enable-background:new" />
+      <circle
+         cx="336"
+         cy="148.02043"
+         r="14.999998"
+         fill="url(#a)"
+         id="circle459"
+         style="display:inline;fill:url(#linearGradient477);stroke-width:0.658938;enable-background:new" />
+      <path
+         d="m 336,133.02043 c -8.29891,0 -15,6.70109 -15,15 0,8.29891 6.70109,14.99999 15,14.99999 8.29891,0 14.99999,-6.70108 14.99999,-14.99999 0,-8.29891 -6.70108,-15 -14.99999,-15 z m 0,1.40479 c 7.54239,0 13.59521,6.05282 13.59521,13.59521 0,7.54239 -6.05282,13.59522 -13.59521,13.59522 -7.5424,0 -13.59521,-6.05283 -13.59521,-13.59522 0,-7.54239 6.05281,-13.59521 13.59521,-13.59521 z"
+         fill="#808080"
+         fill-opacity="0.5"
+         fill-rule="nonzero"
+         id="path461"
+         style="display:inline;stroke-width:0.652173;enable-background:new" />
+      <path
+         d="m 335.97364,159.26253 v 3.71705 h 0.12915 v -3.71705 z m 0.53637,3.71507 -0.0244,-0.77227 -0.0659,0.002 0.0244,0.77227 z m -1.02991,0 0.0283,-0.77227 -0.0652,-0.003 -0.029,0.77227 z m 1.55245,-0.027 -0.0514,-0.77095 -0.0659,0.005 0.0514,0.77095 z m -2.07499,-6.5e-4 0.056,-0.77096 -0.0659,-0.005 -0.0554,0.77095 z m 2.64299,-0.0145 -0.1476,-1.40419 -0.0652,0.007 0.1476,1.40419 z m -3.13587,0.007 0.1476,-1.40419 -0.0652,-0.007 -0.1476,1.40419 z m 3.59251,-0.0975 -0.0652,0.009 -0.10478,-0.76634 0.0652,-0.008 z m -4.12362,-0.001 0.10807,-0.76502 -0.0652,-0.009 -0.10807,0.76502 z m 4.64022,-0.0797 -0.13112,-0.76107 -0.0646,0.0112 0.13113,0.76107 z m -5.15682,-0.001 -0.0652,-0.0119 0.13508,-0.76041 0.0646,0.0112 z m 5.73406,-0.0758 -0.29323,-1.38113 -0.0646,0.0138 0.29323,1.38113 z m -6.23748,0.0138 0.29322,-1.38113 -0.0646,-0.0138 -0.29323,1.38113 z m 6.66842,-0.14826 -0.18319,-0.75053 -0.0639,0.0151 0.18318,0.75119 z m -7.17317,-0.002 0.18714,-0.74987 -0.0639,-0.0159 -0.18713,0.74986 z m 7.67857,-0.13179 -0.20888,-0.74394 -0.0633,0.0178 0.20888,0.74394 z m -8.18397,-0.003 0.21284,-0.74262 -0.0633,-0.0185 -0.21283,0.74328 z m -0.50738,-0.1186 0.43621,-1.34292 -0.0626,-0.0204 -0.43621,1.34292 z m 9.27055,-0.0204 -0.43621,-1.34292 -0.0626,0.0204 0.43621,1.34292 z m -9.772,-0.18648 0.26489,-0.72615 -0.062,-0.0224 -0.2649,0.72549 z m 10.28598,-0.0277 -0.26556,-0.72549 -0.0619,0.0224 0.26555,0.72614 z m -10.77491,-0.15946 -0.0613,-0.0244 0.29059,-0.71627 0.0606,0.0244 z m 11.26318,-0.0297 -0.062,0.025 -0.29059,-0.71627 0.0606,-0.025 z m -11.74025,-0.13575 0.57459,-1.28953 -0.0607,-0.027 -0.57393,1.28953 z m 12.20282,-0.027 -0.0599,0.027 -0.5746,-1.28953 0.0606,-0.027 z m -12.66605,-0.22403 0.33803,-0.69452 -0.0593,-0.029 -0.33803,0.69452 z m 13.1563,-0.0422 -0.0599,0.029 -0.33935,-0.69386 0.0586,-0.029 z m -13.62349,-0.19373 -0.058,-0.031 0.36242,-0.68266 0.0586,0.031 z m 14.08803,-0.0455 -0.36373,-0.68134 -0.058,0.031 0.36373,0.68134 z m -13.28676,-2.54481 -1.33896,2.31945 0.0573,0.0323 1.33895,-2.31879 z m 12.34778,0.0626 1.31589,2.27728 0.0573,-0.0323 -1.31524,-2.27794 z m 1.82064,1.97021 -0.4092,-0.65563 -0.056,0.035 0.4092,0.65564 z m -15.95216,-0.0106 0.41316,-0.653 -0.056,-0.0356 -0.41316,0.653 z m 16.39035,-0.27543 -0.43226,-0.64114 -0.0547,0.0369 0.43226,0.64114 z m -16.82854,-0.0112 -0.0541,-0.0369 0.43556,-0.6385 0.0547,0.0369 z m 17.26608,-0.25896 -0.8296,-1.14193 -0.0534,0.0382 0.8296,1.14193 z m -17.63377,0.0382 0.8296,-1.14193 -0.0533,-0.0382 -0.8296,1.14193 z m 18.0423,-0.38547 -0.47575,-0.60886 -0.052,0.0402 0.47575,0.60951 z m -18.4851,0.0151 -0.0514,-0.0408 0.47707,-0.60754 0.052,0.0408 z m 18.89101,-0.34529 -0.49684,-0.59172 -0.0507,0.0422 0.49684,0.59173 z m -19.29691,0.0158 0.49815,-0.5904 -0.0501,-0.0429 -0.49882,0.5904 z m 19.70083,-0.32946 -0.0494,0.0442 -0.94425,-1.04903 0.0488,-0.0442 z m -20.07445,0.0442 -0.0494,-0.0442 0.94492,-1.04903 0.0488,0.0442 z m -0.37296,-0.38548 0.53703,-0.55614 -0.0475,-0.0455 -0.53702,0.55614 z m 20.83553,-0.062 -0.53769,-0.55548 -0.0474,0.0461 0.5377,0.55482 z m -21.20585,-0.30706 -0.0461,-0.0475 0.55614,-0.53703 0.0455,0.0474 z m 21.57419,-0.0646 -0.5568,-0.53572 -0.0455,0.0474 0.55681,0.53572 z m -21.94385,-0.28862 -0.0442,-0.0494 1.04902,-0.94425 0.0442,0.0488 z m 22.29507,-0.0494 -0.0442,0.0494 -1.04903,-0.94491 0.0442,-0.0488 z m -22.60016,-0.34001 0.59106,-0.49881 -0.0428,-0.0501 -0.5904,0.49816 z m 22.92567,-0.0771 -0.0422,0.0507 -0.59239,-0.49749 0.0428,-0.0501 z m -23.2558,-0.32815 0.60754,-0.47773 -0.0408,-0.0514 -0.60754,0.47773 z m 23.58461,-0.0784 -0.6082,-0.47641 -0.0408,0.0521 0.60886,0.47575 z m -23.94043,-0.34528 1.14193,-0.8296 -0.0382,-0.0534 -1.14194,0.8296 z m 24.27121,-0.0534 -1.14193,-0.8296 -0.0382,0.0534 1.14193,0.8296 z m -24.5361,-0.36769 0.63916,-0.43424 -0.0369,-0.054 -0.63917,0.43359 z m 24.801,-0.054 -0.63917,-0.43424 -0.0369,0.0547 0.63916,0.43358 z m 0.28532,-0.43885 -0.65432,-0.41117 -0.0349,0.0553 0.65433,0.41183 z m -25.37362,0.0553 0.65432,-0.41117 -0.0349,-0.056 -0.65433,0.41183 z m 23.32762,-1.79296 2.2786,1.31523 0.0323,-0.0567 -2.27859,-1.31523 z m -21.36992,-0.0567 -2.27794,1.31523 0.0329,0.0567 2.27795,-1.31523 z m 23.92461,0.91724 -0.68068,-0.36637 -0.0316,0.058 0.68068,0.36637 z m -26.41077,0.0277 0.68134,-0.36505 -0.031,-0.058 -0.68134,0.36504 z m 26.64931,-0.49289 -0.6932,-0.34264 -0.029,0.0593 0.6932,0.34198 z m -26.88916,0.0277 0.69385,-0.34067 -0.029,-0.0593 -0.69386,0.34067 z m -0.25303,-0.48366 -0.027,-0.06 1.28953,-0.57459 0.027,0.0606 z m 27.40708,-0.06 -1.28954,-0.57459 -0.027,0.0606 1.28954,0.57393 z m 0.15089,-0.40854 -0.025,0.0606 -0.71428,-0.29454 0.025,-0.0613 z m -27.73589,-0.003 -0.025,-0.0606 0.7156,-0.2919 0.025,0.0613 z m 27.92567,-0.48431 -0.0224,0.0619 -0.72483,-0.26951 0.0231,-0.0619 z m -28.11544,-0.003 0.72548,-0.26621 -0.0231,-0.0619 -0.72548,0.26621 z m -0.19834,-0.50541 -0.0204,-0.0626 1.34292,-0.43621 0.0204,0.0626 z m 28.53255,-0.0626 -1.34291,-0.43621 -0.0204,0.0626 1.3429,0.43621 z m 0.10081,-0.39075 -0.0191,0.0626 -0.74064,-0.21942 0.0185,-0.0633 z m -28.76383,-0.0362 -0.0185,-0.0632 0.74262,-0.21481 0.0185,0.0633 z m 28.90287,-0.4685 -0.74855,-0.19373 -0.0165,0.0639 0.74855,0.19373 z m -29.04059,-0.0362 0.74921,-0.18911 -0.0158,-0.0639 -0.74921,0.18911 z m 29.204,-0.58579 -1.38112,-0.29323 -0.0138,0.0646 1.38113,0.29323 z m -29.34567,0.0646 1.38113,-0.29323 -0.0138,-0.0646 -1.38113,0.29323 z m 29.42474,-0.56339 -0.7604,-0.1364 -0.0125,0.0646 0.76172,0.1364 z m -29.50579,0.06 -0.0112,-0.0646 0.76041,-0.13574 0.0119,0.0646 z m 29.5875,-0.57657 -0.01,0.0652 -0.76436,-0.11004 0.01,-0.0652 z m -29.67119,0.0606 -0.01,-0.0652 0.76503,-0.10938 0.01,0.0652 z m 29.75224,-0.59634 -1.40419,-0.1476 -0.007,0.0652 1.40418,0.1476 z m -29.83658,0.0652 1.40419,-0.1476 -0.007,-0.0652 -1.40418,0.1476 z m 29.86426,-0.55153 -0.7703,-0.0567 -0.005,0.0659 0.77096,0.0567 z m -29.89457,0.0402 -0.005,-0.0652 0.77095,-0.056 0.005,0.0659 z m 29.9229,-0.56273 -0.77227,-0.0297 -0.003,0.0659 0.77228,0.0297 z m -29.95255,0.0409 -0.002,-0.0659 0.77227,-0.029 0.002,0.0659 z m 26.2579,-0.48551 H 351 v -0.12981 h -3.71706 z m -22.56589,-0.14634 H 321 v 0.12915 h 3.71705 z m -3.69662,-0.41644 0.003,-0.0659 0.77228,0.0257 -0.002,0.0659 z m 29.95716,-0.083 -0.77227,0.0264 0.003,0.0659 0.77227,-0.0264 z m -29.93147,-0.43951 0.77096,0.0527 0.005,-0.0659 -0.77161,-0.0527 z m 29.9038,-0.083 -0.77095,0.0534 0.004,0.0659 0.77161,-0.0534 z m -29.87151,-0.44874 1.40419,0.14761 0.007,-0.0652 -1.40419,-0.14761 z m 29.83658,-0.0652 -1.40419,0.1476 0.007,0.0652 1.40419,-0.1476 z m -0.0698,-0.483 0.009,0.0652 -0.76568,0.10477 -0.009,-0.0659 z m -29.69425,0.0369 0.009,-0.0652 0.76569,0.10609 -0.009,0.0652 z m 29.61321,-0.55416 -0.76173,0.13179 0.0112,0.0646 0.76173,-0.13113 z m -29.53347,0.0376 0.0119,-0.0652 0.76107,0.1331 -0.0112,0.0646 z m 29.43528,-0.58777 -1.38112,0.29323 0.0138,0.0646 1.38114,-0.29323 z m -29.34567,0.0646 1.38113,0.29322 0.0138,-0.0646 -1.38112,-0.29322 z m 0.12454,-0.50343 0.0158,-0.0639 0.74986,0.18582 -0.0158,0.0639 z m 29.09265,-0.0784 0.0158,0.0639 -0.74987,0.18648 -0.0165,-0.0639 z m -28.95954,-0.42699 0.74327,0.21152 0.0185,-0.0633 -0.74328,-0.21152 z m 28.82314,-0.0778 -0.74328,0.21218 0.0184,0.0633 0.74328,-0.21218 z m -28.67752,-0.43094 0.0204,-0.0626 1.34291,0.43621 -0.0204,0.0626 z m 28.53255,-0.0626 -1.34291,0.43621 0.0204,0.0626 1.34291,-0.43621 z m -0.1733,-0.48366 -0.72681,0.26291 0.0224,0.0619 0.7268,-0.26291 z m -28.18463,0.0567 0.7268,0.26291 0.0224,-0.0619 -0.72681,-0.26291 z m 27.99683,-0.54494 -0.71692,0.28795 0.0244,0.0613 0.71758,-0.28795 z m -27.81101,0.056 0.0244,-0.0613 0.71692,0.28861 -0.0244,0.0606 z m 27.60608,-0.54889 -1.28953,0.57393 0.027,0.0606 1.28953,-0.57459 z m -27.40708,0.06 0.027,-0.06 1.28953,0.57393 -0.027,0.0606 z m 3.02451,-0.14431 -2.27794,-1.31523 -0.0329,0.0567 2.27795,1.31523 z m 24.1704,-0.36176 -0.69584,0.33672 0.0284,0.0593 0.69584,-0.33672 z m -2.75238,0.39339 2.27794,-1.31589 -0.0329,-0.0567 -2.27794,1.31523 z m -24.21916,-0.3578 0.029,-0.0593 0.69518,0.33803 -0.029,0.0593 z m 26.73432,-0.50145 -0.68331,0.36043 0.0303,0.058 0.68398,-0.36043 z m -26.49842,0.0343 0.68332,0.36175 0.0303,-0.058 -0.68265,-0.36176 z m 25.98577,-0.92515 -0.65696,0.40656 0.035,0.056 0.65695,-0.40656 z m -25.46455,0.0158 0.65564,0.40854 0.0349,-0.056 -0.65565,-0.40854 z m 25.18121,-0.45532 -0.64312,0.42962 0.0369,0.0547 0.64246,-0.42962 z m -24.89787,0.0158 0.64115,0.43094 0.0369,-0.0547 -0.64114,-0.43094 z m 24.56971,-0.48564 -1.14193,0.8296 0.0382,0.0534 1.14193,-0.8296 z m -24.27121,0.0534 1.14194,0.8296 0.0382,-0.0534 -1.14193,-0.8296 z m 23.99776,-0.41645 0.0402,0.0521 -0.61149,0.47246 -0.0408,-0.0521 z m -23.68345,-0.002 0.60952,0.4751 0.0408,-0.0521 -0.60952,-0.4751 z m 0.6708,-0.8039 0.0442,-0.0494 1.04902,0.94492 -0.0442,0.0488 z m 22.29507,-0.0494 -1.04903,0.94492 0.0442,0.0488 1.04903,-0.94426 z m 0.38943,0.44742 -0.59436,0.49354 0.0415,0.0507 0.59502,-0.49354 z m -23.02715,-10e-4 0.59239,0.49618 0.0422,-0.0507 -0.59238,-0.49618 z m 22.34317,-0.76502 -0.56009,0.53307 0.0455,0.0481 0.56009,-0.53307 z m -21.64404,-0.0165 0.55615,0.53637 0.0455,-0.0474 -0.55614,-0.53638 z m 0.75119,-0.72813 0.94491,1.04903 0.0488,-0.0442 -0.94426,-1.04903 z m 20.07446,-0.0442 0.0494,0.0442 -0.94491,1.04903 -0.0488,-0.0442 z m 0.45005,0.41711 0.0468,0.0461 -0.54032,0.55219 -0.0474,-0.0461 z m -20.90735,-0.0158 0.0475,-0.0461 0.5377,0.55548 -0.0474,0.0461 z m 16.63284,0.0876 1.31523,-2.27794 -0.0573,-0.0329 -1.31524,2.27794 z m -12.33329,-0.0329 -1.31523,-2.27794 -0.0573,0.0329 1.31524,2.27794 z m 15.84805,-0.7301 -0.50145,0.58777 0.0501,0.0428 0.50145,-0.58777 z m -19.37072,-0.0283 0.0501,-0.0428 0.4975,0.59172 -0.0501,0.0422 z m 18.45809,-0.68266 -0.8296,1.14194 0.0533,0.0382 0.8296,-1.14194 z m -17.63376,0.0382 0.8296,1.14194 0.0533,-0.0382 -0.8296,-1.14194 z m 18.1418,0.34067 -0.48102,0.60556 0.0521,0.0409 0.48036,-0.6049 z m -18.56088,-0.027 0.47641,0.60886 0.052,-0.0409 -0.47641,-0.6082 z m 9.40564,0.5568 V 133.059 h -0.12915 v 3.71705 z m 8.26239,-1.18345 -0.4349,0.63851 0.0547,0.0369 0.43424,-0.63851 z m -16.8213,0.008 0.43226,0.64049 0.0547,-0.0369 -0.43292,-0.64049 z m 16.3831,-0.29388 -0.41249,0.65366 0.056,0.0349 0.41183,-0.65366 z m -15.94557,0.008 0.40986,0.65498 0.056,-0.0349 -0.40986,-0.65498 z m 1.847,-0.98247 0.0599,-0.027 0.57459,1.28953 -0.0606,0.027 z m 12.20281,-0.027 0.0599,0.027 -0.57394,1.28953 -0.0607,-0.027 z m -13.14311,0.483 0.36307,0.68199 0.058,-0.031 -0.36308,-0.68199 z m 14.08012,-0.0349 -0.36307,0.68265 0.058,0.031 0.36307,-0.68265 z m -13.61492,-0.20428 0.0593,-0.029 0.33869,0.69452 -0.0586,0.029 z m 13.1484,-0.0323 0.0593,0.029 -0.33935,0.69452 -0.0586,-0.029 z m -1.93793,-0.77095 -0.43622,1.34291 0.0626,0.0204 0.43622,-1.34291 z m -9.27056,0.0204 0.0626,-0.0204 0.43622,1.34291 -0.0626,0.0204 z m 10.28597,0.34133 0.0613,0.0244 -0.29125,0.71626 -0.0613,-0.025 z m -11.26976,0.0125 0.28993,0.71692 0.0613,-0.025 -0.28994,-0.71626 z m 2.49934,-0.76371 0.29323,1.38113 0.0646,-0.0138 -0.29323,-1.38113 z m 6.23748,-0.0138 -0.29322,1.38113 0.0646,0.0138 0.29323,-1.38113 z m 2.04467,0.57723 -0.2662,0.72549 0.062,0.0224 0.2662,-0.72549 z m -10.29322,0.0119 0.062,-0.0224 0.26423,0.72614 -0.0619,0.0224 z m 3.56154,-0.82433 0.0652,-0.007 0.1476,1.40419 -0.0652,0.007 z m 3.13588,-0.007 0.0652,0.007 -0.1476,1.40419 -0.0652,-0.007 z m 2.63705,0.50606 -0.21679,0.7413 0.0633,0.0185 0.21679,-0.7413 z m -8.33882,-0.002 0.2135,0.74328 0.0633,-0.0185 -0.21284,-0.74262 z m 7.83342,-0.13508 0.0639,0.0165 -0.19043,0.74855 -0.0639,-0.0165 z m -7.32802,-0.001 0.0639,-0.0158 0.18714,0.74987 -0.0639,0.0158 z m 6.34226,-0.21284 0.0646,0.0125 -0.13969,0.75976 -0.0646,-0.0119 z m -5.31761,-0.007 0.13442,0.76107 0.0646,-0.0119 -0.13376,-0.76107 z m 4.80166,-0.0771 -0.11334,0.76437 0.0652,0.01 0.11269,-0.76437 z m -4.28505,-0.006 0.0652,-0.009 0.1074,0.76503 -0.0652,0.009 z m 3.28215,-0.10609 -0.062,0.7703 0.0659,0.005 0.0613,-0.7703 z m -2.23972,-0.006 0.0652,-0.005 0.0541,0.77096 -0.0659,0.005 z m 1.71719,-0.0257 -0.0342,0.77228 0.0659,0.003 0.0342,-0.77228 z m -1.19532,-0.003 0.0659,-0.002 0.027,0.77228 -0.0659,0.002 z"
+         fill="#ffffff"
+         id="path473"
+         style="display:inline;stroke-width:0.658938;enable-background:new" />
+      <circle
+         cx="332"
+         cy="200.01521"
+         r="11.499999"
+         fill="url(#a)"
+         id="circle479"
+         style="display:inline;fill:url(#linearGradient497);stroke-width:0.505186;enable-background:new" />
+      <path
+         d="m 332,188.51521 c -6.3625,0 -11.5,5.1375 -11.5,11.5 0,6.3625 5.1375,11.49999 11.5,11.49999 6.3625,0 11.49999,-5.13749 11.49999,-11.49999 0,-6.3625 -5.13749,-11.5 -11.49999,-11.5 z m 0,1.07701 c 5.7825,0 10.42299,4.64049 10.42299,10.42299 0,5.7825 -4.64049,10.423 -10.42299,10.423 -5.78251,0 -10.42299,-4.6405 -10.42299,-10.423 0,-5.7825 4.64048,-10.42299 10.42299,-10.42299 z"
+         fill="#808080"
+         fill-opacity="0.5"
+         fill-rule="nonzero"
+         id="path481"
+         style="display:inline;stroke-width:0.499999;enable-background:new" />
+      <path
+         d="m 331.97979,208.63415 v 2.84974 h 0.099 v -2.84974 z m 0.41122,2.84822 -0.0187,-0.59207 -0.0505,0.002 0.0187,0.59208 z m -0.7896,0 0.0217,-0.59207 -0.05,-0.002 -0.0222,0.59207 z m 1.19021,-0.0207 -0.0394,-0.59106 -0.0505,0.004 0.0394,0.59106 z m -1.59082,-4.9e-4 0.0429,-0.59107 -0.0505,-0.004 -0.0425,0.59106 z m 2.02629,-0.0111 -0.11316,-1.07655 -0.05,0.005 0.11316,1.07655 z m -2.40417,0.005 0.11316,-1.07655 -0.05,-0.005 -0.11316,1.07655 z m 2.75426,-0.0747 -0.05,0.007 -0.0803,-0.58753 0.05,-0.006 z m -3.16144,-7.7e-4 0.0828,-0.58652 -0.05,-0.007 -0.0829,0.58652 z m 3.5575,-0.0611 -0.10053,-0.58349 -0.0495,0.009 0.10053,0.58348 z m -3.95356,-7.7e-4 -0.05,-0.009 0.10356,-0.58299 0.0495,0.009 z m 4.39611,-0.0581 -0.22481,-1.05887 -0.0495,0.0106 0.22481,1.05887 z m -4.78207,0.0106 0.2248,-1.05887 -0.0495,-0.0106 -0.22481,1.05887 z m 5.11246,-0.11367 -0.14045,-0.57541 -0.049,0.0116 0.14044,0.57591 z m -5.49943,-0.002 0.14347,-0.5749 -0.049,-0.0122 -0.14347,0.57489 z m 5.8869,-0.10104 -0.16014,-0.57036 -0.0485,0.0137 0.16014,0.57035 z m -6.27438,-0.002 0.16318,-0.56934 -0.0485,-0.0142 -0.16317,0.56985 z m -0.38899,-0.0909 0.33443,-1.02957 -0.048,-0.0156 -0.33443,1.02958 z m 7.10742,-0.0156 -0.33442,-1.02958 -0.048,0.0156 0.33443,1.02957 z m -7.49186,-0.14297 0.20308,-0.55671 -0.0475,-0.0172 -0.20309,0.55621 z m 7.88592,-0.0212 -0.2036,-0.55621 -0.0475,0.0172 0.20359,0.55671 z m -8.26077,-0.12226 -0.047,-0.0187 0.22279,-0.54914 0.0465,0.0187 z m 8.63511,-0.0228 -0.0475,0.0192 -0.22278,-0.54914 0.0465,-0.0192 z m -9.00086,-0.10407 0.44052,-0.98864 -0.0465,-0.0207 -0.44001,0.98864 z m 9.35549,-0.0207 -0.0459,0.0207 -0.44053,-0.98864 0.0465,-0.0207 z m -9.71064,-0.17177 0.25916,-0.53245 -0.0455,-0.0222 -0.25916,0.53247 z m 10.0865,-0.0324 -0.0459,0.0222 -0.26017,-0.53196 0.0449,-0.0222 z m -10.44467,-0.14853 -0.0445,-0.0238 0.27785,-0.52338 0.0449,0.0238 z m 10.80082,-0.0349 -0.27886,-0.52236 -0.0445,0.0238 0.27886,0.52237 z m -10.18652,-1.95102 -1.02653,1.77824 0.0439,0.0248 1.02652,-1.77774 z m 9.46663,0.048 1.00885,1.74592 0.0439,-0.0248 -1.00835,-1.74642 z m 1.39583,1.5105 -0.31372,-0.50265 -0.0429,0.0268 0.31372,0.50266 z m -12.22999,-0.008 0.31675,-0.50063 -0.0429,-0.0273 -0.31676,0.50064 z m 12.56593,-0.21116 -0.3314,-0.49154 -0.0419,0.0283 0.3314,0.49154 z m -12.90188,-0.009 -0.0415,-0.0283 0.33393,-0.48952 0.0419,0.0283 z m 13.23733,-0.19854 -0.63603,-0.87548 -0.0409,0.0293 0.63603,0.87548 z m -13.51922,0.0293 0.63602,-0.87548 -0.0409,-0.0293 -0.63603,0.87548 z m 13.83243,-0.29553 -0.36474,-0.46679 -0.0399,0.0308 0.36474,0.46728 z m -14.17191,0.0116 -0.0394,-0.0313 0.36575,-0.46578 0.0399,0.0313 z m 14.4831,-0.26472 -0.38091,-0.45365 -0.0389,0.0324 0.38091,0.45366 z m -14.79429,0.0121 0.38191,-0.45264 -0.0384,-0.0329 -0.38243,0.45264 z m 15.10397,-0.25259 -0.0379,0.0339 -0.72392,-0.80426 0.0374,-0.0339 z m -15.39042,0.0339 -0.0379,-0.0339 0.72444,-0.80425 0.0374,0.0339 z m -0.28593,-0.29553 0.41172,-0.42638 -0.0364,-0.0349 -0.41172,0.42637 z m 15.97391,-0.0475 -0.41223,-0.42586 -0.0363,0.0353 0.41223,0.42536 z m -16.25782,-0.23541 -0.0353,-0.0364 0.42638,-0.41172 0.0349,0.0363 z m 16.54021,-0.0495 -0.42688,-0.41071 -0.0349,0.0363 0.42688,0.41071 z m -16.82362,-0.22127 -0.0339,-0.0379 0.80425,-0.72393 0.0339,0.0374 z m 17.09289,-0.0379 -0.0339,0.0379 -0.80426,-0.72443 0.0339,-0.0374 z m -17.32679,-0.26068 0.45314,-0.38242 -0.0328,-0.0384 -0.45264,0.38192 z m 17.57635,-0.0591 -0.0324,0.0389 -0.45416,-0.38141 0.0328,-0.0384 z m -17.82945,-0.25158 0.46578,-0.36626 -0.0313,-0.0394 -0.46578,0.36626 z m 18.08153,-0.0601 -0.46628,-0.36525 -0.0313,0.04 0.46679,0.36474 z m -18.35433,-0.26471 0.87548,-0.63603 -0.0293,-0.0409 -0.87549,0.63603 z m 18.60793,-0.0409 -0.87548,-0.63603 -0.0293,0.0409 0.87548,0.63603 z m -18.81101,-0.2819 0.49002,-0.33292 -0.0283,-0.0414 -0.49003,0.33242 z m 19.0141,-0.0414 -0.49003,-0.33292 -0.0283,0.0419 0.49002,0.33241 z m 0.21875,-0.33645 -0.50165,-0.31523 -0.0268,0.0424 0.50166,0.31573 z m -19.45311,0.0424 0.50164,-0.31523 -0.0267,-0.0429 -0.50166,0.31574 z m 17.88451,-1.37461 1.74692,1.00835 0.0248,-0.0435 -1.74692,-1.00835 z m -16.38361,-0.0435 -1.74642,1.00835 0.0252,0.0435 1.74643,-1.00835 z m 18.3422,0.70322 -0.52185,-0.28088 -0.0242,0.0445 0.52186,0.28089 z m -20.24825,0.0212 0.52236,-0.27987 -0.0238,-0.0445 -0.52236,0.27986 z m 20.43113,-0.37788 -0.53145,-0.26269 -0.0222,0.0455 0.53145,0.26218 z m -20.61502,0.0212 0.53195,-0.26118 -0.0222,-0.0455 -0.53196,0.26118 z m -0.19399,-0.3708 -0.0207,-0.046 0.98864,-0.44052 0.0207,0.0465 z m 21.0121,-0.046 -0.98865,-0.44052 -0.0207,0.0465 0.98865,0.44001 z m 0.11568,-0.31322 -0.0192,0.0465 -0.54761,-0.22581 0.0192,-0.047 z m -21.26418,-0.002 -0.0192,-0.0465 0.54863,-0.22379 0.0192,0.047 z m 21.40968,-0.3713 -0.0172,0.0475 -0.5557,-0.20663 0.0177,-0.0475 z m -21.55518,-0.002 0.55621,-0.2041 -0.0177,-0.0474 -0.55621,0.20409 z m -0.15206,-0.38748 -0.0156,-0.048 1.02958,-0.33442 0.0156,0.048 z m 21.87496,-0.048 -1.02957,-0.33442 -0.0156,0.048 1.02956,0.33443 z m 0.0773,-0.29957 -0.0147,0.048 -0.56782,-0.16822 0.0142,-0.0485 z m -22.05227,-0.0277 -0.0142,-0.0485 0.56935,-0.16469 0.0142,0.0485 z m 22.15886,-0.35919 -0.57388,-0.14852 -0.0127,0.049 0.57388,0.14852 z m -22.26445,-0.0277 0.5744,-0.14499 -0.0121,-0.049 -0.57439,0.14499 z m 22.38974,-0.44911 -1.05886,-0.22481 -0.0106,0.0495 1.05886,0.22481 z m -22.49835,0.0495 1.05886,-0.22481 -0.0106,-0.0495 -1.05886,0.22481 z m 22.55897,-0.43193 -0.58298,-0.10458 -0.01,0.0495 0.58398,0.10457 z m -22.62111,0.046 -0.009,-0.0495 0.58298,-0.10407 0.009,0.0495 z m 22.68375,-0.44204 -0.008,0.05 -0.58601,-0.0844 0.008,-0.05 z m -22.74791,0.0465 -0.008,-0.05 0.58652,-0.0838 0.008,0.05 z m 22.81005,-0.45719 -1.07655,-0.11316 -0.005,0.05 1.07653,0.11316 z m -22.87471,0.05 1.07654,-0.11316 -0.005,-0.05 -1.07654,0.11316 z m 22.89593,-0.42284 -0.59056,-0.0435 -0.004,0.0505 0.59107,0.0435 z m -22.91917,0.0308 -0.004,-0.05 0.59106,-0.0429 0.004,0.0505 z m 22.94089,-0.43142 -0.59207,-0.0228 -0.002,0.0505 0.59208,0.0228 z m -22.96362,0.0314 -0.002,-0.0505 0.59208,-0.0222 0.002,0.0505 z m 20.13105,-0.37222 H 343.5 v -0.0995 h -2.84975 z m -17.30051,-0.11218 H 320.5 v 0.099 h 2.84974 z m -2.83408,-0.31927 0.002,-0.0505 0.59208,0.0197 -0.002,0.0505 z m 22.96716,-0.0636 -0.59207,0.0202 0.002,0.0505 0.59207,-0.0202 z m -22.94746,-0.33696 0.59107,0.0404 0.004,-0.0505 -0.59157,-0.0404 z m 22.92625,-0.0636 -0.59107,0.0409 0.003,0.0505 0.59157,-0.0409 z m -22.9015,-0.34403 1.07655,0.11316 0.005,-0.05 -1.07655,-0.11317 z m 22.87472,-0.05 -1.07655,0.11316 0.005,0.05 1.07654,-0.11316 z m -0.0535,-0.3703 0.007,0.05 -0.58702,0.0803 -0.007,-0.0505 z m -22.76559,0.0283 0.007,-0.05 0.58703,0.0813 -0.007,0.05 z m 22.70346,-0.42486 -0.58399,0.10104 0.009,0.0495 0.58399,-0.10053 z m -22.64233,0.0288 0.009,-0.05 0.58349,0.10205 -0.009,0.0495 z m 22.56705,-0.45062 -1.05886,0.22481 0.0106,0.0495 1.05888,-0.22481 z m -22.49834,0.0495 1.05886,0.22481 0.0106,-0.0495 -1.05886,-0.2248 z m 0.0955,-0.38596 0.0121,-0.049 0.57489,0.14246 -0.0121,0.049 z m 22.30436,-0.0601 0.0121,0.049 -0.5749,0.14297 -0.0127,-0.049 z m -22.20231,-0.32735 0.56984,0.16216 0.0142,-0.0485 -0.56985,-0.16216 z m 22.09774,-0.0597 -0.56985,0.16267 0.0141,0.0485 0.56984,-0.16267 z m -21.9861,-0.33039 0.0156,-0.048 1.02956,0.33443 -0.0156,0.048 z m 21.87495,-0.048 -1.02956,0.33443 0.0156,0.048 1.02956,-0.33443 z m -0.13286,-0.37081 -0.55722,0.20157 0.0172,0.0474 0.55722,-0.20156 z m -21.60822,0.0435 0.55722,0.20157 0.0172,-0.0475 -0.55722,-0.20156 z m 21.46424,-0.41779 -0.54964,0.22077 0.0187,0.047 0.55014,-0.22076 z m -21.32177,0.0429 0.0187,-0.047 0.54964,0.22127 -0.0187,0.0465 z m 21.16466,-0.42082 -0.98864,0.44002 0.0207,0.0465 0.98864,-0.44052 z m -21.0121,0.046 0.0207,-0.046 0.98864,0.44002 -0.0207,0.0465 z m 2.31879,-0.11064 -1.74642,-1.00834 -0.0252,0.0435 1.74643,1.00834 z m 18.53064,-0.27734 -0.53347,0.25815 0.0218,0.0455 0.53348,-0.25815 z m -2.11015,0.30159 1.74642,-1.00884 -0.0252,-0.0435 -1.74642,1.00834 z m -18.56803,-0.27431 0.0222,-0.0455 0.53297,0.25915 -0.0222,0.0455 z m 20.49632,-0.38444 -0.52388,0.27633 0.0232,0.0445 0.52439,-0.27633 z m -20.31546,0.0263 0.52388,0.27734 0.0232,-0.0445 -0.52337,-0.27735 z m 19.92242,-0.70928 -0.50367,0.3117 0.0268,0.0429 0.50366,-0.3117 z m -19.52282,0.0121 0.50266,0.31322 0.0268,-0.0429 -0.50267,-0.31321 z m 19.3056,-0.34908 -0.49306,0.32938 0.0283,0.0419 0.49255,-0.32938 z m -19.08837,0.0121 0.49155,0.33038 0.0283,-0.0419 -0.49154,-0.33038 z m 18.83678,-0.37234 -0.87548,0.63604 0.0293,0.0409 0.87548,-0.63603 z m -18.60793,0.0409 0.87549,0.63603 0.0293,-0.0409 -0.87548,-0.63604 z m 18.39828,-0.31926 0.0308,0.0399 -0.46881,0.36222 -0.0313,-0.0399 z m -18.15731,-0.002 0.4673,0.36425 0.0313,-0.04 -0.4673,-0.36423 z m 0.51428,-0.61632 0.0339,-0.0379 0.80425,0.72444 -0.0339,0.0374 z m 17.09289,-0.0379 -0.80426,0.72444 0.0339,0.0374 0.80425,-0.72393 z m 0.29856,0.34302 -0.45568,0.37838 0.0318,0.0389 0.45618,-0.37838 z m -17.65415,-7.7e-4 0.45417,0.38042 0.0324,-0.0389 -0.45416,-0.38041 z m 17.12977,-0.58651 -0.42941,0.40868 0.0349,0.0369 0.4294,-0.40869 z m -16.59377,-0.0127 0.42638,0.41122 0.0349,-0.0363 -0.42638,-0.41121 z m 0.57591,-0.55824 0.72444,0.80426 0.0374,-0.0339 -0.72393,-0.80425 z m 15.39042,-0.0339 0.0379,0.0339 -0.72443,0.80426 -0.0374,-0.0339 z m 0.34504,0.31978 0.0359,0.0353 -0.41424,0.42335 -0.0363,-0.0353 z m -16.02897,-0.0121 0.0364,-0.0354 0.41224,0.42587 -0.0363,0.0354 z m 12.75185,0.0672 1.00834,-1.74642 -0.0439,-0.0252 -1.00835,1.74642 z m -9.45552,-0.0252 -1.00835,-1.74642 -0.0439,0.0252 1.00835,1.74642 z m 12.15017,-0.55974 -0.38445,0.45062 0.0384,0.0328 0.38445,-0.45063 z m -14.85089,-0.0217 0.0384,-0.0328 0.38142,0.45365 -0.0384,0.0324 z m 14.1512,-0.52337 -0.63602,0.87549 0.0409,0.0293 0.63603,-0.8755 z m -13.51921,0.0293 0.63602,0.8755 0.0409,-0.0293 -0.63603,-0.87549 z m 13.90871,0.26118 -0.36878,0.46426 0.0399,0.0314 0.36828,-0.46376 z m -14.23001,-0.0207 0.36525,0.46679 0.0399,-0.0314 -0.36525,-0.46628 z m 7.21099,0.42688 v -2.84925 h -0.099 v 2.84974 z m 6.3345,-0.90731 -0.33342,0.48952 0.0419,0.0283 0.33291,-0.48952 z m -12.89633,0.006 0.3314,0.49104 0.0419,-0.0283 -0.33191,-0.49104 z m 12.56038,-0.22531 -0.31624,0.50114 0.0429,0.0268 0.31574,-0.50114 z m -12.22494,0.006 0.31423,0.50215 0.0429,-0.0268 -0.31422,-0.50215 z m 1.41604,-0.75323 0.0459,-0.0207 0.44052,0.98864 -0.0465,0.0207 z m 9.35548,-0.0207 0.0459,0.0207 -0.44002,0.98864 -0.0465,-0.0207 z m -10.07638,0.3703 0.27835,0.52286 0.0445,-0.0238 -0.27836,-0.52286 z m 10.79476,-0.0268 -0.27836,0.52337 0.0445,0.0238 0.27835,-0.52336 z m -10.43811,-0.15661 0.0455,-0.0222 0.25966,0.53247 -0.0449,0.0222 z m 10.08044,-0.0248 0.0455,0.0222 -0.26017,0.53246 -0.0449,-0.0222 z m -1.48574,-0.59106 -0.33444,1.02957 0.048,0.0156 0.33444,-1.02957 z m -7.10743,0.0156 0.048,-0.0156 0.33444,1.02957 -0.048,0.0156 z m 7.88591,0.26169 0.047,0.0187 -0.22329,0.54913 -0.047,-0.0192 z m -8.64015,0.01 0.22228,0.54964 0.047,-0.0192 -0.22228,-0.54913 z m 1.91616,-0.58551 0.22481,1.05887 0.0495,-0.0106 -0.22481,-1.05887 z m 4.78207,-0.0106 -0.22481,1.05887 0.0495,0.0106 0.22481,-1.05887 z m 1.56758,0.44254 -0.20409,0.55621 0.0475,0.0172 0.20409,-0.55621 z m -7.89147,0.009 0.0475,-0.0172 0.20258,0.55671 -0.0475,0.0172 z m 2.73051,-0.63199 0.05,-0.005 0.11316,1.07655 -0.05,0.005 z m 2.40418,-0.005 0.05,0.005 -0.11316,1.07655 -0.05,-0.005 z m 2.02174,0.38798 -0.16621,0.56833 0.0485,0.0142 0.16621,-0.56833 z m -6.3931,-0.002 0.16368,0.56985 0.0485,-0.0142 -0.16317,-0.56935 z m 6.00562,-0.10356 0.049,0.0127 -0.14599,0.57389 -0.049,-0.0127 z m -5.61815,-7.7e-4 0.049,-0.0121 0.14348,0.5749 -0.049,0.0121 z m 4.8624,-0.16317 0.0495,0.01 -0.1071,0.58248 -0.0495,-0.009 z m -4.07683,-0.005 0.10305,0.58349 0.0495,-0.009 -0.10255,-0.58348 z m 3.68127,-0.0591 -0.0869,0.58602 0.05,0.008 0.0864,-0.58601 z m -3.2852,-0.005 0.05,-0.007 0.0823,0.58652 -0.05,0.007 z m 2.51631,-0.0813 -0.0475,0.59057 0.0505,0.004 0.047,-0.59056 z m -1.71712,-0.005 0.05,-0.004 0.0415,0.59107 -0.0505,0.004 z m 1.31651,-0.0197 -0.0262,0.59208 0.0505,0.002 0.0262,-0.59208 z m -0.91641,-0.002 0.0505,-0.002 0.0207,0.59208 -0.0505,0.002 z"
+         fill="#ffffff"
+         id="path493"
+         style="display:inline;stroke-width:0.505186;enable-background:new" />
+      <circle
+         cx="328"
+         cy="244.00742"
+         r="7.4999986"
+         fill="url(#a)"
+         id="circle499"
+         style="display:inline;fill:url(#linearGradient517);stroke-width:0.329469;enable-background:new" />
+      <path
+         d="m 328,236.50741 c -4.14946,0 -7.5,3.35054 -7.5,7.5 0,4.14946 3.35054,7.49999 7.5,7.49999 4.14946,0 7.49999,-3.35053 7.49999,-7.49999 0,-4.14946 -3.35053,-7.5 -7.49999,-7.5 z m 0,0.7024 c 3.77119,0 6.7976,3.0264 6.7976,6.7976 0,3.77119 -3.02641,6.79761 -6.7976,6.79761 -3.7712,0 -6.7976,-3.02642 -6.7976,-6.79761 0,-3.7712 3.0264,-6.7976 6.7976,-6.7976 z"
+         fill="#808080"
+         fill-opacity="0.5"
+         fill-rule="nonzero"
+         id="path501"
+         style="display:inline;stroke-width:0.326086;enable-background:new" />
+      <path
+         d="m 327.98682,249.62846 v 1.85852 h 0.0646 v -1.85852 z m 0.26819,1.85753 -0.0122,-0.38613 -0.0329,0.001 0.0122,0.38614 z m -0.51496,0 0.0142,-0.38613 -0.0326,-0.001 -0.0145,0.38614 z m 0.77622,-0.0135 -0.0257,-0.38547 -0.0329,0.003 0.0257,0.38547 z m -1.03749,-3.2e-4 0.028,-0.38548 -0.0329,-0.003 -0.0277,0.38548 z m 1.3215,-0.007 -0.0738,-0.7021 -0.0326,0.003 0.0738,0.70209 z m -1.56794,0.003 0.0738,-0.70209 -0.0326,-0.003 -0.0738,0.7021 z m 1.79625,-0.0487 -0.0326,0.005 -0.0524,-0.38317 0.0326,-0.004 z m -2.0618,-5.1e-4 0.054,-0.38251 -0.0326,-0.005 -0.0541,0.38251 z m 2.3201,-0.0398 -0.0656,-0.38054 -0.0323,0.006 0.0656,0.38053 z m -2.5784,-5.1e-4 -0.0326,-0.006 0.0675,-0.38021 0.0323,0.006 z m 2.86702,-0.0379 -0.14661,-0.69056 -0.0323,0.007 0.14661,0.69057 z m -3.11874,0.007 0.14661,-0.69057 -0.0323,-0.007 -0.14662,0.69056 z m 3.33422,-0.0741 -0.0916,-0.37526 -0.032,0.008 0.0916,0.37559 z m -3.58659,-0.001 0.0936,-0.37494 -0.032,-0.008 -0.0936,0.37493 z m 3.83928,-0.0659 -0.10444,-0.37197 -0.0316,0.009 0.10444,0.37197 z m -4.09198,-0.001 0.10642,-0.37131 -0.0316,-0.009 -0.10642,0.37164 z m -0.25369,-0.0593 0.2181,-0.67146 -0.0313,-0.0102 -0.21811,0.67147 z m 4.63527,-0.0102 -0.2181,-0.67146 -0.0313,0.0102 0.2181,0.67146 z m -4.88599,-0.0932 0.13244,-0.36307 -0.031,-0.0112 -0.13245,0.36275 z m 5.14299,-0.0138 -0.13279,-0.36274 -0.031,0.0112 0.13277,0.36307 z m -5.38746,-0.0797 -0.0306,-0.0122 0.14529,-0.35813 0.0303,0.0122 z m 5.63159,-0.0149 -0.031,0.0125 -0.14529,-0.35813 0.0303,-0.0125 z m -5.87012,-0.0679 0.28729,-0.64477 -0.0303,-0.0135 -0.28697,0.64477 z m 6.1014,-0.0135 -0.0299,0.0135 -0.2873,-0.64477 0.0303,-0.0135 z m -6.33302,-0.11203 0.16901,-0.34725 -0.0297,-0.0145 -0.16902,0.34726 z m 6.57815,-0.0211 -0.0299,0.0145 -0.16967,-0.34693 0.0293,-0.0145 z m -6.81174,-0.0969 -0.029,-0.0155 0.1812,-0.34134 0.0293,0.0155 z m 7.04401,-0.0228 -0.18186,-0.34067 -0.029,0.0155 0.18187,0.34067 z m -6.64338,-1.27241 -0.66948,1.15972 0.0286,0.0162 0.66947,-1.1594 z m 6.17389,0.0313 0.65794,1.13864 0.0286,-0.0162 -0.65762,-1.13897 z m 0.91032,0.9851 -0.2046,-0.32781 -0.028,0.0175 0.2046,0.32782 z m -7.97608,-0.005 0.20658,-0.3265 -0.028,-0.0178 -0.20658,0.3265 z m 8.19517,-0.13772 -0.21613,-0.32057 -0.0273,0.0185 0.21613,0.32057 z m -8.41427,-0.006 -0.0271,-0.0185 0.21778,-0.31925 0.0273,0.0185 z m 8.63304,-0.12948 -0.4148,-0.57096 -0.0267,0.0191 0.4148,0.57096 z m -8.81688,0.0191 0.4148,-0.57096 -0.0267,-0.0191 -0.4148,0.57096 z m 9.02115,-0.19274 -0.23787,-0.30442 -0.026,0.0201 0.23787,0.30475 z m -9.24255,0.008 -0.0257,-0.0204 0.23853,-0.30377 0.026,0.0204 z m 9.4455,-0.17264 -0.24842,-0.29586 -0.0254,0.0211 0.24842,0.29586 z m -9.64845,0.008 0.24907,-0.2952 -0.025,-0.0215 -0.24941,0.2952 z m 9.85042,-0.16474 -0.0247,0.0221 -0.47212,-0.52451 0.0244,-0.0221 z m -10.03723,0.0221 -0.0247,-0.0221 0.47246,-0.52451 0.0244,0.0221 z m -0.18648,-0.19273 0.26851,-0.27808 -0.0237,-0.0228 -0.26851,0.27807 z m 10.41777,-0.031 -0.26885,-0.27774 -0.0237,0.023 0.26884,0.27741 z m -10.60293,-0.15353 -0.023,-0.0237 0.27807,-0.26851 0.0228,0.0237 z m 10.78709,-0.0323 -0.2784,-0.26786 -0.0228,0.0237 0.2784,0.26785 z m -10.97192,-0.14431 -0.0221,-0.0247 0.52451,-0.47212 0.0221,0.0244 z m 11.14754,-0.0247 -0.0221,0.0247 -0.52452,-0.47245 0.0221,-0.0244 z m -11.30008,-0.17001 0.29552,-0.2494 -0.0214,-0.025 -0.2952,0.24907 z m 11.46283,-0.0385 -0.0211,0.0254 -0.29619,-0.24874 0.0214,-0.025 z m -11.6279,-0.16407 0.30377,-0.23887 -0.0204,-0.0257 -0.30377,0.23886 z m 11.7923,-0.0392 -0.30409,-0.2382 -0.0204,0.0261 0.30443,0.23788 z m -11.97021,-0.17264 0.57096,-0.4148 -0.0191,-0.0267 -0.57097,0.4148 z m 12.1356,-0.0267 -0.57096,-0.4148 -0.0191,0.0267 0.57096,0.4148 z m -12.26805,-0.18385 0.31958,-0.21712 -0.0184,-0.027 -0.31959,0.2168 z m 12.4005,-0.027 -0.31958,-0.21712 -0.0185,0.0273 0.31958,0.21679 z m 0.14267,-0.21942 -0.32717,-0.20559 -0.0175,0.0277 0.32717,0.20591 z m -12.68681,0.0276 0.32715,-0.20558 -0.0174,-0.028 -0.32717,0.20592 z m 11.66381,-0.89648 1.13929,0.65762 0.0162,-0.0284 -1.1393,-0.65762 z m -10.68497,-0.0284 -1.13897,0.65762 0.0164,0.0284 1.13898,-0.65762 z m 11.96231,0.45862 -0.34034,-0.18318 -0.0158,0.029 0.34034,0.18319 z m -13.20538,0.0138 0.34067,-0.18252 -0.0155,-0.029 -0.34067,0.18252 z m 13.32465,-0.24644 -0.3466,-0.17132 -0.0145,0.0297 0.3466,0.17098 z m -13.44458,0.0138 0.34692,-0.17034 -0.0145,-0.0297 -0.34693,0.17033 z m -0.12652,-0.24183 -0.0135,-0.03 0.64477,-0.28729 0.0135,0.0303 z m 13.70355,-0.03 -0.64477,-0.28729 -0.0135,0.0303 0.64477,0.28696 z m 0.0754,-0.20427 -0.0125,0.0303 -0.35714,-0.14726 0.0125,-0.0307 z m -13.86794,-0.001 -0.0125,-0.0303 0.3578,-0.14595 0.0125,0.0306 z m 13.96283,-0.24215 -0.0112,0.031 -0.36241,-0.13476 0.0115,-0.031 z m -14.05772,-10e-4 0.36274,-0.13311 -0.0115,-0.0309 -0.36275,0.13311 z m -0.0992,-0.25271 -0.0102,-0.0313 0.67147,-0.2181 0.0102,0.0313 z m 14.26627,-0.0313 -0.67145,-0.2181 -0.0102,0.0313 0.67145,0.21811 z m 0.0504,-0.19537 -0.01,0.0313 -0.37032,-0.10971 0.009,-0.0316 z m -14.38192,-0.0181 -0.009,-0.0316 0.37132,-0.10741 0.009,0.0316 z m 14.45143,-0.23425 -0.37427,-0.0969 -0.008,0.032 0.37427,0.0969 z m -14.52029,-0.0181 0.37461,-0.0946 -0.008,-0.0319 -0.3746,0.0945 z m 14.602,-0.2929 -0.69056,-0.14661 -0.007,0.0323 0.69056,0.14662 z m -14.67283,0.0323 0.69056,-0.14662 -0.007,-0.0323 -0.69057,0.14661 z m 14.71237,-0.2817 -0.38021,-0.0682 -0.007,0.0323 0.38086,0.0682 z m -14.7529,0.03 -0.006,-0.0323 0.38021,-0.0679 0.006,0.0323 z m 14.79375,-0.28828 -0.005,0.0326 -0.38218,-0.055 0.005,-0.0326 z m -14.83559,0.0303 -0.005,-0.0326 0.38251,-0.0547 0.005,0.0326 z m 14.87612,-0.29817 -0.7021,-0.0738 -0.003,0.0326 0.70208,0.0738 z m -14.91829,0.0326 0.70209,-0.0738 -0.003,-0.0326 -0.70209,0.0738 z m 14.93213,-0.27576 -0.38515,-0.0284 -0.003,0.0329 0.38548,0.0284 z m -14.94729,0.0201 -0.003,-0.0326 0.38548,-0.028 0.003,0.0329 z m 14.96145,-0.28136 -0.38613,-0.0149 -10e-4,0.0329 0.38614,0.0149 z m -14.97627,0.0205 -0.001,-0.0329 0.38614,-0.0145 10e-4,0.0329 z m 13.12894,-0.24275 H 335.5 v -0.0649 h -1.85853 z m -11.28294,-0.0732 H 320.5 v 0.0646 h 1.85853 z m -1.84831,-0.20822 10e-4,-0.0329 0.38614,0.0128 -10e-4,0.0329 z m 14.97858,-0.0415 -0.38613,0.0132 0.001,0.0329 0.38614,-0.0132 z m -14.96573,-0.21975 0.38548,0.0263 0.003,-0.0329 -0.38581,-0.0264 z m 14.9519,-0.0415 -0.38548,0.0267 0.002,0.0329 0.38581,-0.0267 z m -14.93576,-0.22437 0.7021,0.0738 0.003,-0.0326 -0.7021,-0.0738 z m 14.91829,-0.0326 -0.70209,0.0738 0.003,0.0326 0.70209,-0.0738 z m -0.0349,-0.2415 0.005,0.0326 -0.38284,0.0524 -0.005,-0.0329 z m -14.84712,0.0185 0.005,-0.0326 0.38285,0.053 -0.005,0.0326 z m 14.8066,-0.27709 -0.38086,0.0659 0.006,0.0323 0.38086,-0.0656 z m -14.76673,0.0188 0.006,-0.0326 0.38053,0.0666 -0.006,0.0323 z m 14.71764,-0.29389 -0.69056,0.14662 0.007,0.0323 0.69057,-0.14661 z m -14.67283,0.0323 0.69056,0.14661 0.007,-0.0323 -0.69056,-0.14661 z m 0.0623,-0.25172 0.008,-0.0319 0.37493,0.0929 -0.008,0.0319 z m 14.54632,-0.0392 0.008,0.032 -0.37493,0.0932 -0.008,-0.032 z m -14.47977,-0.21349 0.37164,0.10576 0.009,-0.0316 -0.37164,-0.10576 z m 14.41157,-0.0389 -0.37164,0.10609 0.009,0.0316 0.37163,-0.10608 z m -14.33876,-0.21547 0.0102,-0.0313 0.67145,0.21811 -0.0102,0.0313 z m 14.26627,-0.0313 -0.67145,0.21811 0.0102,0.0313 0.67145,-0.21811 z m -0.0866,-0.24183 -0.36341,0.13145 0.0112,0.0309 0.3634,-0.13145 z m -14.09232,0.0284 0.3634,0.13145 0.0112,-0.031 -0.3634,-0.13146 z m 13.99842,-0.27248 -0.35847,0.14398 0.0122,0.0307 0.35879,-0.14398 z m -13.90551,0.028 0.0122,-0.0306 0.35846,0.14431 -0.0122,0.0303 z m 13.80304,-0.27445 -0.64476,0.28697 0.0135,0.0303 0.64476,-0.2873 z m -13.70354,0.03 0.0135,-0.03 0.64477,0.28697 -0.0135,0.0303 z m 1.51225,-0.0721 -1.13896,-0.65762 -0.0164,0.0284 1.13898,0.65762 z m 12.0852,-0.18088 -0.34791,0.16836 0.0142,0.0297 0.34792,-0.16836 z m -1.37618,0.19669 1.13897,-0.65794 -0.0164,-0.0284 -1.13897,0.65762 z m -12.10958,-0.17889 0.0145,-0.0297 0.34759,0.16901 -0.0145,0.0297 z m 13.36716,-0.25073 -0.34166,0.18022 0.0151,0.029 0.34199,-0.18021 z m -13.24921,0.0172 0.34166,0.18087 0.0151,-0.029 -0.34133,-0.18088 z m 12.99288,-0.46258 -0.32848,0.20328 0.0175,0.028 0.32847,-0.20328 z m -12.73227,0.008 0.32782,0.20428 0.0175,-0.028 -0.32783,-0.20427 z m 12.5906,-0.22766 -0.32156,0.21482 0.0185,0.0273 0.32123,-0.21481 z m -12.44893,0.008 0.32057,0.21547 0.0185,-0.0273 -0.32057,-0.21546 z m 12.28485,-0.24283 -0.57096,0.41481 0.0191,0.0267 0.57096,-0.41481 z m -12.1356,0.0267 0.57097,0.4148 0.0191,-0.0267 -0.57097,-0.41481 z m 11.99887,-0.20822 0.0201,0.026 -0.30574,0.23623 -0.0204,-0.026 z m -11.84172,-0.001 0.30476,0.23755 0.0204,-0.0261 -0.30476,-0.23754 z m 0.3354,-0.40195 0.0221,-0.0247 0.52451,0.47247 -0.0221,0.0244 z m 11.14754,-0.0247 -0.52452,0.47247 0.0221,0.0244 0.52451,-0.47213 z m 0.19471,0.22371 -0.29718,0.24677 0.0207,0.0254 0.29751,-0.24677 z m -11.51357,-5e-4 0.29619,0.2481 0.0211,-0.0254 -0.29619,-0.24809 z m 11.17158,-0.38251 -0.28005,0.26653 0.0228,0.0241 0.28005,-0.26654 z m -10.82202,-0.008 0.27808,0.26819 0.0228,-0.0237 -0.27808,-0.26818 z m 0.37559,-0.36407 0.47247,0.52452 0.0244,-0.0221 -0.47213,-0.52451 z m 10.03723,-0.0221 0.0247,0.0221 -0.47245,0.52452 -0.0244,-0.0221 z m 0.22503,0.20856 0.0234,0.023 -0.27015,0.2761 -0.0237,-0.023 z m -10.45367,-0.008 0.0237,-0.0231 0.26886,0.27774 -0.0237,0.0231 z m 8.31642,0.0438 0.65761,-1.13897 -0.0286,-0.0164 -0.65762,1.13897 z m -6.16664,-0.0164 -0.65762,-1.13897 -0.0286,0.0164 0.65761,1.13897 z m 7.92402,-0.36505 -0.25073,0.29388 0.025,0.0214 0.25073,-0.29389 z m -9.68536,-0.0142 0.025,-0.0214 0.24875,0.29586 -0.025,0.0211 z m 9.22904,-0.34133 -0.4148,0.57097 0.0267,0.0191 0.4148,-0.57098 z m -8.81688,0.0191 0.4148,0.57097 0.0267,-0.0191 -0.4148,-0.57098 z m 9.0709,0.17033 -0.24051,0.30278 0.026,0.0205 0.24019,-0.30245 z m -9.28044,-0.0135 0.23821,0.30443 0.026,-0.0205 -0.23821,-0.30409 z m 4.70282,0.2784 v -1.85821 h -0.0646 v 1.85853 z m 4.13119,-0.59172 -0.21744,0.31925 0.0273,0.0185 0.21712,-0.31926 z m -8.41064,0.004 0.21613,0.32024 0.0273,-0.0185 -0.21646,-0.32025 z m 8.19155,-0.14694 -0.20625,0.32683 0.028,0.0175 0.20592,-0.32683 z m -7.97279,0.004 0.20493,0.32749 0.028,-0.0175 -0.20492,-0.32749 z m 0.9235,-0.49123 0.0299,-0.0135 0.2873,0.64476 -0.0303,0.0135 z m 6.1014,-0.0135 0.0299,0.0135 -0.28697,0.64476 -0.0303,-0.0135 z m -6.57155,0.2415 0.18154,0.34099 0.029,-0.0155 -0.18154,-0.341 z m 7.04006,-0.0175 -0.18154,0.34133 0.029,0.0155 0.18153,-0.34132 z m -6.80746,-0.10214 0.0297,-0.0145 0.16935,0.34726 -0.0293,0.0145 z m 6.5742,-0.0162 0.0297,0.0145 -0.16967,0.34726 -0.0293,-0.0145 z m -0.96896,-0.38548 -0.21811,0.67146 0.0313,0.0102 0.21811,-0.67145 z m -4.63528,0.0102 0.0313,-0.0102 0.21812,0.67146 -0.0313,0.0102 z m 5.14298,0.17066 0.0307,0.0122 -0.14563,0.35813 -0.0306,-0.0125 z m -5.63488,0.007 0.14497,0.35846 0.0306,-0.0125 -0.14496,-0.35812 z m 1.24967,-0.38186 0.14662,0.69057 0.0323,-0.007 -0.14661,-0.69057 z m 3.11874,-0.007 -0.14661,0.69057 0.0323,0.007 0.14662,-0.69057 z m 1.02234,0.28861 -0.1331,0.36275 0.031,0.0112 0.13311,-0.36274 z m -5.14661,0.006 0.031,-0.0112 0.13211,0.36307 -0.031,0.0112 z m 1.78077,-0.41217 0.0326,-0.003 0.0738,0.7021 -0.0326,0.003 z m 1.56794,-0.003 0.0326,0.003 -0.0738,0.7021 -0.0326,-0.003 z m 1.31852,0.25303 -0.10839,0.37065 0.0316,0.009 0.1084,-0.37065 z m -4.16941,-0.001 0.10675,0.37164 0.0316,-0.009 -0.10641,-0.37132 z m 3.91671,-0.0675 0.032,0.008 -0.0952,0.37428 -0.032,-0.008 z m -3.66401,-5e-4 0.032,-0.008 0.0936,0.37493 -0.032,0.008 z m 3.17113,-0.10642 0.0323,0.007 -0.0699,0.37988 -0.0323,-0.006 z m -2.6588,-0.003 0.0672,0.38054 0.0323,-0.006 -0.0669,-0.38053 z m 2.40083,-0.0385 -0.0567,0.38218 0.0326,0.005 0.0564,-0.38218 z m -2.14253,-0.003 0.0326,-0.005 0.0537,0.38251 -0.0326,0.005 z m 1.64108,-0.053 -0.031,0.38516 0.0329,0.003 0.0306,-0.38515 z m -1.11986,-0.003 0.0326,-0.003 0.0271,0.38548 -0.0329,0.003 z m 0.85859,-0.0128 -0.0171,0.38614 0.0329,0.001 0.0171,-0.38614 z m -0.59766,-10e-4 0.0329,-0.001 0.0135,0.38614 -0.0329,0.001 z"
+         fill="#ffffff"
+         id="path513"
+         style="display:inline;stroke-width:0.329469;enable-background:new" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline;opacity:0.5">
+       id="layer6"
+       inkscape:label="Pictogram"
+       style="display:inline">
       <path
-         style="display:inline;opacity:1;fill:url(#linearGradient8590);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="M 344,62.000016 A 22,21.99999 0 0 0 322,84.000013 22,21.99999 0 0 0 344,106 22,21.99999 0 0 0 366,84.000013 22,21.99999 0 0 0 344,62.000016 Z m 0,0.956532 A 21.043478,21.043469 0 0 1 365.04348,84.000013 21.043478,21.043469 0 0 1 344,105.04348 21.043478,21.043469 0 0 1 322.95652,84.000013 21.043478,21.043469 0 0 1 344,62.956548 Z"
-         id="path9498-1-6"
-         inkscape:connector-curvature="0" />
+         d="m 147.35824,206.30187 c 0.83026,-1.04591 2.43444,-1.00138 3.2155,-0.2406 0.78268,0.76266 0.74386,2.2435 -0.0994,3.70101 -0.59154,1.09614 -2.065,2.16847 -3.28635,2.87602 -1.18244,-0.77329 -2.5967,-1.923 -3.12905,-3.04886 -0.76079,-1.50199 -0.72192,-2.98283 0.0994,-3.70096 0.82337,-0.71975 2.42755,-0.67522 3.1999,0.41329 z m 1.37043,0.74243 c 0.38721,0.0664 0.69978,0.32522 0.69043,0.7077 -0.01,0.37737 -0.33604,0.6646 -0.72832,0.66662 -0.45559,0.002 -0.70135,-0.32669 -0.69067,-0.70431 0.01,-0.38278 0.26174,-0.74745 0.72856,-0.67001 z m -2.79543,-0.0704 c 0.44822,-0.0635 0.70298,0.32866 0.69206,0.70952 -0.01,0.37737 -0.16827,0.65122 -0.72832,0.66662 -0.39114,0.01 -0.70135,-0.32669 -0.6923,-0.70617 0.01,-0.38081 0.34096,-0.61437 0.72856,-0.66997 z"
+         fill="#ffffff"
+         id="path16"
+         style="display:inline;fill:#ededed;stroke-width:2.42474;enable-background:new" />
       <path
-         style="display:inline;opacity:1;fill:url(#linearGradient8590-3);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 336,134 c -7.73199,0 -14,6.26802 -14,14 0,7.73198 6.26801,14 14,14 7.73199,0 14,-6.26802 14,-14 0,-7.73198 -6.26801,-14 -14,-14 z m 0,1 a 13,13 0 0 1 13,13 13,13 0 0 1 -13,13 13,13 0 0 1 -13,-13 13,13 0 0 1 13,-13 z"
-         id="path9498-1-6-7"
-         inkscape:connector-curvature="0" />
+         d="m 135.85703,212.49385 h -0.26519 c -0.25043,0 -0.45067,-0.20517 -0.45067,-0.45462 v -0.76236 c -1.07508,-0.27109 -1.38298,-0.90903 -1.38298,-2.22007 0,-1.93457 1.57038,-3.50593 3.50593,-3.50593 1.93363,0 3.50397,1.57136 3.50397,3.50593 0,1.29161 -0.32718,1.92777 -1.38004,2.20743 v 0.7721 c 0,0.25141 -0.20319,0.45461 -0.45362,0.45461 h -0.26322 c -0.24944,0 -0.45364,-0.2032 -0.45364,-0.45461 v -0.60699 c -0.11857,0.01 -0.24009,0.0148 -0.36802,0.0197 v 0.59243 c 0,0.24846 -0.20319,0.45166 -0.45362,0.45166 h -0.26322 c -0.25043,0 -0.45364,-0.2032 -0.45364,-0.45166 v -0.59046 c -0.12791,-0.004 -0.25238,-0.01 -0.37097,-0.0148 v 0.60502 c 0,0.24945 -0.20319,0.45461 -0.45166,0.45461 z m -0.0443,-4.86264 c 0.59533,0.23223 1.077,0.46593 1.077,1.04497 0,0.57398 -0.38917,0.68468 -1.077,1.04108 -0.52733,0.27405 -1.07705,-0.46691 -1.07705,-1.04108 0,-0.57884 0.52251,-1.26056 1.07705,-1.04497 z m 2.89216,0 c 0.572,-0.16334 1.07508,0.46593 1.07508,1.04497 0,0.57398 -0.56429,1.34505 -1.07508,1.04108 -0.62741,-0.37195 -1.07705,-0.46691 -1.07705,-1.04108 0,-0.57884 0.41968,-0.8585 1.07705,-1.04497 z"
+         fill="#ededed"
+         id="path18"
+         style="display:inline;stroke-width:0.971169;enable-background:new" />
       <path
-         style="display:inline;opacity:1;fill:url(#linearGradient8590-3-3);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 332,189 c -6.07513,0 -11,4.92488 -11,11 0,6.07513 4.92487,11 11,11 6.07513,0 11,-4.92487 11,-11 0,-6.07512 -4.92487,-11 -11,-11 z m 0,1 a 10,10 0 0 1 10,10 10,10 0 0 1 -10,10 10,10 0 0 1 -10,-10 10,10 0 0 1 10,-10 z"
-         id="path9498-1-6-7-2"
-         inkscape:connector-curvature="0" />
+         d="m 155.30909,206.57011 1.19606,1.26425 1.89097,-1.79109 1.51218,1.59365 -1.89102,1.79105 1.19769,1.26607 c 0.40836,0.42903 0.40393,1.09575 -0.01,1.4831 -0.4123,0.39065 -1.07695,0.35867 -1.48197,-0.0699 l -1.19951,-1.2645 -1.89653,1.79581 -1.51213,-1.59365 1.89835,-1.70455 -1.19768,-1.35892 c -0.40837,-0.42903 -0.40246,-1.09392 0.01,-1.4831 0.4123,-0.39065 1.07695,-0.35867 1.48359,0.0718 z"
+         fill="#ffffff"
+         id="path20"
+         style="display:inline;fill:#ededed;stroke-width:2.42474;enable-background:new" />
       <path
-         style="display:inline;opacity:1;fill:url(#linearGradient8590-3-3-4);fill-opacity:1;stroke:none;stroke-width:1.86940372;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 328,237 c -3.86599,0 -7,3.13402 -7,7 0,3.86599 3.13401,7 7,7 3.866,0 7,-3.13401 7,-7 0,-3.86598 -3.134,-7 -7,-7 z m 0,1 a 6,6 0 0 1 6,6 6,6 0 0 1 -6,6 6,6 0 0 1 -6,-6 6,6 0 0 1 6,-6 z"
-         id="path9498-1-6-7-2-0"
-         inkscape:connector-curvature="0" />
+         d="m 166.22919,206.28489 0.0148,-0.48561 1.73466,0.0492 -0.0153,0.48364 0.93688,0.0246 c 0.9006,0.0246 1.61197,0.77752 1.58685,1.67651 l -0.0878,3.26175 c -0.0236,0.90086 -0.77406,1.61225 -1.67492,1.58868 l -3.60659,-0.0979 c -0.90086,-0.0246 -1.61038,-0.77559 -1.58687,-1.67646 l 0.0876,-3.26174 c 0.0246,-0.90086 0.77565,-1.61038 1.67651,-1.58687 z m -0.52084,1.41944 c 0.46692,0.01 0.83675,0.40196 0.82299,0.86878 -0.01,0.46691 -0.40198,0.8368 -0.86885,0.82297 -0.46691,-0.01 -0.8368,-0.40196 -0.82297,-0.86878 0.01,-0.46691 0.40198,-0.8368 0.86883,-0.82297 z m 2.88955,0.0758 c 0.46662,0.0148 0.8368,0.40197 0.82456,0.87061 -0.0123,0.46839 -0.40216,0.8368 -0.87063,0.82455 -0.46844,-0.01 -0.83679,-0.40197 -0.82456,-0.8706 0.0138,-0.46643 0.40217,-0.83681 0.87063,-0.82456 z"
+         fill="#ffffff"
+         id="path22"
+         style="display:inline;fill:#ededed;stroke-width:2.42474;enable-background:new" />
+      <path
+         d="m 163.64085,156.10334 c -0.30013,-2.48462 -1.24478,-4.74785 -2.69127,-6.63715 l 9.95818,-61.810564 c 0.369,-2.30259 -1.10701,-4.49693 -3.37515,-5.01845 l -0.11317,-0.0246 c -2.26814,-0.52645 -4.55596,0.80196 -5.23001,3.03075 L 144.04429,145.5646 c -4.47232,2.24846 -7.57195,6.82902 -7.57195,12.16728 0,7.53751 6.12547,13.66789 13.66298,13.66789 1.40222,0 2.73062,-0.2706 4.00984,-0.66912 l 37.90406,19.69987 c 2.0861,1.08242 4.64945,0.40837 5.93358,-1.56457 l 0.0541,-0.0886 c 1.27921,-1.96802 0.85117,-4.59041 -0.98893,-6.05166 z m -20.25585,1.62854 c 0,-3.72448 3.03075,-6.75031 6.75031,-6.75031 3.72448,0 6.75523,3.02583 6.75523,6.75031 0,3.72447 -3.03075,6.7503 -6.75523,6.7503 -3.71956,0 -6.75031,-3.02583 -6.75031,-6.7503 z"
+         fill="url(#b)"
+         fill-rule="nonzero"
+         id="path24"
+         style="display:inline;fill:url(#b);stroke-width:4.92005;enable-background:new" />
+      <path
+         d="m 343.04678,94.329819 c 0.1705,-0.214784 0.49993,-0.20564 0.66032,-0.04941 0.16073,0.156617 0.15276,0.460717 -0.0204,0.760027 -0.12147,0.2251 -0.42406,0.44531 -0.67487,0.59061 -0.24282,-0.1588 -0.53325,-0.394901 -0.64257,-0.626104 -0.15623,-0.308444 -0.14825,-0.612544 0.0204,-0.760017 0.16908,-0.147805 0.49851,-0.138661 0.65712,0.08487 z m 0.28143,0.152463 c 0.0795,0.01364 0.1437,0.06679 0.14178,0.145331 -0.002,0.0775 -0.069,0.13648 -0.14956,0.136895 -0.0936,4.11e-4 -0.14403,-0.06709 -0.14184,-0.144635 0.002,-0.07861 0.0538,-0.153493 0.14962,-0.137591 z m -0.57406,-0.01446 c 0.092,-0.01304 0.14436,0.06749 0.14212,0.145705 -0.002,0.07749 -0.0346,0.133732 -0.14957,0.136895 -0.0803,0.0021 -0.14403,-0.06709 -0.14217,-0.145017 0.002,-0.0782 0.07,-0.126165 0.14962,-0.137583 z"
+         fill="#ffffff"
+         id="path443"
+         style="display:inline;fill:#ededed;stroke-width:0.497937;enable-background:new" />
+      <path
+         d="m 340.68493,95.601384 h -0.0545 c -0.0514,0 -0.0926,-0.04213 -0.0926,-0.09336 v -0.156556 c -0.22077,-0.05567 -0.284,-0.186675 -0.284,-0.455906 0,-0.397277 0.32248,-0.719966 0.71996,-0.719966 0.39709,0 0.71957,0.322689 0.71957,0.719966 0,0.265241 -0.0672,0.39588 -0.2834,0.45331 v 0.158556 c 0,0.05163 -0.0417,0.09336 -0.0932,0.09336 h -0.054 c -0.0512,0 -0.0932,-0.04173 -0.0932,-0.09336 v -0.124649 c -0.0244,0.0021 -0.0493,0.003 -0.0756,0.004 v 0.12166 c 0,0.05102 -0.0417,0.09275 -0.0931,0.09275 h -0.0541 c -0.0514,0 -0.0932,-0.04173 -0.0932,-0.09275 v -0.121255 c -0.0263,-8.22e-4 -0.0518,-0.0021 -0.0762,-0.003 v 0.124244 c 0,0.05123 -0.0417,0.09336 -0.0928,0.09336 z m -0.009,-0.998576 c 0.12225,0.04769 0.22117,0.09568 0.22117,0.214592 0,0.117871 -0.0799,0.140604 -0.22117,0.213793 -0.10829,0.05628 -0.22118,-0.09588 -0.22118,-0.213793 0,-0.118869 0.1073,-0.258865 0.22118,-0.214592 z m 0.59392,0 c 0.11747,-0.03354 0.22078,0.09568 0.22078,0.214592 0,0.117871 -0.11588,0.276215 -0.22078,0.213793 -0.12884,-0.07638 -0.22118,-0.09588 -0.22118,-0.213793 0,-0.118869 0.0862,-0.176299 0.22118,-0.214592 z"
+         fill="#ededed"
+         id="path445"
+         style="display:inline;stroke-width:0.199436;enable-background:new" />
+      <path
+         d="m 344.67954,94.384904 0.24562,0.259623 0.38832,-0.367813 0.31054,0.327267 -0.38833,0.367804 0.24595,0.259996 c 0.0839,0.0881 0.0829,0.22502 -0.002,0.304564 -0.0847,0.08022 -0.22116,0.07366 -0.30433,-0.01435 l -0.24633,-0.259673 -0.38947,0.368781 -0.31052,-0.327267 0.38984,-0.35004 -0.24595,-0.279064 c -0.0839,-0.0881 -0.0827,-0.224643 0.002,-0.304564 0.0847,-0.08022 0.22115,-0.07366 0.30466,0.01474 z"
+         fill="#ffffff"
+         id="path447"
+         style="display:inline;fill:#ededed;stroke-width:0.497937;enable-background:new" />
+      <path
+         d="m 346.92206,94.326332 0.003,-0.09972 0.35622,0.0101 -0.003,0.09932 0.1924,0.0051 c 0.18494,0.0051 0.33102,0.159669 0.32587,0.344283 l -0.018,0.669822 c -0.005,0.184998 -0.15896,0.331086 -0.34396,0.326246 l -0.74064,-0.0201 c -0.185,-0.0051 -0.3307,-0.159273 -0.32587,-0.344273 l 0.018,-0.66982 c 0.005,-0.184997 0.15928,-0.330702 0.34428,-0.325874 z m -0.10696,0.291492 c 0.0959,0.0021 0.17183,0.08255 0.169,0.17841 -0.002,0.09588 -0.0826,0.171842 -0.17842,0.169002 -0.0959,-0.0021 -0.17184,-0.08254 -0.169,-0.17841 0.002,-0.09588 0.0825,-0.171842 0.17842,-0.169002 z m 0.59339,0.01557 c 0.0958,0.003 0.17184,0.08255 0.16933,0.178786 -0.002,0.09619 -0.0826,0.171842 -0.17879,0.169326 -0.0962,-0.0021 -0.17184,-0.08255 -0.16933,-0.178783 0.003,-0.09578 0.0826,-0.171845 0.17879,-0.169329 z"
+         fill="#ffffff"
+         id="path449"
+         style="display:inline;fill:#ededed;stroke-width:0.497937;enable-background:new" />
+      <path
+         d="m 346.39052,84.021215 c -0.0616,-0.510233 -0.25562,-0.975003 -0.55267,-1.362983 l 2.04498,-12.693214 c 0.0758,-0.472852 -0.22733,-0.923474 -0.69311,-1.030572 l -0.0232,-0.0051 c -0.46578,-0.108062 -0.93559,0.164736 -1.07402,0.622433 l -3.72622,12.305235 c -0.91842,0.461737 -1.55495,1.402385 -1.55495,2.498633 0,1.547878 1.2579,2.806792 2.80578,2.806792 0.28796,0 0.56075,-0.05557 0.82345,-0.137408 l 7.78385,4.0455 c 0.4284,0.222283 0.9548,0.08386 1.2185,-0.321295 l 0.0111,-0.01819 c 0.2627,-0.404146 0.1748,-0.942672 -0.20308,-1.242749 z m -4.15967,0.334432 c 0,-0.764847 0.62238,-1.386222 1.38622,-1.386222 0.76485,0 1.38723,0.621375 1.38723,1.386222 0,0.764845 -0.62238,1.386219 -1.38723,1.386219 -0.76384,0 -1.38622,-0.621374 -1.38622,-1.386219 z"
+         fill="url(#b)"
+         fill-rule="nonzero"
+         id="path451"
+         style="display:inline;fill:url(#linearGradient455);stroke-width:1.01037;enable-background:new" />
+      <path
+         d="m 335.37833,154.75729 c 0.1112,-0.14008 0.32604,-0.13412 0.43065,-0.0322 0.10482,0.10214 0.0996,0.30046 -0.0133,0.49567 -0.0792,0.1468 -0.27656,0.29042 -0.44013,0.38518 -0.15836,-0.10357 -0.34777,-0.25755 -0.41907,-0.40833 -0.10189,-0.20116 -0.0967,-0.39949 0.0133,-0.49567 0.11027,-0.0964 0.32512,-0.0904 0.42856,0.0554 z m 0.18354,0.0994 c 0.0519,0.009 0.0937,0.0436 0.0925,0.0948 -10e-4,0.0505 -0.045,0.089 -0.0975,0.0893 -0.061,2.6e-4 -0.0939,-0.0438 -0.0925,-0.0943 0.001,-0.0513 0.0351,-0.10011 0.0976,-0.0897 z m -0.37438,-0.009 c 0.06,-0.008 0.0941,0.044 0.0927,0.095 -10e-4,0.0505 -0.0226,0.0872 -0.0975,0.0893 -0.0524,0.001 -0.0939,-0.0438 -0.0927,-0.0946 10e-4,-0.051 0.0456,-0.0823 0.0976,-0.0897 z"
+         fill="#ffffff"
+         id="path463"
+         style="display:inline;fill:#ededed;stroke-width:0.324742;enable-background:new" />
+      <path
+         d="m 333.83799,155.58657 h -0.0355 c -0.0335,0 -0.0604,-0.0275 -0.0604,-0.0609 v -0.1021 c -0.14398,-0.0363 -0.18522,-0.12175 -0.18522,-0.29733 0,-0.2591 0.21031,-0.46955 0.46954,-0.46955 0.25897,0 0.46928,0.21045 0.46928,0.46955 0,0.17298 -0.0438,0.25818 -0.18482,0.29563 v 0.10341 c 0,0.0337 -0.0272,0.0609 -0.0608,0.0609 h -0.0352 c -0.0334,0 -0.0608,-0.0272 -0.0608,-0.0609 v -0.0813 c -0.0159,10e-4 -0.0322,0.002 -0.0493,0.003 v 0.0793 c 0,0.0333 -0.0272,0.0605 -0.0607,0.0605 h -0.0353 c -0.0335,0 -0.0608,-0.0272 -0.0608,-0.0605 v -0.0791 c -0.0171,-5.4e-4 -0.0338,-0.001 -0.0497,-0.002 v 0.081 c 0,0.0334 -0.0272,0.0609 -0.0605,0.0609 z m -0.006,-0.65125 c 0.0797,0.0311 0.14424,0.0624 0.14424,0.13995 0,0.0769 -0.0521,0.0917 -0.14424,0.13943 -0.0706,0.0367 -0.14425,-0.0625 -0.14425,-0.13943 0,-0.0775 0.07,-0.16882 0.14425,-0.13995 z m 0.38734,0 c 0.0766,-0.0219 0.14399,0.0624 0.14399,0.13995 0,0.0769 -0.0756,0.18014 -0.14399,0.13943 -0.084,-0.0498 -0.14425,-0.0625 -0.14425,-0.13943 0,-0.0775 0.0562,-0.11497 0.14425,-0.13995 z"
+         fill="#ededed"
+         id="path465"
+         style="display:inline;stroke-width:0.130067;enable-background:new" />
+      <path
+         d="m 336.44318,154.79321 0.16018,0.16932 0.25326,-0.23988 0.20252,0.21344 -0.25326,0.23987 0.16041,0.16956 c 0.0547,0.0575 0.0541,0.14676 -0.001,0.19863 -0.0552,0.0523 -0.14423,0.048 -0.19847,-0.009 l -0.16065,-0.16935 -0.25401,0.24051 -0.20251,-0.21344 0.25424,-0.22828 -0.1604,-0.182 c -0.0547,-0.0575 -0.0539,-0.14651 10e-4,-0.19863 0.0552,-0.0523 0.14422,-0.048 0.19869,0.01 z"
+         fill="#ffffff"
+         id="path467"
+         style="display:inline;fill:#ededed;stroke-width:0.324742;enable-background:new" />
+      <path
+         d="m 337.90569,154.75501 0.002,-0.065 0.23232,0.007 -0.002,0.0648 0.12548,0.003 c 0.12061,0.003 0.21588,0.10413 0.21252,0.22453 l -0.0117,0.43685 c -0.003,0.12065 -0.10366,0.21592 -0.22432,0.21277 l -0.48302,-0.0131 c -0.12066,-0.003 -0.21568,-0.10388 -0.21253,-0.22453 l 0.0117,-0.43684 c 0.003,-0.12065 0.10388,-0.21568 0.22453,-0.21253 z m -0.0697,0.19011 c 0.0625,0.001 0.11206,0.0538 0.11021,0.11635 -10e-4,0.0625 -0.0539,0.11207 -0.11636,0.11022 -0.0625,-0.001 -0.11207,-0.0538 -0.11021,-0.11636 0.001,-0.0625 0.0538,-0.11207 0.11636,-0.11021 z m 0.38699,0.0102 c 0.0625,0.002 0.11207,0.0538 0.11043,0.1166 -0.001,0.0627 -0.0539,0.11207 -0.1166,0.11043 -0.0627,-0.001 -0.11207,-0.0538 -0.11043,-0.1166 0.002,-0.0625 0.0539,-0.11208 0.1166,-0.11043 z"
+         fill="#ffffff"
+         id="path469"
+         style="display:inline;fill:#ededed;stroke-width:0.324742;enable-background:new" />
+      <path
+         d="m 337.55904,148.03427 c -0.0402,-0.33276 -0.16671,-0.63587 -0.36044,-0.8889 l 1.33368,-8.2782 c 0.0494,-0.30839 -0.14826,-0.60227 -0.45203,-0.67212 l -0.0151,-0.003 c -0.30377,-0.0705 -0.61016,0.10744 -0.70045,0.40594 l -2.43014,8.02517 c -0.59897,0.30113 -1.0141,0.9146 -1.0141,1.62954 0,1.00949 0.82037,1.83052 1.82986,1.83052 0.1878,0 0.3657,-0.0362 0.53703,-0.0896 l 5.07643,2.63838 c 0.2794,0.14497 0.6227,0.0547 0.79468,-0.20954 l 0.007,-0.0119 c 0.17133,-0.26358 0.114,-0.61479 -0.13244,-0.81049 z m -2.71284,0.21811 c 0,-0.49882 0.4059,-0.90406 0.90406,-0.90406 0.49882,0 0.90472,0.40524 0.90472,0.90406 0,0.49881 -0.4059,0.90405 -0.90472,0.90405 -0.49816,0 -0.90406,-0.40524 -0.90406,-0.90405 z"
+         fill="url(#b)"
+         fill-rule="nonzero"
+         id="path471"
+         style="display:inline;fill:url(#linearGradient475);stroke-width:0.658938;enable-background:new" />
+      <path
+         d="m 331.52339,205.18014 c 0.0852,-0.1074 0.24996,-0.10283 0.33016,-0.0247 0.0804,0.0783 0.0764,0.23035 -0.0102,0.38001 -0.0607,0.11255 -0.21202,0.22266 -0.33743,0.29531 -0.12141,-0.0794 -0.26662,-0.19746 -0.32129,-0.31306 -0.0781,-0.15422 -0.0741,-0.30627 0.0102,-0.38001 0.0845,-0.0739 0.24926,-0.0693 0.32856,0.0425 z m 0.14071,0.0762 c 0.0398,0.007 0.0718,0.0334 0.0709,0.0727 -7.7e-4,0.0387 -0.0345,0.0682 -0.0747,0.0685 -0.0468,2e-4 -0.072,-0.0336 -0.0709,-0.0723 7.7e-4,-0.0393 0.0269,-0.0768 0.0748,-0.0688 z m -0.28702,-0.007 c 0.046,-0.006 0.0721,0.0337 0.0711,0.0728 -7.7e-4,0.0387 -0.0173,0.0669 -0.0747,0.0685 -0.0402,7.7e-4 -0.072,-0.0336 -0.0711,-0.0725 7.6e-4,-0.0391 0.035,-0.0631 0.0748,-0.0688 z"
+         fill="#ffffff"
+         id="path483"
+         style="display:inline;fill:#ededed;stroke-width:0.248969;enable-background:new" />
+      <path
+         d="m 330.34246,205.81592 h -0.0272 c -0.0257,0 -0.0463,-0.0211 -0.0463,-0.0467 v -0.0783 c -0.11039,-0.0278 -0.14201,-0.0933 -0.14201,-0.22795 0,-0.19865 0.16124,-0.35999 0.35998,-0.35999 0.19855,0 0.35979,0.16134 0.35979,0.35999 0,0.13262 -0.0336,0.19794 -0.1417,0.22665 v 0.0793 c 0,0.0258 -0.0208,0.0467 -0.0466,0.0467 h -0.027 c -0.0256,0 -0.0466,-0.0208 -0.0466,-0.0467 v -0.0623 c -0.0122,7.7e-4 -0.0247,0.002 -0.0378,0.002 v 0.0608 c 0,0.0255 -0.0208,0.0464 -0.0465,0.0464 h -0.0271 c -0.0257,0 -0.0466,-0.0208 -0.0466,-0.0464 v -0.0607 c -0.0131,-4.1e-4 -0.0259,-7.6e-4 -0.0381,-0.002 v 0.0621 c 0,0.0256 -0.0208,0.0467 -0.0464,0.0467 z m -0.005,-0.49929 c 0.0611,0.0238 0.11058,0.0478 0.11058,0.10729 0,0.059 -0.0399,0.0703 -0.11058,0.1069 -0.0541,0.0281 -0.11059,-0.0479 -0.11059,-0.1069 0,-0.0594 0.0537,-0.12943 0.11059,-0.10729 z m 0.29696,0 c 0.0587,-0.0168 0.11039,0.0478 0.11039,0.10729 0,0.059 -0.058,0.13811 -0.11039,0.1069 -0.0644,-0.0382 -0.11059,-0.0479 -0.11059,-0.1069 0,-0.0594 0.0431,-0.0881 0.11059,-0.10729 z"
+         fill="#ededed"
+         id="path485"
+         style="display:inline;stroke-width:0.099718;enable-background:new" />
+      <path
+         d="m 332.33977,205.20767 0.12281,0.12982 0.19416,-0.18391 0.15527,0.16364 -0.19417,0.1839 0.12298,0.12999 c 0.0419,0.0441 0.0415,0.11251 -7.6e-4,0.15229 -0.0423,0.0401 -0.11058,0.0368 -0.15216,-0.007 l -0.12317,-0.12984 -0.19474,0.1844 -0.15526,-0.16364 0.19492,-0.17501 -0.12297,-0.13953 c -0.0419,-0.0441 -0.0413,-0.11233 7.6e-4,-0.15229 0.0423,-0.0401 0.11057,-0.0368 0.15233,0.008 z"
+         fill="#ffffff"
+         id="path487"
+         style="display:inline;fill:#ededed;stroke-width:0.248969;enable-background:new" />
+      <path
+         d="m 333.46103,205.17839 0.002,-0.0498 0.17811,0.005 -0.002,0.0497 0.0962,0.002 c 0.0925,0.002 0.16551,0.0798 0.16293,0.17214 l -0.009,0.33492 c -0.002,0.0925 -0.0795,0.16554 -0.17197,0.16312 l -0.37032,-0.01 c -0.0925,-0.002 -0.16535,-0.0796 -0.16294,-0.17214 l 0.009,-0.33491 c 0.002,-0.0925 0.0796,-0.16536 0.17214,-0.16294 z m -0.0534,0.14575 c 0.0479,7.7e-4 0.0859,0.0412 0.0845,0.0892 -7.7e-4,0.0479 -0.0413,0.0859 -0.0892,0.0845 -0.0479,-7.6e-4 -0.0859,-0.0412 -0.0845,-0.0892 7.7e-4,-0.0479 0.0412,-0.0859 0.0892,-0.0845 z m 0.29669,0.008 c 0.0479,0.002 0.0859,0.0413 0.0847,0.0894 -7.7e-4,0.0481 -0.0413,0.0859 -0.0894,0.0847 -0.0481,-7.7e-4 -0.0859,-0.0412 -0.0847,-0.0894 0.002,-0.0479 0.0413,-0.0859 0.0894,-0.0847 z"
+         fill="#ffffff"
+         id="path489"
+         style="display:inline;fill:#ededed;stroke-width:0.248969;enable-background:new" />
+      <path
+         d="m 333.19526,200.02582 c -0.0308,-0.25512 -0.12781,-0.4875 -0.27633,-0.68149 l 1.02248,-6.34662 c 0.0379,-0.23643 -0.11366,-0.46174 -0.34655,-0.51529 l -0.0116,-0.002 c -0.23289,-0.0541 -0.46779,0.0824 -0.53701,0.31122 l -1.86311,6.15263 c -0.45921,0.23087 -0.77747,0.70119 -0.77747,1.24931 0,0.77395 0.62895,1.4034 1.40289,1.4034 0.14398,0 0.28037,-0.0277 0.41172,-0.0687 l 3.89193,2.02276 c 0.21421,0.11114 0.4774,0.0419 0.60926,-0.16065 l 0.005,-0.009 c 0.13136,-0.20208 0.0874,-0.47134 -0.10153,-0.62138 z m -2.07984,0.16722 c 0,-0.38243 0.31119,-0.69311 0.69311,-0.69311 0.38243,0 0.69362,0.31068 0.69362,0.69311 0,0.38242 -0.31119,0.6931 -0.69362,0.6931 -0.38192,0 -0.69311,-0.31068 -0.69311,-0.6931 z"
+         fill="url(#b)"
+         fill-rule="nonzero"
+         id="path491"
+         style="display:inline;fill:url(#linearGradient495);stroke-width:0.505186;enable-background:new" />
+      <path
+         d="m 327.68917,247.37584 c 0.0556,-0.07 0.16301,-0.0671 0.21532,-0.0161 0.0524,0.0511 0.0498,0.15023 -0.007,0.24784 -0.0396,0.0734 -0.13828,0.14521 -0.22007,0.19259 -0.0792,-0.0518 -0.17388,-0.12878 -0.20953,-0.20417 -0.0509,-0.10058 -0.0483,-0.19974 0.007,-0.24783 0.0551,-0.0482 0.16256,-0.0452 0.21428,0.0277 z m 0.0918,0.0497 c 0.026,0.005 0.0468,0.0218 0.0462,0.0474 -5e-4,0.0252 -0.0225,0.0445 -0.0487,0.0447 -0.0305,1.3e-4 -0.047,-0.0219 -0.0462,-0.0471 5e-4,-0.0256 0.0175,-0.0501 0.0488,-0.0449 z m -0.18718,-0.005 c 0.03,-0.004 0.047,0.022 0.0464,0.0475 -5.1e-4,0.0252 -0.0113,0.0436 -0.0487,0.0447 -0.0262,5.1e-4 -0.047,-0.0219 -0.0464,-0.0473 5e-4,-0.0255 0.0228,-0.0411 0.0488,-0.0449 z"
+         fill="#ffffff"
+         id="path503"
+         style="display:inline;fill:#ededed;stroke-width:0.162371;enable-background:new" />
+      <path
+         d="m 326.919,247.79048 h -0.0177 c -0.0168,0 -0.0302,-0.0138 -0.0302,-0.0305 v -0.0511 c -0.072,-0.0181 -0.0926,-0.0608 -0.0926,-0.14866 0,-0.12956 0.10515,-0.23478 0.23476,-0.23478 0.12949,0 0.23465,0.10522 0.23465,0.23478 0,0.0865 -0.0219,0.12909 -0.0924,0.14781 v 0.0517 c 0,0.0168 -0.0136,0.0305 -0.0304,0.0305 h -0.0176 c -0.0167,0 -0.0304,-0.0136 -0.0304,-0.0305 v -0.0406 c -0.008,5e-4 -0.0161,0.001 -0.0247,0.001 v 0.0397 c 0,0.0166 -0.0136,0.0303 -0.0303,0.0303 h -0.0177 c -0.0168,0 -0.0304,-0.0136 -0.0304,-0.0303 v -0.0396 c -0.009,-2.7e-4 -0.0169,-5e-4 -0.0249,-10e-4 v 0.0405 c 0,0.0167 -0.0136,0.0305 -0.0303,0.0305 z m -0.003,-0.32562 c 0.0399,0.0155 0.0721,0.0312 0.0721,0.07 0,0.0385 -0.026,0.0459 -0.0721,0.0697 -0.0353,0.0183 -0.0721,-0.0312 -0.0721,-0.0697 0,-0.0387 0.035,-0.0844 0.0721,-0.07 z m 0.19367,0 c 0.0383,-0.011 0.072,0.0312 0.072,0.07 0,0.0385 -0.0378,0.0901 -0.072,0.0697 -0.042,-0.0249 -0.0721,-0.0312 -0.0721,-0.0697 0,-0.0387 0.0281,-0.0575 0.0721,-0.07 z"
+         fill="#ededed"
+         id="path505"
+         style="display:inline;stroke-width:0.0650335;enable-background:new" />
+      <path
+         d="m 328.22159,247.3938 0.0801,0.0847 0.12663,-0.11994 0.10126,0.10672 -0.12663,0.11994 0.0802,0.0848 c 0.0273,0.0288 0.0271,0.0734 -4.9e-4,0.0993 -0.0276,0.0262 -0.0721,0.024 -0.0992,-0.005 l -0.0803,-0.0847 -0.127,0.12026 -0.10126,-0.10672 0.12712,-0.11414 -0.0802,-0.091 c -0.0273,-0.0288 -0.0269,-0.0733 4.9e-4,-0.0993 0.0276,-0.0262 0.0721,-0.024 0.0994,0.005 z"
+         fill="#ffffff"
+         id="path507"
+         style="display:inline;fill:#ededed;stroke-width:0.162371;enable-background:new" />
+      <path
+         d="m 328.95284,247.3747 0.001,-0.0325 0.11616,0.003 -10e-4,0.0324 0.0627,0.001 c 0.0603,0.001 0.10794,0.052 0.10626,0.11227 l -0.006,0.21842 c -0.001,0.0603 -0.0519,0.10796 -0.11215,0.10638 l -0.24152,-0.007 c -0.0603,-0.001 -0.10783,-0.0519 -0.10626,-0.11226 l 0.006,-0.21842 c 10e-4,-0.0603 0.0519,-0.10785 0.11226,-0.10627 z m -0.0348,0.0951 c 0.0312,5.1e-4 0.056,0.0269 0.0551,0.0582 -5e-4,0.0312 -0.0269,0.056 -0.0582,0.0551 -0.0312,-5e-4 -0.056,-0.0269 -0.0551,-0.0582 5.1e-4,-0.0312 0.0269,-0.056 0.0582,-0.0551 z m 0.19349,0.005 c 0.0312,0.001 0.056,0.0269 0.0552,0.0583 -5e-4,0.0314 -0.0269,0.056 -0.0583,0.0552 -0.0314,-5.1e-4 -0.056,-0.0269 -0.0552,-0.0583 0.001,-0.0312 0.0269,-0.056 0.0583,-0.0552 z"
+         fill="#ffffff"
+         id="path509"
+         style="display:inline;fill:#ededed;stroke-width:0.162371;enable-background:new" />
+      <path
+         d="m 328.77952,244.01433 c -0.0201,-0.16638 -0.0834,-0.31794 -0.18022,-0.44445 l 0.66684,-4.1391 c 0.0247,-0.15419 -0.0741,-0.30114 -0.22601,-0.33606 l -0.008,-0.001 c -0.15188,-0.0353 -0.30508,0.0537 -0.35022,0.20297 l -1.21508,4.01258 c -0.29948,0.15057 -0.50704,0.4573 -0.50704,0.81477 0,0.50475 0.41018,0.91526 0.91493,0.91526 0.0939,0 0.18285,-0.0181 0.26851,-0.0448 l 2.53822,1.3192 c 0.1397,0.0725 0.31134,0.0273 0.39734,-0.10478 l 0.003,-0.006 c 0.0857,-0.13179 0.057,-0.30739 -0.0662,-0.40524 z m -1.35642,0.10906 c 0,-0.24942 0.20295,-0.45203 0.45203,-0.45203 0.24941,0 0.45236,0.20261 0.45236,0.45203 0,0.2494 -0.20295,0.45202 -0.45236,0.45202 -0.24908,0 -0.45203,-0.20262 -0.45203,-0.45202 z"
+         fill="url(#b)"
+         fill-rule="nonzero"
+         id="path511"
+         style="display:inline;fill:url(#linearGradient515);stroke-width:0.329469;enable-background:new" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/configurator-app.svg
+++ b/icons/src/fullcolor/default/apps/configurator-app.svg
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="configurator-app.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="299.81317"
-     inkscape:cy="131.04762"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="335.52217"
+     inkscape:cy="166.52365"
      inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,165 +93,181 @@
   <defs
      id="defs3">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="linearGradient924"
+       x1="162.61"
+       x2="162.61"
+       y1="15.335"
+       y2="27.41"
+       gradientTransform="matrix(14.669286,0,0,14.669286,-2232.7133,-157.51669)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient922" />
+    <linearGradient
+       id="linearGradient922">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#91aab4"
          offset="0"
-         id="stop923" />
+         id="stop2" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#648291"
          offset="1"
-         id="stop925" />
+         id="stop4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient951"
+       x1="156.58"
+       x2="168.85001"
+       y1="15.3"
+       y2="27.534"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient922"
+       gradientTransform="matrix(14.669286,0,0,14.669286,-2232.7133,-156.85742)" />
+    <linearGradient
+       id="linearGradient965"
+       x1="162.73"
+       x2="163.37"
+       y1="20.333"
+       y2="19.09"
+       gradientTransform="matrix(1.1538,0,0,1.1538,-22.383,-3.3235)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#fafafa"
+         offset="0"
+         id="stop9" />
+      <stop
+         stop-color="#c8e6f0"
+         offset="1"
+         id="stop11" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient16491"
-       id="linearGradient1686"
-       x1="319.99991"
-       y1="108.00015"
-       x2="367.99991"
-       y2="108.00015"
+       xlink:href="#linearGradient922"
+       id="linearGradient832"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,428.00015,428.00015)" />
+       gradientTransform="matrix(3.0124427,0,0,3.0124427,-146.25999,19.61825)"
+       x1="162.61"
+       y1="15.335"
+       x2="162.61"
+       y2="27.41" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient16491"
-       id="linearGradient1688"
-       x1="320.00003"
-       y1="164.00002"
-       x2="352.00003"
-       y2="164.00002"
+       xlink:href="#linearGradient922"
+       id="linearGradient834"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,484.00002,484.00002)" />
+       x1="156.58"
+       y1="15.3"
+       x2="168.85001"
+       y2="27.534"
+       gradientTransform="matrix(3.0124427,0,0,3.0124427,-146.25999,19.753635)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient16491"
-       id="linearGradient1690"
-       x1="319.9993"
-       y1="211.99928"
-       x2="343.9993"
-       y2="211.99928"
+       xlink:href="#linearGradient965"
+       id="linearGradient836"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,531.99928,531.9999)" />
+       gradientTransform="matrix(3.4757564,0,0,3.4757564,-213.68749,9.7417817)"
+       x1="162.73"
+       y1="20.333"
+       x2="163.37"
+       y2="19.09" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient16491"
-       id="linearGradient1692"
-       x1="320.00031"
-       y1="252.00034"
-       x2="336.00031"
-       y2="252.00034"
+       xlink:href="#linearGradient922"
+       id="linearGradient864"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,572.00033,572.00033)" />
+       gradientTransform="matrix(1.9646365,0,0,1.9646365,16.265233,106.01191)"
+       x1="162.61"
+       y1="15.335"
+       x2="162.61"
+       y2="27.41" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient16491"
-       id="linearGradient1694"
-       x1="38.309559"
-       y1="270.69043"
-       x2="263.99759"
-       y2="267.99701"
+       xlink:href="#linearGradient922"
+       id="linearGradient866"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,307.997,307.99699)" />
+       x1="156.58"
+       y1="15.3"
+       x2="168.85001"
+       y2="27.534"
+       gradientTransform="matrix(1.9646365,0,0,1.9646365,16.265233,106.1002)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1692-6"
-       x1="321.00031"
-       y1="244.00034"
-       x2="335.00031"
-       y2="244.00034"
+       xlink:href="#linearGradient965"
+       id="linearGradient868"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
+       gradientTransform="matrix(2.2667976,0,0,2.2667976,-27.709226,99.570731)"
+       x1="162.73"
+       y1="20.333"
+       x2="163.37"
+       y2="19.09" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1690-9"
-       x1="320.9993"
-       y1="199.99928"
-       x2="342.9993"
-       y2="199.99928"
+       xlink:href="#linearGradient922"
+       id="linearGradient896"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
+       gradientTransform="matrix(1.5062213,0,0,1.5062213,86.870015,167.80913)"
+       x1="162.61"
+       y1="15.335"
+       x2="162.61"
+       y2="27.41" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1688-4"
-       x1="322"
-       y1="148.00002"
-       x2="350"
-       y2="148.00002"
+       xlink:href="#linearGradient922"
+       id="linearGradient898"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00001,148)" />
+       x1="156.58"
+       y1="15.3"
+       x2="168.85001"
+       y2="27.534"
+       gradientTransform="matrix(1.5062213,0,0,1.5062213,86.870015,167.87682)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1686-0"
-       x1="321.99991"
-       y1="84.000153"
-       x2="365.99991"
-       y2="84.000153"
+       xlink:href="#linearGradient965"
+       id="linearGradient900"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000125)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58449"
-       x="-0.047999425"
-       width="1.0959988"
-       y="-0.048000575"
-       height="1.0960012">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.4800539"
-         id="feGaussianBlur58451" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58492"
-       x="-0.011999856"
-       width="1.0239997"
-       y="-0.012000144"
-       height="1.0240003">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1200135"
-         id="feGaussianBlur58494" />
-    </filter>
+       gradientTransform="matrix(1.7378781,0,0,1.7378781,53.156264,162.87089)"
+       x1="162.73"
+       y1="20.333"
+       x2="163.37"
+       y2="19.09" />
     <linearGradient
-       id="linearGradient16491">
-      <stop
-         style="stop-color:#f76363;stop-opacity:1"
-         offset="0"
-         id="stop16487" />
-      <stop
-         style="stop-color:#f22c42;stop-opacity:1"
-         offset="1"
-         id="stop16489" />
-    </linearGradient>
-    <filter
        inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1027"
-       x="-0.024012255"
-       width="1.0480245"
-       y="-0.023987759"
-       height="1.0479755">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.5307812"
-         id="feGaussianBlur1029" />
-    </filter>
+       xlink:href="#linearGradient922"
+       id="linearGradient928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98231827,0,0,0.98231827,168.14735,223.00595)"
+       x1="162.61"
+       y1="15.335"
+       x2="162.61"
+       y2="27.41" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient922"
+       id="linearGradient930"
+       gradientUnits="userSpaceOnUse"
+       x1="156.58"
+       y1="15.3"
+       x2="168.85001"
+       y2="27.534"
+       gradientTransform="matrix(0.98231827,0,0,0.98231827,168.14735,223.0501)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient965"
+       id="linearGradient932"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1333988,0,0,1.1333988,146.16012,219.78537)"
+       x1="162.73"
+       y1="20.333"
+       x2="163.37"
+       y2="19.09" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient965"
+       id="linearGradient934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(16.925422,0,0,16.925422,-2561.0559,-205.61079)"
+       x1="162.73"
+       y1="20.333"
+       x2="163.37"
+       y2="19.09" />
   </defs>
   <metadata
      id="metadata4">
@@ -262,13 +279,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -350,7 +367,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">configurator-app</tspan></text>
+           id="tspan924">configurator-app</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -385,330 +402,309 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 137.10985,43.994444 h 35.35885 c 3.44156,0 5.75725,2.800807 6.2123,6.212149 l 3.89865,29.232953 c 0.45475,3.411343 -2.77073,6.21215 -6.21229,6.21215 h -43.80543 c -3.44156,0 -6.74141,-2.811516 -6.21229,-6.21215 L 130.898,50.206593 c 0.52956,-3.400634 2.77073,-6.212149 6.21244,-6.212149 z"
+         id="path18"
+         style="fill:#5a7882;stroke-width:14.6693" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 137.10985,267.99444 h 35.35885 c 3.44156,0 5.75725,-2.80081 6.2123,-6.21215 l 3.89865,-29.23295 c 0.45475,-3.41134 -2.77073,-6.21215 -6.21229,-6.21215 h -43.80543 c -3.44156,0 -6.74141,2.81151 -6.21229,6.21215 l 4.54836,29.23295 c 0.52956,3.40064 2.77073,6.21215 6.21244,6.21215 z"
+         id="path20"
+         style="fill:#5a7882;stroke-width:14.6693" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.12858,237.00001 c -3.74357,0 -4.14638,0.30899 -4.12803,3.32331 v 4.17669 4.17668 c -0.0183,3.01433 0.38446,3.32332 4.12803,3.32332 h 7.74335 c 3.7436,0 4.12805,-0.30895 4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 -0.38446,-3.32331 -4.12805,-3.32331 z"
-         id="path918-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 242.72871,84.980429 17.67943,30.622131 c 1.7207,2.98051 0.45328,6.38642 -2.27389,8.48619 l -23.36671,17.99334 c -2.72687,2.09947 -6.76532,0.70662 -8.48603,-2.27388 L 204.3788,101.8705 c -1.72071,-2.980507 -0.9359,-7.243989 2.27388,-8.486184 l 27.59,-10.67748 c 3.20993,-1.241755 6.76533,-0.706619 8.48618,2.274033 z"
+         id="path22"
+         style="fill:#5a7882;stroke-width:14.6693" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 326.45275,189.00048 c -1.2321,0 -2.21668,0.0221 -3.06999,0.14144 -0.85332,0.11937 -1.62809,0.35533 -2.21066,0.83967 -0.58256,0.48436 -0.86983,1.13381 -1.01188,1.84587 -0.14202,0.71207 -0.16501,1.53239 -0.15897,2.56202 v 7.61066 4.6143 c -0.006,1.02762 0.0171,1.84735 0.15897,2.55843 0.14203,0.71208 0.42931,1.36152 1.01188,1.84587 0.58258,0.48434 1.35734,0.7203 2.21066,0.83967 0.85331,0.11936 1.83789,0.14144 3.06999,0.14144 h 11.09542 c 1.2321,0 2.21381,-0.022 3.0657,-0.14144 0.85187,-0.11947 1.62795,-0.35683 2.2085,-0.84146 0.58057,-0.48464 0.86451,-1.13152 1.00758,-1.84228 0.14307,-0.71077 0.16972,-1.5314 0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 -0.0266,-1.84946 -0.16972,-2.56023 -0.14307,-0.71076 -0.42701,-1.35765 -1.00758,-1.84228 -0.58055,-0.48464 -1.35661,-0.722 -2.2085,-0.84147 -0.8519,-0.11947 -1.83359,-0.14144 -3.0657,-0.14144 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         d="m 48.800752,196.98043 17.679423,30.62213 c 1.720854,2.98051 5.304267,3.58547 8.486035,2.27389 l 27.2658,-11.2402 c 3.18162,-1.31187 3.9946,-5.50567 2.27374,-8.48618 l -21.902709,-37.9377 c -1.720854,-2.98051 -5.805664,-4.43248 -8.486182,-2.27389 l -23.042515,18.55518 c -2.680225,2.15902 -3.994446,5.50568 -2.273592,8.48618 z"
+         id="path24"
+         style="fill:#5a7882;stroke-width:14.6693" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 329.30094,134 c -1.63949,0 -2.94082,0.0308 -4.04505,0.19141 -1.10422,0.16064 -2.06697,0.4726 -2.78308,1.09179 -0.71611,0.61919 -1.0805,1.45612 -1.26421,2.41407 -0.18374,0.95795 -0.21537,2.08705 -0.20733,3.51171 V 149 v 7.79688 c -0.009,1.42131 0.0239,2.5495 0.20733,3.50585 0.18371,0.95796 0.5481,1.79488 1.26421,2.41407 0.71611,0.61919 1.67886,0.93115 2.78308,1.09179 1.10423,0.16065 2.40556,0.19141 4.04505,0.19141 h 13.40164 c 1.63949,0 2.93835,-0.0307 4.04054,-0.19141 1.10219,-0.16075 2.06274,-0.47425 2.77633,-1.09375 0.71357,-0.6195 1.07457,-1.45363 1.25969,-2.41015 C 350.96429,159.34816 351,158.22066 351,156.79688 V 149 141.20312 c 0,-1.42378 -0.0358,-2.55128 -0.22086,-3.50781 -0.18512,-0.95653 -0.54612,-1.79065 -1.25969,-2.41015 -0.71359,-0.61951 -1.67414,-0.933 -2.77633,-1.09375 C 345.64093,134.03065 344.34207,134 342.70258,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
+         d="m 260.47855,196.98043 -17.67942,30.62213 c -1.72086,2.98036 -5.30413,3.58576 -8.48619,2.27389 l -27.2658,-11.2402 c -3.18162,-1.31172 -3.99459,-5.50567 -2.27374,-8.48603 l 21.90271,-37.93771 c 1.72086,-2.98036 5.80552,-4.43247 8.48618,-2.27374 l 23.04252,18.55518 c 2.68037,2.15903 3.99459,5.50568 2.27374,8.48633 z"
+         id="path26"
+         style="fill:#5a7882;stroke-width:14.6693" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 333.65776,62 c -2.6221,0 -4.68675,0.05009 -6.38561,0.286735 -1.69887,0.236639 -3.08904,0.680503 -4.10735,1.523515 -1.0183,0.843013 -1.55577,1.996072 -1.83828,3.406406 -0.28252,1.410336 -0.33767,3.127346 -0.32482,5.308412 v 12.474816 12.480783 c -0.0127,2.177715 0.0426,3.893853 0.32482,5.302673 0.28251,1.41034 0.81998,2.5634 1.83828,3.40641 1.01831,0.84301 2.40848,1.28688 4.10735,1.52351 1.69888,0.23665 3.76351,0.28674 6.38561,0.28674 h 20.68618 c 2.62213,0 4.68568,-0.05 6.38104,-0.28674 1.69534,-0.23674 3.08126,-0.6821 4.09581,-1.52542 1.01457,-0.84331 1.54885,-1.99555 1.83367,-3.4045 C 366.93929,101.37441 367,99.660878 367,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0608,-3.893733 -0.34554,-5.302677 -0.28482,-1.408942 -0.81911,-2.561177 -1.83368,-3.404494 -1.01455,-0.843317 -2.40047,-1.288685 -4.09582,-1.525427 C 359.02962,62.049992 356.96605,62 354.34394,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
+         d="M 66.550588,84.980429 48.871164,115.60256 c -1.720707,2.98051 -0.453281,6.38642 2.273739,8.48604 l 23.366706,17.99334 c 2.726874,2.09947 6.765328,0.70662 8.486035,-2.27388 l 21.902716,-37.93771 c 1.7207,-2.980504 0.9359,-7.244132 -2.27389,-8.48618 L 75.036476,82.70669 c -3.209786,-1.241609 -6.765328,-0.706473 -8.486035,2.274179 z"
+         id="path28"
+         style="fill:#5a7882;stroke-width:14.6693" />
+      <circle
+         cx="154.41956"
+         cy="155.99443"
+         r="89.682144"
+         fill="url(#linearGradient924)"
+         stroke="url(#linearGradient951)"
+         stroke-width="1.16435"
+         id="circle32"
+         style="fill:url(#linearGradient924);stroke:url(#linearGradient951);stroke-dashoffset:0.42096" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,106.50019 c -10.01116,0 -11.88667,-0.90635 -11.83407,-9.74838 V 84.00024 71.24843 c -0.0527,-8.842031 1.82291,-9.748381 11.83407,-9.748381 h 21.3308 c 10.00866,0 11.83405,0.90625 11.83405,9.748381 v 12.75181 12.75157 c 0,8.84213 -1.82539,9.74838 -11.83406,9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 340.40013,61 h 7.26119 c 0.70675,0 1.18229,0.575166 1.27574,1.27571 l 0.80062,6.003195 c 0.0934,0.700544 -0.56899,1.27571 -1.27574,1.27571 h -8.99576 c -0.70675,0 -1.3844,-0.577365 -1.27574,-1.27571 l 0.93404,-6.003195 C 339.23323,61.577365 339.69347,61 340.40025,61 Z"
+         id="path806"
+         style="fill:#5a7882;stroke-width:3.01244" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1694);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 225.07297,267.9997 c 35.29673,0 39.09461,-3.62542 38.92162,-38.99353 V 155.9997 82.993224 c 0.17299,-35.36812 -3.62489,-38.99353 -38.92162,-38.99353 H 78.916218 c -35.29671,0 -38.92161,3.625 -38.92161,38.99353 v 73.006476 73.00647 c 0,35.36853 3.6249,38.99353 38.92161,38.99353 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 340.40013,107 h 7.26119 c 0.70675,0 1.18229,-0.57517 1.27574,-1.27571 l 0.80062,-6.003195 c 0.0934,-0.700543 -0.56899,-1.275709 -1.27574,-1.275709 h -8.99576 c -0.70675,0 -1.3844,0.577365 -1.27574,1.275709 l 0.93404,6.003195 c 0.10875,0.69835 0.56899,1.27571 1.27577,1.27571 z"
+         id="path808"
+         style="fill:#5a7882;stroke-width:3.01244" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 326.17688,211.50115 c -5.14666,0 -5.70043,-0.43262 -5.67521,-4.65309 v -5.84793 -7.84761 c -0.0253,-4.22046 0.52855,-4.65307 5.67521,-4.65307 h 11.64568 c 5.14665,0 5.67521,0.43255 5.67521,4.65307 v 7.84761 5.84793 c 0,4.22051 -0.52857,4.65309 -5.67522,4.65309 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
+         d="m 362.08972,69.416765 3.63059,6.288474 c 0.35336,0.612069 0.0931,1.311498 -0.46696,1.742699 L 360.45483,81.143 c -0.55998,0.431141 -1.38931,0.145109 -1.74267,-0.466959 l -4.49787,-7.790779 c -0.35336,-0.612068 -0.1922,-1.487605 0.46696,-1.742698 l 5.6658,-2.192697 c 0.65918,-0.255003 1.38931,-0.14511 1.7427,0.466989 z"
+         id="path810"
+         style="fill:#5a7882;stroke-width:3.01244" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.4056,251.50001 c -3.47604,0 -3.85006,-0.30899 -3.83302,-3.32331 v -4.17669 -4.17668 c -0.017,-3.01433 0.35698,-3.32332 3.83302,-3.32332 h 7.18996 c 3.47605,0 3.83303,0.30895 3.83303,3.32332 v 4.17668 4.17669 c 0,3.01436 -0.35699,3.32331 -3.83303,3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 322.26522,92.416765 3.6306,6.288475 c 0.35339,0.612068 1.08927,0.736301 1.74267,0.466958 l 5.59922,-2.308254 c 0.65337,-0.269403 0.82032,-1.13063 0.46693,-1.742698 l -4.49788,-7.790779 c -0.35338,-0.612068 -1.19223,-0.91024 -1.74269,-0.466959 l -4.73195,3.810439 c -0.5504,0.443371 -0.82029,1.13063 -0.4669,1.742698 z"
+         id="path812"
+         style="fill:#5a7882;stroke-width:3.01244" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,162.5 c -6.45163,0 -7.6603,-0.58409 -7.62639,-6.28227 v -8.21765 -8.21781 c -0.034,-5.69818 1.17476,-6.28227 7.62639,-6.28227 h 13.74651 c 6.45003,0 7.62639,0.58403 7.62639,6.28227 v 8.21781 8.21765 c 0,5.69824 -1.17636,6.28227 -7.62639,6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 365.73477,92.416765 -3.63059,6.288475 c -0.35339,0.612037 -1.08924,0.736361 -1.7427,0.466958 l -5.59923,-2.308254 c -0.65337,-0.269372 -0.82032,-1.13063 -0.46693,-1.742668 l 4.49788,-7.790779 c 0.35339,-0.612038 1.1922,-0.91024 1.7427,-0.466929 l 4.73194,3.810439 c 0.55044,0.443371 0.82032,1.13063 0.46693,1.742728 z"
+         id="path814"
+         style="fill:#5a7882;stroke-width:3.01244" />
+      <path
+         d="m 325.91028,69.416765 -3.6306,6.288474 c -0.35336,0.612069 -0.0931,1.311498 0.46693,1.742668 l 4.79852,3.695063 c 0.55998,0.43114 1.38931,0.145109 1.74267,-0.466959 l 4.49788,-7.790779 c 0.35336,-0.612068 0.19219,-1.487635 -0.46696,-1.742698 l -5.6658,-2.192697 c -0.65916,-0.254973 -1.38931,-0.14508 -1.74267,0.467019 z"
+         id="path816"
+         style="fill:#5a7882;stroke-width:3.01244" />
+      <circle
+         cx="343.9548"
+         cy="84"
+         r="18.416868"
+         fill="url(#linearGradient924)"
+         stroke="url(#linearGradient951)"
+         stroke-width="0.239107"
+         id="circle820"
+         style="fill:url(#linearGradient832);stroke:url(#linearGradient834);stroke-dashoffset:0.42096" />
+      <path
+         d="m 333.65226,133 h 4.73556 c 0.46092,0 0.77106,0.37511 0.832,0.83199 l 0.52214,3.91512 c 0.0609,0.45688 -0.37108,0.83199 -0.832,0.83199 h -5.8668 c -0.46092,0 -0.90287,-0.37654 -0.832,-0.83199 l 0.60915,-3.91512 C 332.89124,133.37655 333.1914,133 333.65234,133 Z"
+         id="path838"
+         style="fill:#5a7882;stroke-width:1.96464" />
+      <path
+         d="m 333.65226,163 h 4.73556 c 0.46092,0 0.77106,-0.37511 0.832,-0.83198 l 0.52214,-3.91513 c 0.0609,-0.45688 -0.37108,-0.83198 -0.832,-0.83198 h -5.8668 c -0.46092,0 -0.90287,0.37654 -0.832,0.83198 l 0.60915,3.91513 c 0.0709,0.45544 0.37109,0.83198 0.83203,0.83198 z"
+         id="path840"
+         style="fill:#5a7882;stroke-width:1.96464" />
+      <path
+         d="m 347.79764,138.4892 2.36778,4.10118 c 0.23045,0.39917 0.0607,0.85532 -0.30454,1.13654 l -3.12947,2.40982 c -0.3652,0.28118 -0.90607,0.0946 -1.13652,-0.30454 l -2.9334,-5.08094 c -0.23045,-0.39917 -0.12534,-0.97018 0.30454,-1.13654 l 3.69509,-1.43002 c 0.4299,-0.16631 0.90607,-0.0946 1.13654,0.30456 z"
+         id="path842"
+         style="fill:#5a7882;stroke-width:1.96464" />
+      <path
+         d="m 321.82515,153.4892 2.36778,4.10118 c 0.23047,0.39917 0.71039,0.48019 1.13652,0.30453 l 3.65167,-1.50538 c 0.42611,-0.1757 0.53499,-0.73737 0.30452,-1.13654 l -2.9334,-5.08094 c -0.23047,-0.39918 -0.77754,-0.59364 -1.13654,-0.30454 l -3.08605,2.48507 c -0.35896,0.28915 -0.53497,0.73736 -0.3045,1.13654 z"
+         id="path844"
+         style="fill:#5a7882;stroke-width:1.96464" />
+      <path
+         d="m 350.17485,153.4892 -2.36778,4.10118 c -0.23047,0.39915 -0.71037,0.48023 -1.13654,0.30453 l -3.65167,-1.50538 c -0.42611,-0.17568 -0.53499,-0.73737 -0.30452,-1.13652 l 2.9334,-5.08094 c 0.23047,-0.39916 0.77753,-0.59364 1.13654,-0.30452 l 3.08605,2.48507 c 0.35898,0.28915 0.53499,0.73736 0.30452,1.13656 z"
+         id="path846"
+         style="fill:#5a7882;stroke-width:1.96464" />
+      <path
+         d="m 324.20236,138.4892 -2.36778,4.10118 c -0.23045,0.39917 -0.0607,0.85532 0.30452,1.13652 l 3.12947,2.40982 c 0.3652,0.28118 0.90607,0.0946 1.13652,-0.30454 l 2.9334,-5.08094 c 0.23045,-0.39917 0.12534,-0.9702 -0.30454,-1.13654 l -3.69509,-1.43002 c -0.42988,-0.16629 -0.90607,-0.0946 -1.13652,0.30458 z"
+         id="path848"
+         style="fill:#5a7882;stroke-width:1.96464" />
+      <circle
+         cx="335.97052"
+         cy="148"
+         r="12.011002"
+         fill="url(#linearGradient924)"
+         stroke="url(#linearGradient951)"
+         stroke-width="0.155939"
+         id="circle852"
+         style="fill:url(#linearGradient864);stroke:url(#linearGradient866);stroke-dashoffset:0.42096" />
+      <path
+         d="m 330.20007,188.5 h 3.63059 c 0.35338,0 0.59115,0.28758 0.63787,0.63786 l 0.40031,3.00159 c 0.0467,0.35028 -0.2845,0.63786 -0.63787,0.63786 h -4.49788 c -0.35337,0 -0.6922,-0.28868 -0.63787,-0.63786 l 0.46702,-3.00159 c 0.0544,-0.34918 0.2845,-0.63786 0.63789,-0.63786 z"
+         id="path870"
+         style="fill:#5a7882;stroke-width:1.50622" />
+      <path
+         d="m 330.20007,211.5 h 3.63059 c 0.35338,0 0.59115,-0.28758 0.63787,-0.63785 l 0.40031,-3.0016 c 0.0467,-0.35027 -0.2845,-0.63786 -0.63787,-0.63786 h -4.49788 c -0.35337,0 -0.6922,0.28869 -0.63787,0.63786 l 0.46702,3.0016 c 0.0544,0.34917 0.2845,0.63785 0.63789,0.63785 z"
+         id="path872"
+         style="fill:#5a7882;stroke-width:1.50622" />
+      <path
+         d="m 341.04486,192.70838 1.8153,3.14424 c 0.17668,0.30604 0.0465,0.65575 -0.23348,0.87135 l -2.39926,1.84753 c -0.27999,0.21557 -0.69466,0.0726 -0.87134,-0.23348 l -2.24893,-3.89539 c -0.17668,-0.30603 -0.0961,-0.7438 0.23347,-0.87135 l 2.83291,-1.09634 c 0.32959,-0.12751 0.69465,-0.0726 0.87134,0.23349 z"
+         id="path874"
+         style="fill:#5a7882;stroke-width:1.50622" />
+      <path
+         d="m 321.13261,204.20838 1.8153,3.14424 c 0.1767,0.30603 0.54464,0.36815 0.87134,0.23348 l 2.79961,-1.15413 c 0.32668,-0.1347 0.41016,-0.56531 0.23346,-0.87135 l -2.24894,-3.89539 c -0.17669,-0.30603 -0.59611,-0.45512 -0.87134,-0.23347 l -2.36598,1.90521 c -0.2752,0.22169 -0.41014,0.56532 -0.23345,0.87135 z"
+         id="path876"
+         style="fill:#5a7882;stroke-width:1.50622" />
+      <path
+         d="m 342.86739,204.20838 -1.8153,3.14424 c -0.1767,0.30602 -0.54462,0.36818 -0.87135,0.23348 l -2.79961,-1.15413 c -0.32669,-0.13468 -0.41016,-0.56531 -0.23347,-0.87133 l 2.24894,-3.89539 c 0.1767,-0.30602 0.5961,-0.45512 0.87135,-0.23346 l 2.36597,1.90521 c 0.27522,0.22169 0.41016,0.56532 0.23347,0.87137 z"
+         id="path878"
+         style="fill:#5a7882;stroke-width:1.50622" />
+      <path
+         d="m 322.95514,192.70838 -1.8153,3.14424 c -0.17668,0.30604 -0.0465,0.65575 0.23347,0.87134 l 2.39926,1.84753 c 0.27999,0.21557 0.69465,0.0725 0.87133,-0.23348 l 2.24894,-3.89539 c 0.17668,-0.30604 0.0961,-0.74382 -0.23348,-0.87135 l -2.8329,-1.09635 c -0.32958,-0.12749 -0.69465,-0.0725 -0.87133,0.23351 z"
+         id="path880"
+         style="fill:#5a7882;stroke-width:1.50622" />
+      <circle
+         cx="331.97739"
+         cy="200"
+         r="9.2084341"
+         fill="url(#linearGradient924)"
+         stroke="url(#linearGradient951)"
+         stroke-width="0.119553"
+         id="circle884"
+         style="fill:url(#linearGradient896);stroke:url(#linearGradient898);stroke-dashoffset:0.42096" />
+      <path
+         d="m 326.84087,236.5 h 2.36778 c 0.23046,0 0.38553,0.18756 0.416,0.41599 l 0.26107,1.95757 c 0.0305,0.22844 -0.18554,0.41599 -0.416,0.41599 h -2.9334 c -0.23046,0 -0.45144,-0.18827 -0.416,-0.41599 l 0.30457,-1.95757 c 0.0355,-0.22772 0.18554,-0.41599 0.41602,-0.41599 z"
+         id="path902"
+         style="fill:#5a7882;stroke-width:0.982318" />
+      <path
+         d="m 326.84087,251.5 h 2.36778 c 0.23046,0 0.38553,-0.18755 0.416,-0.41599 l 0.26107,-1.95756 c 0.0305,-0.22844 -0.18554,-0.416 -0.416,-0.416 h -2.9334 c -0.23046,0 -0.45144,0.18827 -0.416,0.416 l 0.30457,1.95756 c 0.0355,0.22772 0.18554,0.41599 0.41602,0.41599 z"
+         id="path904"
+         style="fill:#5a7882;stroke-width:0.982318" />
+      <path
+         d="m 333.91356,239.2446 1.18389,2.05059 c 0.11522,0.19959 0.0303,0.42766 -0.15227,0.56827 l -1.56474,1.20491 c -0.1826,0.14059 -0.45303,0.0473 -0.56826,-0.15227 l -1.4667,-2.54047 c -0.11522,-0.19959 -0.0627,-0.48509 0.15227,-0.56827 l 1.84755,-0.71501 c 0.21495,-0.0832 0.45303,-0.0473 0.56827,0.15228 z"
+         id="path906"
+         style="fill:#5a7882;stroke-width:0.982318" />
+      <path
+         d="m 320.92731,246.7446 1.18389,2.05059 c 0.11524,0.19959 0.3552,0.2401 0.56826,0.15227 l 1.82584,-0.75269 c 0.21305,-0.0879 0.26749,-0.36869 0.15226,-0.56828 l -1.4667,-2.54047 c -0.11524,-0.19958 -0.38878,-0.29681 -0.56827,-0.15227 l -1.54303,1.24254 c -0.17948,0.14458 -0.26749,0.36868 -0.15225,0.56827 z"
+         id="path908"
+         style="fill:#5a7882;stroke-width:0.982318" />
+      <path
+         d="m 335.10216,246.7446 -1.18389,2.05059 c -0.11523,0.19958 -0.35518,0.24012 -0.56827,0.15227 l -1.82583,-0.75269 c -0.21306,-0.0878 -0.2675,-0.36869 -0.15226,-0.56827 l 1.4667,-2.54047 c 0.11523,-0.19957 0.38876,-0.29681 0.56827,-0.15226 l 1.54302,1.24254 c 0.17949,0.14458 0.2675,0.36868 0.15226,0.56828 z"
+         id="path910"
+         style="fill:#5a7882;stroke-width:0.982318" />
+      <path
+         d="m 322.11592,239.2446 -1.18389,2.05059 c -0.11523,0.19959 -0.0304,0.42766 0.15225,0.56826 l 1.56474,1.20491 c 0.1826,0.14059 0.45304,0.0473 0.56826,-0.15227 l 1.4667,-2.54047 c 0.11523,-0.19959 0.0627,-0.4851 -0.15227,-0.56827 l -1.84754,-0.71501 c -0.21494,-0.0831 -0.45304,-0.0473 -0.56826,0.15229 z"
+         id="path912"
+         style="fill:#5a7882;stroke-width:0.982318" />
+      <circle
+         cx="328"
+         cy="244"
+         r="6.0055008"
+         fill="url(#linearGradient924)"
+         stroke="url(#linearGradient951)"
+         stroke-width="0.0779696"
+         id="circle916"
+         style="fill:url(#linearGradient928);stroke:url(#linearGradient930);stroke-dashoffset:0.42096" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms and folds"
+       inkscape:label="Pictogram"
        style="display:inline">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.19999993;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 334,142.00056 c -3.86007,0 -7,3.13993 -7,7 0,3.86007 3.13993,7 7,7 1.71504,0 3.28541,-0.62099 4.5039,-1.64844 l 0.0723,0.0723 1,1.00196 -0.14063,0.14062 4,4 1.13086,-1.13086 -4,-4 -0.14062,0.14063 -1.00196,-1 -0.0723,-0.0723 c 1.02745,-1.21849 1.64844,-2.78886 1.64844,-4.5039 0,-3.86007 -3.13993,-7 -7,-7 z m 0,1 c 3.31963,0 6,2.68037 6,6 0,3.31963 -2.68037,6 -6,6 -3.31963,0 -6,-2.68037 -6,-6 0,-3.31963 2.68037,-6 6,-6 z"
-         id="path978-9"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 340.991,72.006045 c -6.61557,0 -12,5.384424 -12,12.000004 0,6.61557 5.38443,12 12,12 2.94841,0 5.64857,-1.07437 7.74023,-2.84571 l 1.63281,1.63282 -0.35351,0.35351 6.23633,6.236331 2.12109,-2.121091 -6.23633,-6.23633 -0.35351,0.35351 -1.63282,-1.63281 c 1.77134,-2.09167 2.84571,-4.79182 2.84571,-7.74023 0,-6.61558 -5.38443,-12.000004 -12,-12.000004 z m 0,2 c 5.53469,0 10,4.465304 10,10.000004 0,5.53469 -4.46531,10 -10,10 -5.53469,0 -10,-4.46531 -10,-10 0,-5.5347 4.46531,-10.000004 10,-10.000004 z"
-         id="path1054-9"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path917"
-         overflow="visible"
-         font-weight="400"
-         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1.89999998;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:new"
-         d="m 209.74519,109.58986 -72.26904,72.26903 -43.241445,-43.25112 -10.26609,10.29512 53.517205,53.50753 82.54481,-82.53512 z"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path917-3"
-         overflow="visible"
-         font-weight="400"
-         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:new"
-         d="m 355.0583,75.112256 -13.84001,13.840009 -8.28103,-8.282883 -1.96603,1.971586 10.24891,10.247056 15.80789,-15.806038 z"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path917-3-6"
-         overflow="visible"
-         font-weight="400"
-         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.183;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:new"
-         d="m 343.6558,141.84686 -9.58176,9.58176 -5.73315,-5.73446 -1.36113,1.365 7.09557,7.09426 10.94417,-10.94289 z"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path917-3-6-7"
-         overflow="visible"
-         font-weight="400"
-         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.94726658;marker:none;enable-background:new"
-         d="m 337.65291,195.45659 -7.07513,7.07512 -4.23333,-4.2343 -1.00505,1.00791 5.23934,5.23837 8.08112,-8.08018 z"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path917-3-6-7-5"
-         overflow="visible"
-         font-weight="400"
-         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.71653813;marker:none;enable-background:new"
-         d="m 332.77592,240.06328 -5.35181,5.35181 -3.20221,-3.20294 -0.76025,0.76241 3.96318,3.96244 6.11278,-6.11206 z"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:11.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1027);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 139.87487,90 c -35.29804,0 -63.999995,28.70196 -63.999995,64 0,35.29804 28.701955,64 63.999995,64 15.45232,0 29.63935,-5.50209 40.70897,-14.64844 l 6.89063,6.89063 -1.41406,1.41406 31.5,31.5 11.31445,-11.3125 -31.5,-31.5 -1.41406,1.41406 -6.88086,-6.88086 C 198.31151,183.78253 203.87486,169.5323 203.87486,154 c 0,-35.29804 -28.70196,-64 -63.99999,-64 z m 0,8.13672 c 30.90124,0 55.86327,24.96204 55.86327,55.86328 0,30.90124 -24.96203,55.86523 -55.86327,55.86523 -30.90124,0 -55.865225,-24.96399 -55.865225,-55.86523 0,-30.90124 24.963985,-55.86328 55.865225,-55.86328 z"
-         id="path1001"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4480-9"
-         d="m 336.19955,205.20031 -1.2,-1.2"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#666666;stroke-width:1.19999993;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:1.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 338.99955,208.00031 -3,-3"
-         id="path4478-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
       <circle
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.23529412;fill-rule:nonzero;stroke:#545454;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="path4260-0"
-         cx="330.99957"
-         cy="200.00031"
-         r="5.5" />
+         transform="rotate(90)"
+         cx="155.99443"
+         cy="-154.41956"
+         r="50.459412"
+         fill="#2a495d"
+         stroke="#4f6c7a"
+         stroke-width="25.8429"
+         id="circle34"
+         style="display:inline;enable-background:new;stroke-dashoffset:0.42096" />
+      <path
+         d="m 154.41961,206.45679 a 50.45941,50.45941 0 0 1 -50.02667,-43.86264 50.45941,50.45941 0 0 1 36.94607,-55.33254 50.45941,50.45941 0 0 1 59.68786,29.39578"
+         fill="none"
+         stroke="#00a2f3"
+         stroke-width="25.8429"
+         id="path36"
+         style="display:inline;enable-background:new;stroke-dashoffset:0.42096" />
       <circle
-         r="1.5"
-         cy="198.50031"
-         cx="329.49957"
-         id="circle4415-6"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none;stroke-width:0.77669889;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#666666;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 351.49428,93.495037 -2.49473,-2.494728"
-         id="path1054"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path1056"
-         d="m 357.31531,99.316068 -6.23682,-6.236819"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <ellipse
-         cy="83.000313"
-         cx="340.99957"
-         id="circle1060"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.23529412;fill-rule:nonzero;stroke:#545454;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         rx="11"
-         ry="11.000001" />
+         cx="197.25383"
+         cy="128.66557"
+         r="19.734591"
+         fill="url(#linearGradient965)"
+         id="circle40"
+         style="display:inline;enable-background:new;fill:url(#linearGradient934);stroke-width:14.6693" />
       <circle
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none;stroke-width:0.77669883;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="circle1062"
-         cx="337.99957"
-         cy="80.000313"
-         r="3" />
+         transform="rotate(90)"
+         cx="84"
+         cy="-343.9548"
+         r="10.362201"
+         fill="#2a495d"
+         stroke="#4f6c7a"
+         stroke-width="5.30702"
+         id="circle822"
+         style="display:inline;enable-background:new;stroke-dashoffset:0.42096" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#666666;stroke-width:1.19999993;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 340.19955,154.20031 -1.2,-1.2"
-         id="path978"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path980"
-         d="m 343.99955,158.00031 -4,-4"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:1.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         d="m 343.95481,94.362803 a 10.3622,10.3622 0 0 1 -10.27333,-9.007505 10.3622,10.3622 0 0 1 7.58714,-11.362933 10.3622,10.3622 0 0 1 12.25732,6.036633"
+         fill="none"
+         stroke="#00a2f3"
+         stroke-width="5.30702"
+         id="path824"
+         style="display:inline;enable-background:new;stroke-dashoffset:0.42096" />
       <circle
-         r="6.5"
-         cy="148.00031"
-         cx="333.99957"
-         id="circle984"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.23529412;fill-rule:nonzero;stroke:#545454;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         cx="352.75113"
+         cy="78.387825"
+         r="4.052639"
+         fill="url(#linearGradient965)"
+         id="circle828"
+         style="display:inline;enable-background:new;fill:url(#linearGradient836);stroke-width:3.01244" />
       <circle
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none;stroke-width:0.77669895;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="circle986"
-         cx="331.99957"
-         cy="146.00031"
-         r="2" />
+         transform="rotate(90)"
+         cx="148"
+         cy="-335.97052"
+         r="6.7579565"
+         fill="#2a495d"
+         stroke="#4f6c7a"
+         stroke-width="3.4611"
+         id="circle854"
+         style="display:inline;enable-background:new;stroke-dashoffset:0.42096" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#666666;stroke-width:1.20000005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 330.19955,247.20031 -0.75057,-0.7"
-         id="path1242"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path1244"
-         d="m 331.99955,249.00031 -2,-2"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:1.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         d="m 335.97053,154.75835 a 6.7579566,6.7579566 0 0 1 -6.7,-5.87446 6.7579566,6.7579566 0 0 1 4.94813,-7.41061 6.7579566,6.7579566 0 0 1 7.99391,3.93694"
+         fill="none"
+         stroke="#00a2f3"
+         stroke-width="3.4611"
+         id="path856"
+         style="display:inline;enable-background:new;stroke-dashoffset:0.42096" />
       <circle
-         r="3.5"
-         cy="244.00031"
-         cx="326.99954"
-         id="circle1248"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.23529412;fill-rule:nonzero;stroke:#545454;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         cx="341.70724"
+         cy="144.33989"
+         r="2.6430254"
+         fill="url(#linearGradient965)"
+         id="circle860"
+         style="display:inline;enable-background:new;fill:url(#linearGradient868);stroke-width:1.96464" />
       <circle
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none;stroke-width:0.77669889;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="circle1250"
-         cx="325.99954"
-         cy="243.00031"
-         r="1" />
+         transform="rotate(90)"
+         cx="200"
+         cy="-331.97739"
+         r="5.1810999"
+         fill="#2a495d"
+         stroke="#4f6c7a"
+         stroke-width="2.65351"
+         id="circle886"
+         style="display:inline;enable-background:new;stroke-dashoffset:0.42096" />
       <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4480"
-         d="m 195.71735,208.0003 -12.00001,-12"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#666666;stroke-width:11.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:15.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 223.21735,235.5003 -31.50001,-31.5"
-         id="path4478"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
+         d="m 331.97741,205.1814 a 5.1811,5.1811 0 0 1 -5.13667,-4.50375 5.1811,5.1811 0 0 1 3.79357,-5.68147 5.1811,5.1811 0 0 1 6.12866,3.01832"
+         fill="none"
+         stroke="#00a2f3"
+         stroke-width="2.65351"
+         id="path888"
+         style="display:inline;enable-background:new;stroke-dashoffset:0.42096" />
       <circle
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.23529412;fill-rule:nonzero;stroke:#545454;stroke-width:8.13559246;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="path4260"
-         cx="139.87459"
-         cy="152.00032"
-         r="59.932201" />
+         cx="336.37555"
+         cy="197.19391"
+         r="2.0263195"
+         fill="url(#linearGradient965)"
+         id="circle892"
+         style="display:inline;enable-background:new;fill:url(#linearGradient900);stroke-width:1.50622" />
       <circle
-         style="display:inline;opacity:0.3;vector-effect:none;fill:#ffffff;fill-opacity:0.11764706;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path16459"
-         cx="116"
-         cy="128"
-         r="12" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer4"
-       inkscape:label="Borders"
-       style="display:inline;opacity:1">
+         transform="rotate(90)"
+         cx="244"
+         cy="-328"
+         r="3.3789785"
+         fill="#2a495d"
+         stroke="#4f6c7a"
+         stroke-width="1.73055"
+         id="circle918"
+         style="display:inline;enable-background:new;stroke-dashoffset:0.42096" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92188,43.999698 c -35.296728,0 -39.09487,3.62603 -38.92188,38.99414 v 2 c -0.17299,-35.36811 3.625152,-38.99414 38.92188,-38.99414 h 146.15624 c 35.29673,0 38.92188,3.62561 38.92188,38.99414 v -2 c 0,-35.36853 -3.62515,-38.99414 -38.92188,-38.99414 z"
-         id="path931"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92728,267.9997 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 c -0.17299,35.36811 3.625154,38.99414 38.921885,38.99414 h 146.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 c 0,35.36853 -3.62515,38.99414 -38.92188,38.99414 z"
-         id="path931-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500047 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 V 84 96.75181 c -0.0527,8.84203 1.82291,9.74838 11.83407,9.74838 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 337.97659,211.50015 c 4.67187,0 5.5471,-0.42296 5.52255,-4.54923 v -7.95037 -5.95084 c 0.0245,-4.12627 -0.85068,-4.54923 -5.52255,-4.54923 h -11.95364 c -4.67071,0 -5.52256,0.42291 -5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 0.85185,4.54923 5.52256,4.54923 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.55494,251.5 c 3.33705,0 3.96221,-0.30212 3.94468,-3.24946 v -4.2505 -4.25059 c 0.0175,-2.94734 -0.60763,-3.24945 -3.94468,-3.24945 h -7.11025 c -3.33622,0 -3.94469,0.30208 -3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 0.60847,3.24946 3.94469,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline;opacity:0.5">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.44531,237 c -1.65302,0 -2.54604,0.12548 -2.91601,0.41406 -0.18499,0.14429 -0.30479,0.33122 -0.39649,0.70313 C 321.0411,238.4891 321,239.03036 321,239.75 v 4.25 4.25 c 0,0.71964 0.0411,1.26082 0.13281,1.63281 0.0917,0.37191 0.2115,0.55884 0.39649,0.70313 0.36997,0.28858 1.26299,0.41406 2.91601,0.41406 h 7.10938 c 1.65343,0 2.55203,-0.12511 2.92383,-0.41406 0.18589,-0.14448 0.30578,-0.33208 0.39648,-0.70313 0.0907,-0.37105 0.129,-0.90979 0.125,-1.6289 v -0.002 V 244 v -4.25195 -0.002 c 0.004,-0.71911 -0.0343,-1.25785 -0.125,-1.6289 -0.0907,-0.37105 -0.21059,-0.55865 -0.39648,-0.70313 C 334.10673,237.12512 333.20812,237 331.55469,237 Z m 5.32813,1.04688 c 1.10767,-3.4e-4 2.21363,0.008 3.32031,0.0449 0.26616,0.0599 0.75737,-0.0208 0.79297,0.3457 0.13405,1.84438 0.0662,3.68774 0.10156,5.53906 -0.0126,1.86745 0.0543,3.67031 -0.10351,5.49805 0.0642,0.42314 -0.43946,0.35577 -0.70313,0.42187 -3.43277,0.0703 -6.87577,0.0589 -10.29883,0.002 -0.22288,-0.0398 -0.55622,-3.2e-4 -0.71093,-0.1875 -0.19863,-1.12995 -0.12696,-2.26946 -0.16016,-3.41992 0.0138,-2.55648 -0.029,-5.10728 0.0898,-7.65625 -0.03,-0.2727 0.10944,-0.49629 0.40039,-0.48829 1.30659,-0.161 2.63265,-0.0636 3.94727,-0.0976 1.10718,0.006 2.21655,-0.002 3.32422,-0.002 z"
-         id="path918-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate"
-         d="m 326.02383,189.00048 c -2.32027,0 -3.60941,0.15494 -4.20703,0.62109 -0.29882,0.23308 -0.48964,0.54668 -0.625,1.09571 -0.13541,0.54902 -0.19141,1.31765 -0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 0.056,1.783 0.19141,2.33203 0.13536,0.54903 0.32618,0.86263 0.625,1.09571 0.59762,0.46615 1.88676,0.62109 4.20703,0.62109 h 11.9524 c 2.32085,0 3.61652,-0.15457 4.2168,-0.62109 0.30014,-0.23327 0.49095,-0.54754 0.625,-1.09571 0.13404,-0.54816 0.18764,-1.31623 0.18164,-2.33008 v -7.95279 -5.95312 c 0.006,-1.01386 -0.0476,-1.78191 -0.18164,-2.33008 -0.13406,-0.54817 -0.32486,-0.86244 -0.625,-1.09571 -0.60028,-0.46652 -1.89595,-0.62109 -4.2168,-0.62109 z m 4.95859,1.00977 c 1.5798,-0.002 4.16014,-3.9e-4 5.73991,0.0117 1.50021,0.0511 3.02236,-0.0712 4.5,0.28321 0.55111,0.0919 0.61303,0.71807 0.67773,1.16601 0.1117,4.30832 0.075,10.62608 0.0508,14.94108 -0.0716,0.99089 0.13687,2.07606 -0.30078,3.01366 -0.34356,0.40964 -0.9694,0.35958 -1.45117,0.45509 -3.95407,0.0823 -9.92936,0.0499 -13.89381,0.0371 -1.16908,-0.0622 -2.37292,0.11291 -3.51758,-0.22266 -0.57935,-0.098 -0.6137,-0.75914 -0.6875,-1.2207 -0.1146,-4.11835 -0.0751,-10.24472 -0.0547,-14.36881 0.0572,-1.06305 -0.0797,-2.16734 0.18164,-3.21485 0.10495,-0.6386 0.8614,-0.66043 1.36719,-0.74023 2.1305,-0.19658 5.24071,-0.10662 7.38828,-0.14062 z"
-         id="path914-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12695,134 c -3.21072,0 -5.03255,0.19514 -5.9375,0.89844 -0.45247,0.35165 -0.74178,0.83286 -0.93359,1.61718 -0.19176,0.78433 -0.26386,1.85686 -0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c -0.008,1.40682 0.0641,2.47935 0.25586,3.26368 0.1918,0.78431 0.48112,1.26553 0.93359,1.61718 0.90496,0.7033 2.72678,0.89844 5.9375,0.89844 h 13.7461 c 3.20992,0 5.02461,-0.19551 5.92578,-0.89844 0.45058,-0.35146 0.73805,-0.83201 0.93164,-1.61718 C 349.9241,158.69918 350,157.62415 350,156.2168 V 148 139.7832 c 0,-1.40735 -0.0759,-2.48237 -0.26953,-3.26758 -0.19359,-0.78517 -0.48106,-1.26572 -0.93164,-1.61718 C 347.89766,134.19551 346.08297,134 342.87305,134 Z m 6.49805,1.04688 c 3.45647,0.0171 6.9142,-0.0268 10.36133,0.0918 0.8211,0.13276 1.80664,0.14835 2.39062,0.82617 0.67884,1.16473 0.51296,2.58781 0.56446,3.87305 0.0431,6.02893 0.0678,12.06719 -0.0332,18.08789 -0.0775,0.77792 -0.12055,1.67263 -0.67968,2.27539 -0.70249,0.51038 -1.61833,0.59683 -2.45899,0.67383 -4.04742,0.0864 -8.16222,0.0456 -12.24023,0.0606 -2.45188,-0.0199 -4.91402,0.0317 -7.35352,-0.0606 -0.87784,-0.12055 -1.915,-0.14021 -2.56055,-0.83398 -0.64775,-1.02591 -0.50264,-2.30525 -0.56054,-3.46485 -0.035,-5.65575 -0.0351,-11.35518 0,-17.00976 0.0632,-1.22153 -0.10864,-2.57724 0.59179,-3.65235 0.6025,-0.62665 1.55621,-0.63986 2.35938,-0.77344 2.73743,-0.10739 5.48083,-0.0704 8.22656,-0.0918 0.46403,-2.9e-4 0.92855,-0.002 1.39258,-0.002 z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33594,62 c -4.99049,0 -7.87051,0.276282 -9.38477,1.453125 -0.75713,0.588421 -1.23761,1.403518 -1.54492,2.660156 -0.3073,1.256638 -0.4173,2.940031 -0.4043,5.132813 V 84 96.753906 c -0.0131,2.19278 0.097,3.876174 0.4043,5.132814 0.30731,1.25663 0.78779,2.07172 1.54492,2.66016 1.51427,1.17683 4.39428,1.45312 9.38477,1.45312 h 21.33008 c 4.98923,0 7.85502,-0.27668 9.36328,-1.45312 0.75412,-0.58824 1.23293,-1.40461 1.54297,-2.66211 C 365.8823,100.62727 366,98.945281 366,96.751953 V 84 71.248047 c 0,-2.193329 -0.1177,-3.875313 -0.42773,-5.132813 -0.31004,-1.257499 -0.78884,-2.073874 -1.54297,-2.662109 C 362.52104,62.276656 359.65526,62 354.66602,62 Z m 2.40234,1.097656 c 6.94737,8.3e-4 13.91063,0.0034 20.84961,0.05469 2.14296,0.08293 4.46431,-0.147701 6.42383,0.93164 1.29609,0.695228 1.54862,2.250325 1.76953,3.564454 0.17551,2.202888 0.0915,4.442228 0.13867,6.669921 0.0227,8.479532 0.077,16.968993 -0.0801,25.447266 -0.16151,1.483233 -0.38135,3.305793 -1.79882,4.142573 -1.6055,0.82871 -3.47551,0.90643 -5.24805,0.95313 -9.49974,0.0678 -19.0243,0.0843 -28.52344,-0.0176 -1.57816,-0.11413 -3.27053,-0.24014 -4.63281,-1.12109 -1.22952,-0.99538 -1.36082,-2.72739 -1.50391,-4.193361 -0.1272,-8.998585 -0.0836,-18.004484 -0.0527,-27.007813 0.0997,-2.381275 -0.24538,-4.900002 0.70508,-7.160156 0.67165,-1.50972 2.46573,-1.859954 3.93945,-2.05664 2.66168,-0.316582 5.34184,-0.147022 8.01367,-0.207032 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
+         d="m 328,247.37918 a 3.3789784,3.3789784 0 0 1 -3.35,-2.93723 3.3789784,3.3789784 0 0 1 2.47407,-3.70531 3.3789784,3.3789784 0 0 1 3.99695,1.96847"
+         fill="none"
+         stroke="#00a2f3"
+         stroke-width="1.73055"
+         id="path920"
+         style="display:inline;enable-background:new;stroke-dashoffset:0.42096" />
+      <circle
+         cx="330.86838"
+         cy="242.16994"
+         r="1.3215127"
+         fill="url(#linearGradient965)"
+         id="circle924"
+         style="display:inline;enable-background:new;fill:url(#linearGradient932);stroke-width:0.982318" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/disk-usage-app.svg
+++ b/icons/src/fullcolor/default/apps/disk-usage-app.svg
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="disk-usage-app.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\preferences-system-network.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="159.28053"
-     inkscape:cy="62.273329"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="360.62446"
+     inkscape:cy="189.50462"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,153 +93,451 @@
   <defs
      id="defs3">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="d"
+       x2="1"
+       gradientTransform="matrix(0,-17.226899,17.226899,0,937.2353,249.9597)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#040404"
+         stop-opacity=".45"
          offset="0"
-         id="stop923" />
+         id="stop903" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#121212"
+         stop-opacity=".41"
          offset="1"
-         id="stop925" />
+         id="stop905" />
+    </linearGradient>
+    <linearGradient
+       id="c"
+       x1="14.6558"
+       x2="33.486599"
+       y1="853.91302"
+       y2="853.91302"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.9369655,0,0,4.9369655,32.640081,27.916709)">
+      <stop
+         stop-color="#197cf1"
+         offset="0"
+         id="stop898" />
+      <stop
+         stop-color="#20bcfa"
+         offset="1"
+         id="stop900" />
+    </linearGradient>
+    <linearGradient
+       id="b"
+       x2="1"
+       gradientTransform="matrix(-0.00761092,-191.26101,191.26101,-0.00761092,402.45138,225.656)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#bbbec4"
+         offset="0"
+         id="stop893" />
+      <stop
+         stop-color="#dcdee1"
+         offset="1"
+         id="stop895" />
+    </linearGradient>
+    <linearGradient
+       id="a"
+       x2="1"
+       gradientTransform="matrix(218.67992,-0.92194869,0.92194869,218.67992,75.686761,8270.23)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#1a1a1a"
+         offset="0"
+         id="stop878" />
+      <stop
+         stop-color="#2c2c2e"
+         offset=".11"
+         id="stop880" />
+      <stop
+         stop-color="#2b2b2d"
+         offset=".29"
+         id="stop882" />
+      <stop
+         stop-color="#2a2b2d"
+         offset=".51"
+         id="stop884" />
+      <stop
+         stop-color="#2b2b2d"
+         offset=".75"
+         id="stop886" />
+      <stop
+         stop-color="#323232"
+         offset=".9"
+         id="stop888" />
+      <stop
+         stop-color="#171717"
+         offset="1"
+         id="stop890" />
+    </linearGradient>
+    <linearGradient
+       id="g"
+       x2="1"
+       gradientTransform="matrix(-0.61555707,196.9605,-196.9605,-0.61555707,165.94548,44.843298)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#f8b17e"
+         offset="0"
+         id="stop248" />
+      <stop
+         stop-color="#c6262e"
+         offset="1"
+         id="stop250" />
+    </linearGradient>
+    <linearGradient
+       id="f"
+       x2="1"
+       gradientTransform="matrix(1.746439,-161.55104,161.55104,1.746439,128.16223,209.00989)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#8badea"
+         offset="0"
+         id="stop243" />
+      <stop
+         stop-color="#3b7caf"
+         offset="1"
+         id="stop245" />
+    </linearGradient>
+    <linearGradient
+       id="e"
+       x2="1"
+       gradientTransform="matrix(5.0654035,-189.2173,189.2173,5.0654035,164.22312,265.33438)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#3ec896"
+         offset="0"
+         id="stop238" />
+      <stop
+         stop-color="#66d9af"
+         offset="1"
+         id="stop240" />
+    </linearGradient>
+    <linearGradient
+       id="d-3"
+       x2="1"
+       gradientTransform="matrix(0,-17.220595,17.220595,0,948.04792,264.54476)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#040404"
+         stop-opacity=".45"
+         offset="0"
+         id="stop233" />
+      <stop
+         stop-color="#121212"
+         stop-opacity=".41"
+         offset="1"
+         id="stop235" />
+    </linearGradient>
+    <linearGradient
+       id="c-6"
+       x2="1"
+       gradientTransform="matrix(92.933177,0,0,92.933177,116.11561,4256.7282)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#197cf1"
+         offset="0"
+         id="stop228" />
+      <stop
+         stop-color="#20bcfa"
+         offset="1"
+         id="stop230" />
+    </linearGradient>
+    <linearGradient
+       id="b-7"
+       x2="1"
+       gradientTransform="matrix(-0.00760798,-191.19134,191.19134,-0.00760798,413.46131,240.24918)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#bbbec4"
+         offset="0"
+         id="stop223" />
+      <stop
+         stop-color="#dcdee1"
+         offset="1"
+         id="stop225" />
+    </linearGradient>
+    <linearGradient
+       id="a-5"
+       x2="1"
+       gradientTransform="matrix(218.59605,-0.92158364,0.92158364,218.59605,86.817304,8281.7598)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#1a1a1a"
+         offset="0"
+         id="stop208" />
+      <stop
+         stop-color="#2c2c2e"
+         offset=".11"
+         id="stop210" />
+      <stop
+         stop-color="#2b2b2d"
+         offset=".29"
+         id="stop212" />
+      <stop
+         stop-color="#2a2b2d"
+         offset=".51"
+         id="stop214" />
+      <stop
+         stop-color="#2b2b2d"
+         offset=".75"
+         id="stop216" />
+      <stop
+         stop-color="#323232"
+         offset=".9"
+         id="stop218" />
+      <stop
+         stop-color="#171717"
+         offset="1"
+         id="stop220" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient8590"
+       xlink:href="#a-5"
+       id="linearGradient655"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.23913043,0,0,0.23913032,321.04348,61.043494)"
-       x1="96"
-       y1="4.0000062"
-       x2="96"
-       y2="188" />
+       gradientTransform="matrix(44.890262,-0.18925379,0.18925379,44.890262,328.51208,1751.6508)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient8590-3"
+       xlink:href="#b-7"
+       id="linearGradient657"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.15217394,0,0,0.15217387,321.3913,133.39129)"
-       x1="96"
-       y1="4.0000062"
-       x2="96"
-       y2="188" />
+       gradientTransform="matrix(-0.00156235,-39.262509,39.262509,-0.00156235,395.59077,100.2691)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient8590-3-3"
+       xlink:href="#c-6"
+       id="linearGradient659"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.11956515,0,0,0.11956513,320.52176,188.52174)"
-       x1="95.999878"
-       y1="3.9999957"
-       x2="95.999878"
-       y2="188.00014" />
+       gradientTransform="matrix(19.084492,0,0,19.084492,334.5287,925.08178)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient8590-3-3-4"
+       xlink:href="#d-3"
+       id="linearGradient661"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.0760869,0,0,0.07608688,320.69566,236.69567)"
-       x1="96"
-       y1="4.0000062"
-       x2="96"
-       y2="188" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter48952"
-       x="-0.048"
-       width="1.096"
-       y="-0.048"
-       height="1.096">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.48"
-         id="feGaussianBlur48954" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter48967"
-       x="-0.012"
-       width="1.024"
-       y="-0.012"
-       height="1.024">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.12"
-         id="feGaussianBlur48969" />
-    </filter>
+       gradientTransform="matrix(0,-3.5363723,3.5363723,0,505.37195,105.25837)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient1205"
+       xlink:href="#e"
+       id="linearGradient663"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,308.00017,307.99985)"
-       x1="77"
-       y1="156"
-       x2="227"
-       y2="156" />
+       gradientTransform="matrix(1.0402168,-38.857125,38.857125,1.0402168,344.40792,105.42052)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient1392">
-      <stop
-         style="stop-color:#e6e6e6;stop-opacity:1;"
-         offset="0"
-         id="stop1388" />
-      <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
-         offset="1"
-         id="stop1390" />
-    </linearGradient>
+       xlink:href="#f"
+       id="linearGradient665"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35864374,-33.175661,33.175661,0.35864374,337.00256,93.853884)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient4103"
+       xlink:href="#g"
+       id="linearGradient667"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,308.00017,307.99985)"
-       x1="77"
-       y1="156"
-       x2="227"
-       y2="156" />
+       gradientTransform="matrix(-0.12640905,40.447247,-40.447247,-0.12640905,344.76162,60.141101)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient4105"
+       xlink:href="#a-5"
+       id="linearGradient687"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,308.00017,307.99985)"
-       x1="77"
-       y1="156"
-       x2="227"
-       y2="156" />
+       gradientTransform="matrix(29.276256,-0.12342638,0.12342638,29.276256,325.89919,1235.5983)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient4107"
+       xlink:href="#b-7"
+       id="linearGradient689"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,308.00017,307.99985)"
-       x1="77"
-       y1="156"
-       x2="227"
-       y2="156" />
+       gradientTransform="matrix(-0.00101893,-25.605983,25.605983,-0.00101893,369.64615,158.61028)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient4109"
+       xlink:href="#c-6"
+       id="linearGradient691"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,308.00017,307.99985)"
-       x1="77"
-       y1="156"
-       x2="227"
-       y2="156" />
+       gradientTransform="matrix(12.446408,0,0,12.446408,329.82307,696.53157)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d-3"
+       id="linearGradient693"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-2.3063297,2.3063297,0,441.24257,161.86415)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#e"
+       id="linearGradient695"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67840225,-25.341602,25.341602,0.67840225,336.26604,161.9699)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#f"
+       id="linearGradient697"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23389808,-21.6363,21.6363,0.23389808,331.43645,154.42645)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#g"
+       id="linearGradient699"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.08244068,26.378638,-26.378638,-0.08244068,336.49671,132.43985)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a-5"
+       id="linearGradient719"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(22.44513,-0.09462689,0.09462689,22.44513,324.25604,1033.8254)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b-7"
+       id="linearGradient721"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-7.8117651e-4,-19.631253,19.631253,-7.8117651e-4,357.79538,208.13455)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c-6"
+       id="linearGradient723"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(9.5422457,0,0,9.5422457,327.26434,620.54087)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d-3"
+       id="linearGradient725"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.7681861,1.7681861,0,412.68596,210.62919)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#e"
+       id="linearGradient727"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.52010839,-19.428562,19.428562,0.52010839,332.20396,210.71026)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#f"
+       id="linearGradient729"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17932186,-16.58783,16.58783,0.17932186,328.50127,204.92695)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#g"
+       id="linearGradient731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.06320452,20.223622,-20.223622,-0.06320452,332.3808,188.07056)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a-5"
+       id="linearGradient751"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(14.638129,-0.06171319,0.06171319,14.638129,322.94959,787.79918)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b-7"
+       id="linearGradient753"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.0946298e-4,-12.802992,12.802992,-5.0946298e-4,344.82307,249.30514)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c-6"
+       id="linearGradient755"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(6.2232042,0,0,6.2232042,324.91153,518.2658)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d-3"
+       id="linearGradient757"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.1531649,1.1531649,0,380.62129,250.93207)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#e"
+       id="linearGradient759"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33920115,-12.670802,12.670802,0.33920115,328.13301,250.98495)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#f"
+       id="linearGradient761"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11694905,-10.818151,10.818151,0.11694905,325.71822,247.21322)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#g"
+       id="linearGradient763"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04122034,13.18932,-13.18932,-0.04122034,328.24835,236.21992)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a-5"
+       id="linearGradient765"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(218.59605,-0.92158364,0.92158364,218.59605,76.580562,8276.734)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b-7"
+       id="linearGradient767"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00760798,-191.19134,191.19134,-0.00760798,403.22457,235.22342)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c-6"
+       id="linearGradient769"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(92.933177,0,0,92.933177,105.87887,4251.7024)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d-3"
+       id="linearGradient771"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-17.220595,17.220595,0,937.81118,259.519)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#e"
+       id="linearGradient773"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.0654035,-189.2173,189.2173,5.0654035,153.98638,260.30862)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#f"
+       id="linearGradient775"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.746439,-161.55104,161.55104,1.746439,117.92549,203.98413)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#g"
+       id="linearGradient777"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.61555707,196.9605,-196.9605,-0.61555707,155.70874,39.817539)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -250,13 +549,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -338,7 +637,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">disk-usage-app</tspan></text>
+           id="tspan924">disk-usage-app</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -373,469 +672,239 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
-      <circle
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter48967);enable-background:new"
-         id="path11042-4"
-         r="112"
-         cy="157"
-         cx="152" />
-      <circle
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter48952);enable-background:new"
-         id="path11042-9"
-         r="112"
-         cy="157"
-         cx="152" />
       <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
-      <circle
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-0-0"
-         cx="-344"
-         cy="-85.000015"
-         transform="scale(-1)"
-         r="23" />
-      <circle
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-0-0-2"
-         cx="-336"
-         cy="-149"
-         transform="scale(-1)"
-         r="14.999996" />
-      <ellipse
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-0-0-2-3"
-         cx="-332"
-         cy="-200.52327"
-         transform="scale(-1)"
-         rx="11.999997"
-         ry="11.476745" />
-      <ellipse
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437706;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-0-0-2-3-3"
-         cx="-328"
-         cy="-244.5"
-         transform="scale(-1)"
-         rx="6.9999981"
-         ry="6.5" />
+         d="M 242.54705,267.95805 H 61.452952 c -9.42607,0 -17.89967,-5.82837 -18.48201,-15.22977 -0.46884,-7.62969 -2.966005,-33.88944 -2.97094,-33.94373 H 264 c -0.005,0.0543 -2.5021,26.31404 -2.97094,33.94373 -0.58234,9.4014 -9.05594,15.22977 -18.48201,15.22977 z"
+         fill="url(#a)"
+         fill-rule="nonzero"
+         id="path253"
+         style="fill:url(#linearGradient765);stroke-width:4.93512" />
       <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5-3"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0"
-         clip-path="none" />
-      <g
-         transform="matrix(1.4933316,0,0,1.4933317,-74.986533,-76.959623)"
-         style="display:inline;stroke-width:0.66964358;enable-background:new"
-         id="g8831"
-         clip-path="none">
-        <g
-           id="g1160-7-2"
-           style="display:inline;stroke-width:0.66964358;enable-background:new">
-          <g
-             style="stroke-width:0.66964358"
-             id="g1156-0-6">
-            <path
-               style="opacity:1;fill:#f76363;fill-opacity:1;stroke:none;stroke-width:1.33928716;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.33928721, 1.33928721;stroke-dashoffset:1;stroke-opacity:1"
-               id="path1148-9-1"
-               sodipodi:type="arc"
-               sodipodi:cx="152"
-               sodipodi:cy="156"
-               sodipodi:rx="75"
-               sodipodi:ry="75"
-               sodipodi:start="1.5526524"
-               sodipodi:end="5.703321"
-               d="M 153.36072,230.98766 A 75,75 0 0 1 78.576295,171.29574 75,75 0 0 1 123.30393,86.706885 75,75 0 0 1 214.74028,114.90672 L 152,156 Z" />
-            <path
-               d="m 209.45333,107.79093 a 75,75 0 0 1 5.56361,88.8768 L 152,156 Z"
-               sodipodi:end="0.57309657"
-               sodipodi:start="5.5850536"
-               sodipodi:ry="75"
-               sodipodi:rx="75"
-               sodipodi:cy="156"
-               sodipodi:cx="152"
-               sodipodi:type="arc"
-               id="path1150-3-8"
-               style="opacity:1;fill:#5884f4;fill-opacity:1;stroke:none;stroke-width:1.33928716;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.33928721, 1.33928721;stroke-dashoffset:1;stroke-opacity:1" />
-            <path
-               style="opacity:1;fill:#76c22b;fill-opacity:1;stroke:none;stroke-width:1.33928716;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.33928721, 1.33928721;stroke-dashoffset:1;stroke-opacity:1"
-               id="path1152-6-7"
-               sodipodi:type="arc"
-               sodipodi:cx="152"
-               sodipodi:cy="156"
-               sodipodi:rx="75"
-               sodipodi:ry="75"
-               sodipodi:start="0.9595926"
-               sodipodi:end="1.8325957"
-               d="m 195.03903,217.42184 a 75,75 0 0 1 -62.45046,11.0226 L 152,156 Z" />
-            <path
-               d="M 219.97308,187.69637 A 75,75 0 0 1 189.5,220.95191 L 152,156 Z"
-               sodipodi:end="1.0471976"
-               sodipodi:start="0.43633231"
-               sodipodi:ry="75"
-               sodipodi:rx="75"
-               sodipodi:cy="156"
-               sodipodi:cx="152"
-               sodipodi:type="arc"
-               id="path1154-0-9"
-               style="opacity:1;fill:#fdc92b;fill-opacity:1;stroke:none;stroke-width:1.33928716;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.33928721, 1.33928721;stroke-dashoffset:1;stroke-opacity:1" />
-          </g>
-        </g>
-        <path
-           sodipodi:nodetypes="sssss"
-           inkscape:connector-curvature="0"
-           id="path949"
-           d="m 152.00017,80.999836 c -41.42135,0 -75.000002,33.578644 -75.000002,75.000004 0,41.42136 33.578652,75 75.000002,75 41.42135,0 75,-33.57864 75,-75 0,-41.42136 -33.57865,-75.000004 -75,-75.000004 z"
-           style="display:inline;opacity:0.2;fill:url(#linearGradient4103);fill-opacity:1;stroke:none;stroke-width:10.71429729;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
-      <g
-         transform="matrix(0.29999966,0,0,0.29999966,298.40003,37.200079)"
-         style="display:inline;stroke-width:3.33333707;enable-background:new"
-         id="g8831-6"
-         clip-path="none">
-        <g
-           id="g1160-7-2-0"
-           style="display:inline;stroke-width:3.33333707;enable-background:new">
-          <g
-             style="stroke-width:3.33333707"
-             id="g1156-0-6-7">
-            <path
-               style="opacity:1;fill:#f76363;fill-opacity:1;stroke:none;stroke-width:6.66667414;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6.66667426, 6.66667426;stroke-dashoffset:1;stroke-opacity:1"
-               id="path1148-9-1-5"
-               sodipodi:type="arc"
-               sodipodi:cx="152"
-               sodipodi:cy="156"
-               sodipodi:rx="75"
-               sodipodi:ry="75"
-               sodipodi:start="1.5526524"
-               sodipodi:end="5.703321"
-               d="M 153.36072,230.98766 A 75,75 0 0 1 78.576295,171.29574 75,75 0 0 1 123.30393,86.706885 75,75 0 0 1 214.74028,114.90672 L 152,156 Z" />
-            <path
-               d="m 209.45333,107.79093 a 75,75 0 0 1 5.56361,88.8768 L 152,156 Z"
-               sodipodi:end="0.57309657"
-               sodipodi:start="5.5850536"
-               sodipodi:ry="75"
-               sodipodi:rx="75"
-               sodipodi:cy="156"
-               sodipodi:cx="152"
-               sodipodi:type="arc"
-               id="path1150-3-8-7"
-               style="opacity:1;fill:#5884f4;fill-opacity:1;stroke:none;stroke-width:6.66667414;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6.66667426, 6.66667426;stroke-dashoffset:1;stroke-opacity:1" />
-            <path
-               style="opacity:1;fill:#76c22b;fill-opacity:1;stroke:none;stroke-width:6.66667414;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6.66667426, 6.66667426;stroke-dashoffset:1;stroke-opacity:1"
-               id="path1152-6-7-3"
-               sodipodi:type="arc"
-               sodipodi:cx="152"
-               sodipodi:cy="156"
-               sodipodi:rx="75"
-               sodipodi:ry="75"
-               sodipodi:start="0.9595926"
-               sodipodi:end="1.8325957"
-               d="m 195.03903,217.42184 a 75,75 0 0 1 -62.45046,11.0226 L 152,156 Z" />
-            <path
-               d="M 219.97308,187.69637 A 75,75 0 0 1 189.5,220.95191 L 152,156 Z"
-               sodipodi:end="1.0471976"
-               sodipodi:start="0.43633231"
-               sodipodi:ry="75"
-               sodipodi:rx="75"
-               sodipodi:cy="156"
-               sodipodi:cx="152"
-               sodipodi:type="arc"
-               id="path1154-0-9-8"
-               style="opacity:1;fill:#fdc92b;fill-opacity:1;stroke:none;stroke-width:6.66667414;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6.66667426, 6.66667426;stroke-dashoffset:1;stroke-opacity:1" />
-          </g>
-        </g>
-        <path
-           sodipodi:nodetypes="sssss"
-           inkscape:connector-curvature="0"
-           id="path949-6"
-           d="m 152.00017,80.999836 c -41.42135,0 -75.000002,33.578644 -75.000002,75.000004 0,41.42136 33.578652,75 75.000002,75 41.42135,0 75,-33.57864 75,-75 0,-41.42136 -33.57865,-75.000004 -75,-75.000004 z"
-           style="display:inline;opacity:0.2;fill:url(#linearGradient4105);fill-opacity:1;stroke:none;stroke-width:53.3333931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
-      <g
-         transform="matrix(0.19333311,0,0,0.19333311,306.61335,117.84005)"
-         style="display:inline;stroke-width:5.17241955;enable-background:new"
-         id="g8831-6-6"
-         clip-path="none">
-        <g
-           id="g1160-7-2-0-3"
-           style="display:inline;stroke-width:5.17241955;enable-background:new">
-          <g
-             style="stroke-width:5.17241955"
-             id="g1156-0-6-7-5">
-            <path
-               style="opacity:1;fill:#f76363;fill-opacity:1;stroke:none;stroke-width:10.3448391;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:10.34483937, 10.34483937;stroke-dashoffset:1;stroke-opacity:1"
-               id="path1148-9-1-5-9"
-               sodipodi:type="arc"
-               sodipodi:cx="152"
-               sodipodi:cy="156"
-               sodipodi:rx="75"
-               sodipodi:ry="75"
-               sodipodi:start="1.5526524"
-               sodipodi:end="5.703321"
-               d="M 153.36072,230.98766 A 75,75 0 0 1 78.576295,171.29574 75,75 0 0 1 123.30393,86.706885 75,75 0 0 1 214.74028,114.90672 L 152,156 Z" />
-            <path
-               d="m 209.45333,107.79093 a 75,75 0 0 1 5.56361,88.8768 L 152,156 Z"
-               sodipodi:end="0.57309657"
-               sodipodi:start="5.5850536"
-               sodipodi:ry="75"
-               sodipodi:rx="75"
-               sodipodi:cy="156"
-               sodipodi:cx="152"
-               sodipodi:type="arc"
-               id="path1150-3-8-7-0"
-               style="opacity:1;fill:#5884f4;fill-opacity:1;stroke:none;stroke-width:10.3448391;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:10.34483937, 10.34483937;stroke-dashoffset:1;stroke-opacity:1" />
-            <path
-               style="opacity:1;fill:#76c22b;fill-opacity:1;stroke:none;stroke-width:10.3448391;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:10.34483937, 10.34483937;stroke-dashoffset:1;stroke-opacity:1"
-               id="path1152-6-7-3-3"
-               sodipodi:type="arc"
-               sodipodi:cx="152"
-               sodipodi:cy="156"
-               sodipodi:rx="75"
-               sodipodi:ry="75"
-               sodipodi:start="0.9595926"
-               sodipodi:end="1.8325957"
-               d="m 195.03903,217.42184 a 75,75 0 0 1 -62.45046,11.0226 L 152,156 Z" />
-            <path
-               d="M 219.97308,187.69637 A 75,75 0 0 1 189.5,220.95191 L 152,156 Z"
-               sodipodi:end="1.0471976"
-               sodipodi:start="0.43633231"
-               sodipodi:ry="75"
-               sodipodi:rx="75"
-               sodipodi:cy="156"
-               sodipodi:cx="152"
-               sodipodi:type="arc"
-               id="path1154-0-9-8-8"
-               style="opacity:1;fill:#fdc92b;fill-opacity:1;stroke:none;stroke-width:10.3448391;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:10.34483937, 10.34483937;stroke-dashoffset:1;stroke-opacity:1" />
-          </g>
-        </g>
-        <path
-           sodipodi:nodetypes="sssss"
-           inkscape:connector-curvature="0"
-           id="path949-6-4"
-           d="m 152.00017,80.999836 c -41.42135,0 -75.000002,33.578644 -75.000002,75.000004 0,41.42136 33.578652,75 75.000002,75 41.42135,0 75,-33.57864 75,-75 0,-41.42136 -33.57865,-75.000004 -75,-75.000004 z"
-           style="display:inline;opacity:0.2;fill:url(#linearGradient4107);fill-opacity:1;stroke:none;stroke-width:82.75871277;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
-      <g
-         transform="matrix(0.09999989,0,0,0.09999989,312.8,228.40002)"
-         style="display:inline;stroke-width:10.00001049;enable-background:new"
-         id="g8831-6-2"
-         clip-path="none">
-        <g
-           id="g1160-7-2-0-0"
-           style="display:inline;stroke-width:10.00001049;enable-background:new">
-          <g
-             style="stroke-width:10.00001049"
-             id="g1156-0-6-7-1">
-            <path
-               style="opacity:1;fill:#f76363;fill-opacity:1;stroke:none;stroke-width:20.00002098;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:20.00002274, 20.00002274;stroke-dashoffset:1;stroke-opacity:1"
-               id="path1148-9-1-5-93"
-               sodipodi:type="arc"
-               sodipodi:cx="152"
-               sodipodi:cy="156"
-               sodipodi:rx="75"
-               sodipodi:ry="75"
-               sodipodi:start="1.5526524"
-               sodipodi:end="5.703321"
-               d="M 153.36072,230.98766 A 75,75 0 0 1 78.576295,171.29574 75,75 0 0 1 123.30393,86.706885 75,75 0 0 1 214.74028,114.90672 L 152,156 Z" />
-            <path
-               d="m 209.45333,107.79093 a 75,75 0 0 1 5.56361,88.8768 L 152,156 Z"
-               sodipodi:end="0.57309657"
-               sodipodi:start="5.5850536"
-               sodipodi:ry="75"
-               sodipodi:rx="75"
-               sodipodi:cy="156"
-               sodipodi:cx="152"
-               sodipodi:type="arc"
-               id="path1150-3-8-7-4"
-               style="opacity:1;fill:#5884f4;fill-opacity:1;stroke:none;stroke-width:20.00002098;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:20.00002274, 20.00002274;stroke-dashoffset:1;stroke-opacity:1" />
-            <path
-               style="opacity:1;fill:#76c22b;fill-opacity:1;stroke:none;stroke-width:20.00002098;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:20.00002274, 20.00002274;stroke-dashoffset:1;stroke-opacity:1"
-               id="path1152-6-7-3-4"
-               sodipodi:type="arc"
-               sodipodi:cx="152"
-               sodipodi:cy="156"
-               sodipodi:rx="75"
-               sodipodi:ry="75"
-               sodipodi:start="0.9595926"
-               sodipodi:end="1.8325957"
-               d="m 195.03903,217.42184 a 75,75 0 0 1 -62.45046,11.0226 L 152,156 Z" />
-            <path
-               d="M 219.97308,187.69637 A 75,75 0 0 1 189.5,220.95191 L 152,156 Z"
-               sodipodi:end="1.0471976"
-               sodipodi:start="0.43633231"
-               sodipodi:ry="75"
-               sodipodi:rx="75"
-               sodipodi:cy="156"
-               sodipodi:cx="152"
-               sodipodi:type="arc"
-               id="path1154-0-9-8-6"
-               style="opacity:1;fill:#fdc92b;fill-opacity:1;stroke:none;stroke-width:20.00002098;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:20.00002274, 20.00002274;stroke-dashoffset:1;stroke-opacity:1" />
-          </g>
-        </g>
-        <path
-           sodipodi:nodetypes="sssss"
-           inkscape:connector-curvature="0"
-           id="path949-6-3"
-           d="m 152.00017,80.999836 c -41.42135,0 -75.000002,33.578644 -75.000002,75.000004 0,41.42136 33.578652,75 75.000002,75 41.42135,0 75,-33.57864 75,-75 0,-41.42136 -33.57865,-75.000004 -75,-75.000004 z"
-           style="display:inline;opacity:0.2;fill:url(#linearGradient4109);fill-opacity:1;stroke:none;stroke-width:160.00016785;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
-      <g
-         transform="matrix(0.15333316,0,0,0.15333317,308.69334,176.08004)"
-         style="display:inline;stroke-width:6.52174616;enable-background:new"
-         id="g8831-6-60"
-         clip-path="none">
-        <g
-           id="g1160-7-2-0-9"
-           style="display:inline;stroke-width:6.52174616;enable-background:new">
-          <g
-             style="stroke-width:6.52174616"
-             id="g1156-0-6-7-6">
-            <path
-               style="opacity:1;fill:#f76363;fill-opacity:1;stroke:none;stroke-width:13.04349232;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:13.04349273, 13.04349273;stroke-dashoffset:1;stroke-opacity:1"
-               id="path1148-9-1-5-8"
-               sodipodi:type="arc"
-               sodipodi:cx="152"
-               sodipodi:cy="156"
-               sodipodi:rx="75"
-               sodipodi:ry="75"
-               sodipodi:start="1.5526524"
-               sodipodi:end="5.703321"
-               d="M 153.36072,230.98766 A 75,75 0 0 1 78.576295,171.29574 75,75 0 0 1 123.30393,86.706885 75,75 0 0 1 214.74028,114.90672 L 152,156 Z" />
-            <path
-               d="m 209.45333,107.79093 a 75,75 0 0 1 5.56361,88.8768 L 152,156 Z"
-               sodipodi:end="0.57309657"
-               sodipodi:start="5.5850536"
-               sodipodi:ry="75"
-               sodipodi:rx="75"
-               sodipodi:cy="156"
-               sodipodi:cx="152"
-               sodipodi:type="arc"
-               id="path1150-3-8-7-5"
-               style="opacity:1;fill:#5884f4;fill-opacity:1;stroke:none;stroke-width:13.04349232;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:13.04349273, 13.04349273;stroke-dashoffset:1;stroke-opacity:1" />
-            <path
-               style="opacity:1;fill:#76c22b;fill-opacity:1;stroke:none;stroke-width:13.04349232;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:13.04349273, 13.04349273;stroke-dashoffset:1;stroke-opacity:1"
-               id="path1152-6-7-3-48"
-               sodipodi:type="arc"
-               sodipodi:cx="152"
-               sodipodi:cy="156"
-               sodipodi:rx="75"
-               sodipodi:ry="75"
-               sodipodi:start="0.9595926"
-               sodipodi:end="1.8325957"
-               d="m 195.03903,217.42184 a 75,75 0 0 1 -62.45046,11.0226 L 152,156 Z" />
-            <path
-               d="M 219.97308,187.69637 A 75,75 0 0 1 189.5,220.95191 L 152,156 Z"
-               sodipodi:end="1.0471976"
-               sodipodi:start="0.43633231"
-               sodipodi:ry="75"
-               sodipodi:rx="75"
-               sodipodi:cy="156"
-               sodipodi:cx="152"
-               sodipodi:type="arc"
-               id="path1154-0-9-8-65"
-               style="opacity:1;fill:#fdc92b;fill-opacity:1;stroke:none;stroke-width:13.04349232;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:13.04349273, 13.04349273;stroke-dashoffset:1;stroke-opacity:1" />
-          </g>
-        </g>
-        <path
-           sodipodi:nodetypes="sssss"
-           inkscape:connector-curvature="0"
-           id="path949-6-6"
-           d="m 152.00017,80.999836 c -41.42135,0 -75.000002,33.578644 -75.000002,75.000004 0,41.42136 33.578652,75 75.000002,75 41.42135,0 75,-33.57864 75,-75 0,-41.42136 -33.57865,-75.000004 -75,-75.000004 z"
-           style="display:inline;opacity:0.2;fill:url(#linearGradient1205);fill-opacity:1;stroke:none;stroke-width:104.34793854;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
+         d="m 251.02558,60.036659 c -0.75014,-9.04113 -8.30087,-15.99471 -17.37161,-15.99471 H 70.346032 c -9.07074,0 -16.62147,6.95358 -17.37161,15.99471 -2.89691,35.098552 -9.81101,118.743841 -12.915199,156.329691 -0.399744,4.85615 1.248589,9.65802 4.545239,13.24091 3.3016,3.58783 7.95048,5.62604 12.82144,5.62604 H 246.5741 c 4.87096,0 9.51984,-2.03821 12.82144,-5.62604 3.29665,-3.58289 4.94498,-8.38476 4.54524,-13.24091 C 260.83659,178.7805 253.92249,95.135211 251.02558,60.036659 Z"
+         fill="url(#b)"
+         id="path255"
+         style="fill:url(#linearGradient767);stroke-width:4.93512" />
+      <path
+         d="m 362.59449,106.99139 h -37.18897 c -1.93571,0 -3.67582,-1.1969 -3.79541,-3.12755 -0.0963,-1.56681 -0.60909,-6.959435 -0.61011,-6.970584 h 46.00001 c -10e-4,0.01115 -0.51383,5.403774 -0.61011,6.970584 -0.11959,1.93065 -1.8597,3.12755 -3.79541,3.12755 z"
+         fill="url(#a)"
+         fill-rule="nonzero"
+         id="path637"
+         style="fill:url(#linearGradient655);stroke-width:1.01346" />
+      <path
+         d="m 364.33562,64.293242 c -0.15405,-1.856661 -1.70465,-3.284628 -3.56739,-3.284628 h -33.53645 c -1.86274,0 -3.41334,1.427967 -3.56739,3.284628 -0.5949,7.207738 -2.01476,24.384897 -2.65222,32.10342 -0.0821,0.997245 0.2564,1.983343 0.93339,2.719115 0.67801,0.736787 1.63269,1.155343 2.63298,1.155343 h 38.84293 c 1.00029,0 1.95497,-0.418556 2.63298,-1.155343 0.67699,-0.735772 1.01548,-1.72187 0.93339,-2.719115 -0.63746,-7.718523 -2.05732,-24.895682 -2.65222,-32.10342 z"
+         fill="url(#b)"
+         id="path639"
+         style="fill:url(#linearGradient657);stroke-width:1.01346" />
+      <path
+         d="m 348.12684,162.99438 h -24.25367 c -1.26242,0 -2.39728,-0.78058 -2.47527,-2.0397 -0.0628,-1.02183 -0.39723,-4.53876 -0.39789,-4.54604 H 351 c -6.7e-4,0.007 -0.3351,3.52421 -0.39789,4.54604 -0.078,1.25912 -1.21285,2.0397 -2.47527,2.0397 z"
+         fill="url(#a)"
+         fill-rule="nonzero"
+         id="path669"
+         style="fill:url(#linearGradient687);stroke-width:0.660954" />
+      <path
+         d="m 349.26236,135.14777 c -0.10047,-1.21087 -1.11172,-2.14215 -2.32656,-2.14215 h -21.87159 c -1.21484,0 -2.22609,0.93128 -2.32656,2.14215 -0.38798,4.7007 -1.31397,15.90319 -1.72971,20.93701 -0.0535,0.65038 0.16722,1.29348 0.60873,1.77333 0.44218,0.48052 1.0648,0.75349 1.71716,0.75349 h 25.33235 c 0.65236,0 1.27498,-0.27297 1.71716,-0.75349 0.44151,-0.47985 0.66227,-1.12295 0.60873,-1.77333 -0.41574,-5.03382 -1.34173,-16.23631 -1.72971,-20.93701 z"
+         fill="url(#b)"
+         id="path671"
+         style="fill:url(#linearGradient689);stroke-width:0.660954" />
+      <path
+         d="m 341.29724,211.4957 h -18.59448 c -0.96786,0 -1.83792,-0.59845 -1.89771,-1.56377 -0.0481,-0.78341 -0.30455,-3.47972 -0.30505,-3.4853 h 23 c -5.2e-4,0.006 -0.25692,2.70189 -0.30506,3.4853 -0.0598,0.96532 -0.92985,1.56377 -1.8977,1.56377 z"
+         fill="url(#a)"
+         fill-rule="nonzero"
+         id="path701"
+         style="fill:url(#linearGradient719);stroke-width:0.506731" />
+      <path
+         d="m 342.1678,190.14663 c -0.077,-0.92833 -0.85232,-1.64232 -1.78369,-1.64232 h -16.76823 c -0.93137,0 -1.70666,0.71399 -1.78369,1.64232 -0.29745,3.60387 -1.00738,12.19244 -1.32611,16.05171 -0.041,0.49862 0.1282,0.99167 0.4667,1.35955 0.339,0.3684 0.81634,0.57768 1.31648,0.57768 h 19.42147 c 0.50014,0 0.97748,-0.20928 1.31649,-0.57768 0.33849,-0.36788 0.50774,-0.86093 0.4667,-1.35955 -0.31874,-3.85927 -1.02867,-12.44784 -1.32612,-16.05171 z"
+         fill="url(#b)"
+         id="path703"
+         style="fill:url(#linearGradient721);stroke-width:0.506731" />
+      <path
+         d="m 334.06342,251.49719 h -12.12684 c -0.63121,0 -1.19864,-0.3903 -1.23764,-1.01985 -0.0314,-0.51092 -0.19861,-2.26939 -0.19894,-2.27302 h 15 c -3.4e-4,0.004 -0.16755,1.7621 -0.19895,2.27302 -0.039,0.62955 -0.60642,1.01985 -1.23763,1.01985 z"
+         fill="url(#a)"
+         fill-rule="nonzero"
+         id="path733"
+         style="fill:url(#linearGradient751);stroke-width:0.330477" />
+      <path
+         d="m 334.63118,237.57388 c -0.0502,-0.60543 -0.55587,-1.07108 -1.16328,-1.07108 h -10.9358 c -0.60742,0 -1.11305,0.46565 -1.16328,1.07108 -0.19399,2.35035 -0.65699,7.9516 -0.86486,10.46851 -0.0268,0.32518 0.0836,0.64674 0.30437,0.88666 0.22109,0.24026 0.5324,0.37675 0.85858,0.37675 h 12.66618 c 0.32618,0 0.63748,-0.13649 0.85857,-0.37675 0.22076,-0.23992 0.33114,-0.56148 0.30437,-0.88666 -0.20787,-2.51691 -0.67086,-8.11816 -0.86485,-10.46851 z"
+         fill="url(#b)"
+         id="path735"
+         style="fill:url(#linearGradient753);stroke-width:0.330477" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms and folds"
-       style="display:inline" />
-    <g
-       inkscape:groupmode="layer"
-       id="layer2"
-       inkscape:label="Borders"
+       inkscape:label="Pictogram"
        style="display:inline">
+      <path
+         d="m 198.84659,253.02933 c 0,-0.81923 -0.32571,-1.60885 -0.90806,-2.1912 -0.58234,-0.5774 -1.37196,-0.90806 -2.19119,-0.90806 h -86.80376 c -0.82417,0 -1.61379,0.33066 -2.1912,0.90806 -0.58234,0.58235 -0.90806,1.37197 -0.90806,2.1912 v 0.0395 c 0,0.82416 0.32572,1.61378 0.90806,2.19119 0.57741,0.58234 1.36703,0.90806 2.1912,0.90806 h 86.80376 c 0.81923,0 1.60885,-0.32572 2.19119,-0.90806 0.58235,-0.57741 0.90806,-1.36703 0.90806,-2.19119 z"
+         fill="url(#c)"
+         id="path257"
+         style="display:inline;enable-background:new;fill:url(#linearGradient769);stroke-width:4.93512" />
       <circle
-         style="display:inline;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path1377"
-         cx="328.00003"
-         cy="244.00002"
-         r="7.5000005" />
-      <ellipse
-         style="display:inline;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path1384"
-         cx="332"
-         cy="199.97676"
-         rx="11.454546"
-         ry="11.476745" />
+         cx="218.97197"
+         cy="251.97815"
+         fill="url(#d)"
+         id="circle259"
+         style="display:inline;enable-background:new;fill:url(#linearGradient771);stroke-width:4.93512"
+         r="8.6117783" />
+      <path
+         d="m 222.80658,250.28047 c -0.30104,-0.60209 -0.72546,-1.10547 -1.26832,-1.51015 -0.15793,-0.12338 -0.33559,-0.16779 -0.53299,-0.14312 -0.19741,0.0247 -0.35533,0.11844 -0.47378,0.2813 -0.11844,0.15793 -0.16285,0.33066 -0.13324,0.52806 0.0247,0.19741 0.11844,0.35533 0.27636,0.47377 0.3652,0.27637 0.6465,0.61689 0.84884,1.01664 0.19741,0.39974 0.30104,0.82416 0.30104,1.27819 0,0.38988 -0.079,0.76001 -0.22701,1.1104 -0.15299,0.35533 -0.35533,0.66131 -0.61689,0.91793 -0.25663,0.25663 -0.5626,0.46391 -0.913,0.61196 -0.35532,0.15299 -0.72546,0.22701 -1.11533,0.22701 -0.38988,0 -0.76001,-0.074 -1.1104,-0.22701 -0.35533,-0.14805 -0.66131,-0.35533 -0.91794,-0.61196 -0.25662,-0.25662 -0.4639,-0.5626 -0.61195,-0.91793 -0.15299,-0.35039 -0.22702,-0.72052 -0.22702,-1.1104 0,-0.45403 0.0987,-0.87845 0.29611,-1.27819 0.20234,-0.39975 0.48364,-0.74027 0.84884,-1.01664 0.15793,-0.11844 0.25169,-0.27636 0.2813,-0.47377 0.0247,-0.19247 -0.0197,-0.37013 -0.13818,-0.52806 -0.11844,-0.16286 -0.27143,-0.25662 -0.46884,-0.2813 -0.1974,-0.0247 -0.37507,0.0197 -0.53792,0.14312 -0.54287,0.40468 -0.96729,0.90806 -1.26833,1.51015 -0.30104,0.60208 -0.44909,1.24365 -0.44909,1.92469 0,0.58235 0.1135,1.14001 0.34052,1.66807 0.22701,0.53299 0.53299,0.99196 0.91793,1.3769 0.38494,0.38494 0.84391,0.69091 1.3769,0.91793 0.52806,0.22702 1.08572,0.34052 1.66807,0.34052 0.58234,0 1.14001,-0.1135 1.673,-0.34052 0.52806,-0.22702 0.98702,-0.53299 1.37196,-0.91793 0.38494,-0.38494 0.69092,-0.84391 0.91794,-1.3769 0.22701,-0.52806 0.34052,-1.08572 0.34052,-1.66807 0,-0.68104 -0.14805,-1.32261 -0.4491,-1.92469 z m -3.85432,1.92469 c 0.19247,0 0.3652,-0.074 0.50338,-0.21221 0.14312,-0.14312 0.21714,-0.31091 0.21714,-0.50832 v -3.58783 c 0,-0.19246 -0.074,-0.36026 -0.21714,-0.50338 -0.13818,-0.14312 -0.31091,-0.21221 -0.50338,-0.21221 -0.19247,0 -0.36027,0.0691 -0.50338,0.21221 -0.14312,0.14312 -0.21221,0.31092 -0.21221,0.50338 v 3.58783 c 0,0.19741 0.0691,0.3652 0.21221,0.50832 0.14311,0.13818 0.31091,0.21221 0.50338,0.21221 z"
+         fill="#e3e8ea"
+         id="path261"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:4.93512" />
+      <path
+         d="m 227.83053,126.51268 -30.89383,3.94316 c 0.0592,0.68104 0.14806,1.35222 0.14806,2.04314 -0.01,17.76642 -19.89346,32.16709 -44.41605,32.16709 -3.89874,0 -7.6593,-0.39975 -11.26194,-1.08079 l -11.22739,22.26724 c 11.10895,2.44782 23.16544,3.22757 35.38479,1.66807 40.06327,-5.11278 67.14719,-32.13748 62.26636,-61.00791 z m -39.96951,5.11278 -20.32281,2.59094 c -1.1252,5.11278 -7.1954,9.04113 -14.57339,9.04113 -0.42936,0 -0.83404,-0.0691 -1.25352,-0.0987 l -6.70683,13.30507 c 2.67977,0.47871 5.46318,0.76988 8.34528,0.76988 19.07916,0 34.54088,-11.19284 34.54582,-25.01117 0,-0.20234 -0.0296,-0.39974 -0.0345,-0.59715 z"
+         fill="url(#e)"
+         id="path263"
+         style="display:inline;enable-background:new;fill:url(#linearGradient773);fill-rule:nonzero;stroke-width:4.93512" />
+      <path
+         d="m 122.51515,82.550659 c -20.25866,6.24293 -35.587128,18.556041 -42.397588,33.272561 -3.89874,8.42424 -4.9746,17.6381 -2.68964,27.00002 4.63408,19.02981 22.351146,33.88945 45.205668,40.95653 l 11.16323,-22.19815 c -15.07678,-5.14239 -25.54416,-16.21186 -25.54416,-29.08264 -0.005,-12.68325 10.1466,-23.62441 24.86805,-28.8655 z m 13.99599,27.819251 c -10.56115,4.28369 -17.7072,12.45624 -17.7072,21.8527 0.005,9.64322 7.55566,18.00331 18.59552,22.17841 l 6.69695,-13.31988 c -3.58289,-1.95924 -5.93201,-5.04862 -5.93694,-8.55255 0,-3.31147 2.11716,-6.23305 5.3694,-8.20217 z"
+         fill="url(#f)"
+         id="path265"
+         style="display:inline;enable-background:new;fill:url(#linearGradient775);fill-rule:nonzero;stroke-width:4.93512" />
+      <path
+         d="m 154.03574,78.118929 c -4.89564,-0.074 -9.87517,0.18753 -14.88432,0.8291 -3.09431,0.39481 -5.97642,1.04624 -8.91282,1.69274 l 10.50687,20.880481 c 3.7951,-0.76494 7.78761,-1.20417 11.92324,-1.20417 20.79164,0 38.1978,10.36375 43.03421,24.33506 l 30.83461,-3.94809 C 218.6068,95.905091 188.31999,78.627249 154.03574,78.118929 Z m -0.68599,29.067831 c -3.21769,0 -6.32188,0.3504 -9.27801,0.94755 l 6.94864,13.81339 c 0.64156,-0.0642 1.27819,-0.14806 1.94444,-0.14806 6.14422,0 11.40998,2.71432 13.65053,6.57358 l 20.09579,-2.5712 c -3.91355,-10.7092 -17.34693,-18.61526 -33.36139,-18.61526 z"
+         fill="url(#g)"
+         id="path267"
+         style="display:inline;enable-background:new;fill:url(#linearGradient777);fill-rule:nonzero;stroke-width:4.93512" />
+      <path
+         d="m 353.62029,103.92567 c 0,-0.16824 -0.0669,-0.33039 -0.18648,-0.44998 -0.11959,-0.11857 -0.28174,-0.18648 -0.44998,-0.18648 h -17.82577 c -0.16925,0 -0.3314,0.0679 -0.44998,0.18648 -0.11959,0.11959 -0.18647,0.28174 -0.18647,0.44998 v 0.008 c 0,0.16925 0.0669,0.3314 0.18647,0.44997 0.11858,0.11959 0.28073,0.18648 0.44998,0.18648 h 17.82577 c 0.16824,0 0.33039,-0.0669 0.44998,-0.18648 0.11959,-0.11857 0.18648,-0.28072 0.18648,-0.44997 z"
+         fill="url(#c)"
+         id="path641"
+         style="display:inline;enable-background:new;fill:url(#linearGradient659);stroke-width:1.01346" />
       <circle
-         style="display:inline;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path1389"
-         cx="336"
-         cy="148"
-         r="14.5" />
+         cx="357.75317"
+         cy="103.7098"
+         fill="url(#d)"
+         id="circle643"
+         style="display:inline;enable-background:new;fill:url(#linearGradient661);stroke-width:1.01346"
+         r="1.7684902" />
+      <path
+         d="m 358.54064,103.36117 c -0.0618,-0.12364 -0.14898,-0.22702 -0.26046,-0.31012 -0.0324,-0.0253 -0.0689,-0.0345 -0.10945,-0.0294 -0.0405,0.005 -0.073,0.0243 -0.0973,0.0578 -0.0243,0.0324 -0.0335,0.0679 -0.0274,0.10845 0.005,0.0405 0.0243,0.073 0.0568,0.0973 0.075,0.0567 0.13276,0.12668 0.17431,0.20877 0.0405,0.0821 0.0618,0.16925 0.0618,0.26249 0,0.0801 -0.0162,0.15607 -0.0466,0.22803 -0.0314,0.073 -0.073,0.1358 -0.12668,0.1885 -0.0527,0.0527 -0.11553,0.0953 -0.18749,0.12567 -0.073,0.0314 -0.14898,0.0466 -0.22904,0.0466 -0.0801,0 -0.15607,-0.0152 -0.22803,-0.0466 -0.073,-0.0304 -0.1358,-0.073 -0.1885,-0.12567 -0.0527,-0.0527 -0.0953,-0.11553 -0.12567,-0.1885 -0.0314,-0.072 -0.0466,-0.14797 -0.0466,-0.22803 0,-0.0932 0.0203,-0.1804 0.0608,-0.26249 0.0416,-0.0821 0.0993,-0.15202 0.17431,-0.20877 0.0324,-0.0243 0.0517,-0.0568 0.0578,-0.0973 0.005,-0.0395 -0.004,-0.076 -0.0284,-0.10845 -0.0243,-0.0334 -0.0557,-0.0527 -0.0963,-0.0578 -0.0405,-0.005 -0.077,0.004 -0.11046,0.0294 -0.11149,0.0831 -0.19864,0.18648 -0.26046,0.31012 -0.0618,0.12364 -0.0922,0.25539 -0.0922,0.39525 0,0.11959 0.0233,0.23411 0.0699,0.34255 0.0466,0.10945 0.10945,0.2037 0.1885,0.28275 0.079,0.079 0.17331,0.14189 0.28276,0.18851 0.10844,0.0466 0.22296,0.0699 0.34255,0.0699 0.11959,0 0.23411,-0.0233 0.34356,-0.0699 0.10844,-0.0466 0.20269,-0.10946 0.28174,-0.18851 0.079,-0.079 0.14189,-0.1733 0.18851,-0.28275 0.0466,-0.10844 0.0699,-0.22296 0.0699,-0.34255 0,-0.13986 -0.0304,-0.27161 -0.0922,-0.39525 z m -0.79151,0.39525 c 0.0395,0 0.075,-0.0152 0.10337,-0.0436 0.0294,-0.0294 0.0446,-0.0639 0.0446,-0.10439 v -0.73678 c 0,-0.0395 -0.0152,-0.074 -0.0446,-0.10338 -0.0284,-0.0294 -0.0639,-0.0436 -0.10337,-0.0436 -0.0395,0 -0.074,0.0142 -0.10337,0.0436 -0.0294,0.0294 -0.0436,0.0639 -0.0436,0.10338 v 0.73678 c 0,0.0405 0.0142,0.075 0.0436,0.10439 0.0294,0.0284 0.0638,0.0436 0.10337,0.0436 z"
+         fill="#e3e8ea"
+         id="path645"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:1.01346" />
+      <path
+         d="m 359.57235,77.944568 -6.34427,0.809756 c 0.0122,0.139857 0.0304,0.277688 0.0304,0.419574 -0.002,3.648461 -4.08526,6.605742 -9.12115,6.605742 -0.80064,0 -1.57289,-0.08209 -2.31272,-0.221948 l -2.30563,4.572737 c 2.28131,0.502677 4.75719,0.662804 7.26652,0.34255 8.22728,-1.049946 13.78916,-6.599662 12.78685,-12.528411 z m -8.20803,1.049946 -4.17343,0.532068 c -0.23107,1.049946 -1.47763,1.856661 -2.99275,1.856661 -0.0882,0 -0.17128,-0.01419 -0.25742,-0.02027 l -1.3773,2.732291 c 0.55031,0.09831 1.12191,0.158101 1.71377,0.158101 3.91804,0 7.09321,-2.29853 7.09423,-5.136223 0,-0.04155 -0.006,-0.08209 -0.007,-0.122629 z"
+         fill="url(#e)"
+         id="path647"
+         style="display:inline;enable-background:new;fill:url(#linearGradient663);fill-rule:nonzero;stroke-width:1.01346" />
+      <path
+         d="m 337.94508,68.916653 c -4.16026,1.28203 -7.30807,3.810616 -8.70665,6.832758 -0.80063,1.729978 -1.02157,3.62211 -0.55233,5.544647 0.95164,3.907908 4.58996,6.959441 9.2833,8.410717 l 2.29245,-4.558549 c -3.09612,-1.056027 -5.24567,-3.329222 -5.24567,-5.972328 -0.001,-2.604596 2.08367,-4.851442 5.10683,-5.927737 z m 2.87418,5.712882 c -2.16881,0.879686 -3.6363,2.557978 -3.6363,4.487608 0.001,1.980304 1.55161,3.697109 3.81872,4.554495 l 1.37527,-2.735332 c -0.73578,-0.402344 -1.21818,-1.036771 -1.2192,-1.756328 0,-0.680034 0.43478,-1.280001 1.10265,-1.684374 z"
+         fill="url(#f)"
+         id="path649"
+         style="display:inline;enable-background:new;fill:url(#linearGradient665);fill-rule:nonzero;stroke-width:1.01346" />
+      <path
+         d="m 344.41806,68.006565 c -1.00536,-0.0152 -2.02794,0.03851 -3.0566,0.170262 -0.63544,0.08108 -1.2273,0.214853 -1.83031,0.347616 l 2.15766,4.287956 c 0.77935,-0.157086 1.59924,-0.247285 2.44852,-0.247285 4.26971,0 7.84419,2.128271 8.83738,4.997379 l 6.33211,-0.810769 c -1.62863,-5.092643 -7.84825,-8.640772 -14.88876,-8.745159 z m -0.14087,5.969287 c -0.66078,0 -1.29825,0.07196 -1.90531,0.194586 l 1.42695,2.836679 c 0.13175,-0.01318 0.26249,-0.0304 0.39931,-0.0304 1.26176,0 2.34312,0.557405 2.80323,1.349931 l 4.12682,-0.528014 c -0.80368,-2.199211 -3.56232,-3.822777 -6.851,-3.822777 z"
+         fill="url(#g)"
+         id="path651"
+         style="display:inline;enable-background:new;fill:url(#linearGradient667);fill-rule:nonzero;stroke-width:1.01346" />
+      <path
+         d="m 342.2741,160.995 c 0,-0.10972 -0.0436,-0.21547 -0.12161,-0.29347 -0.078,-0.0773 -0.18375,-0.12161 -0.29347,-0.12161 h -11.6255 c -0.11038,0 -0.21613,0.0443 -0.29346,0.12161 -0.078,0.078 -0.12162,0.18375 -0.12162,0.29347 V 161 c 0,0.11038 0.0436,0.21613 0.12162,0.29346 0.0773,0.078 0.18308,0.12162 0.29346,0.12162 h 11.6255 c 0.10972,0 0.21547,-0.0436 0.29347,-0.12162 0.078,-0.0773 0.12161,-0.18308 0.12161,-0.29346 z"
+         fill="url(#c)"
+         id="path673"
+         style="display:inline;enable-background:new;fill:url(#linearGradient691);stroke-width:0.660954" />
       <circle
-         style="display:inline;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path1389-3"
-         cx="344"
-         cy="84"
-         r="22.5" />
+         cx="344.96945"
+         cy="160.85422"
+         fill="url(#d)"
+         id="circle675"
+         style="display:inline;enable-background:new;fill:url(#linearGradient693);stroke-width:0.660954"
+         r="1.1533631" />
       <path
-         inkscape:connector-curvature="0"
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 152,267.99999 a 112,112 0 0 1 -112,-112 112,112 0 0 1 0.04102,-1.16992 A 112,112 0 0 0 152,265.99999 112,112 0 0 0 263.95898,155.16991 a 112,112 0 0 1 0.041,0.83008 112,112 0 0 1 -112,112 z"
-         id="path11042-1-7" />
+         d="m 345.48303,160.62685 c -0.0403,-0.0806 -0.0972,-0.14806 -0.16987,-0.20225 -0.0211,-0.0165 -0.0449,-0.0225 -0.0714,-0.0192 -0.0264,0.003 -0.0476,0.0159 -0.0634,0.0377 -0.0159,0.0212 -0.0218,0.0443 -0.0179,0.0707 0.003,0.0264 0.0159,0.0476 0.037,0.0635 0.0489,0.037 0.0866,0.0826 0.11368,0.13615 0.0264,0.0535 0.0403,0.11038 0.0403,0.17119 0,0.0522 -0.0106,0.10179 -0.0304,0.14871 -0.0205,0.0476 -0.0476,0.0886 -0.0826,0.12294 -0.0344,0.0344 -0.0753,0.0621 -0.12228,0.082 -0.0476,0.0205 -0.0972,0.0304 -0.14937,0.0304 -0.0522,0 -0.10179,-0.01 -0.14872,-0.0304 -0.0476,-0.0198 -0.0886,-0.0476 -0.12294,-0.082 -0.0344,-0.0344 -0.0621,-0.0754 -0.082,-0.12294 -0.0205,-0.0469 -0.0304,-0.0965 -0.0304,-0.14871 0,-0.0608 0.0132,-0.11765 0.0397,-0.17119 0.0271,-0.0535 0.0648,-0.0991 0.11368,-0.13615 0.0211,-0.0159 0.0337,-0.037 0.0377,-0.0635 0.003,-0.0258 -0.003,-0.0496 -0.0185,-0.0707 -0.0159,-0.0218 -0.0363,-0.0344 -0.0628,-0.0377 -0.0264,-0.003 -0.0502,0.003 -0.072,0.0192 -0.0727,0.0542 -0.12955,0.12161 -0.16987,0.20225 -0.0403,0.0806 -0.0602,0.16656 -0.0602,0.25777 0,0.078 0.0152,0.15268 0.0456,0.2234 0.0304,0.0714 0.0714,0.13285 0.12294,0.18441 0.0516,0.0515 0.11302,0.0925 0.1844,0.12293 0.0707,0.0304 0.14541,0.0456 0.22341,0.0456 0.078,0 0.15267,-0.0152 0.22406,-0.0456 0.0707,-0.0304 0.13219,-0.0714 0.18374,-0.12293 0.0516,-0.0516 0.0925,-0.11303 0.12294,-0.18441 0.0304,-0.0707 0.0456,-0.14541 0.0456,-0.2234 0,-0.0912 -0.0198,-0.17714 -0.0602,-0.25777 z m -0.5162,0.25777 c 0.0258,0 0.0489,-0.01 0.0674,-0.0284 0.0192,-0.0192 0.0291,-0.0416 0.0291,-0.0681 v -0.48051 c 0,-0.0258 -0.01,-0.0483 -0.0291,-0.0674 -0.0185,-0.0192 -0.0416,-0.0284 -0.0674,-0.0284 -0.0258,0 -0.0483,0.009 -0.0674,0.0284 -0.0192,0.0192 -0.0284,0.0416 -0.0284,0.0674 v 0.48051 c 0,0.0264 0.009,0.0489 0.0284,0.0681 0.0192,0.0185 0.0416,0.0284 0.0674,0.0284 z"
+         fill="#e3e8ea"
+         id="path677"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.660954" />
       <path
-         style="display:inline;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="M 152,43.999994 A 112,112 0 0 0 40,155.99999 112,112 0 0 0 40.04102,157.16991 112,112 0 0 1 152,45.999994 112,112 0 0 1 263.95898,156.83007 a 112,112 0 0 0 0.041,-0.83008 112,112 0 0 0 -112,-111.999996 z"
-         id="path11042-1"
-         inkscape:connector-curvature="0" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline;opacity:0.8">
+         d="m 346.15588,144.05081 -4.13757,0.5281 c 0.008,0.0912 0.0198,0.1811 0.0198,0.27363 -0.001,2.37943 -2.6643,4.30809 -5.94858,4.30809 -0.52215,0 -1.0258,-0.0535 -1.50829,-0.14474 l -1.50367,2.98222 c 1.48781,0.32783 3.10251,0.43226 4.73903,0.2234 5.36562,-0.68475 8.99293,-4.30413 8.33925,-8.1707 z m -5.35306,0.68474 -2.72181,0.347 c -0.15069,0.68475 -0.96366,1.21087 -1.95179,1.21087 -0.0575,0 -0.1117,-0.009 -0.16788,-0.0132 l -0.89824,1.78193 c 0.3589,0.0641 0.73168,0.10311 1.11767,0.10311 2.55525,0 4.62602,-1.49904 4.62668,-3.34971 0,-0.0271 -0.004,-0.0535 -0.005,-0.08 z"
+         fill="url(#e)"
+         id="path679"
+         style="display:inline;enable-background:new;fill:url(#linearGradient695);fill-rule:nonzero;stroke-width:0.660954" />
       <path
-         style="display:inline;opacity:1;fill:url(#linearGradient8590);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="M 344,62.000016 A 22,21.99999 0 0 0 322,84.000013 22,21.99999 0 0 0 344,106 22,21.99999 0 0 0 366,84.000013 22,21.99999 0 0 0 344,62.000016 Z m 0,0.956532 A 21.043478,21.043469 0 0 1 365.04348,84.000013 21.043478,21.043469 0 0 1 344,105.04348 21.043478,21.043469 0 0 1 322.95652,84.000013 21.043478,21.043469 0 0 1 344,62.956548 Z"
-         id="path9498-1-6"
-         inkscape:connector-curvature="0" />
+         d="m 332.05114,138.16303 c -2.71321,0.83611 -4.76613,2.48519 -5.67825,4.45615 -0.52215,1.12825 -0.66624,2.36225 -0.36022,3.61608 0.62064,2.54863 2.99346,4.53876 6.05433,5.48524 l 1.49508,-2.97296 c -2.01921,-0.68871 -3.42109,-2.17123 -3.42109,-3.895 -6.7e-4,-1.69865 1.35892,-3.16398 3.33054,-3.86591 z m 1.87446,3.7258 c -1.41444,0.57371 -2.3715,1.66824 -2.3715,2.9267 6.7e-4,1.2915 1.01192,2.41116 2.49048,2.97032 l 0.89691,-1.78391 c -0.47985,-0.2624 -0.79447,-0.67616 -0.79513,-1.14543 0,-0.4435 0.28355,-0.83479 0.71912,-1.09851 z"
+         fill="url(#f)"
+         id="path681"
+         style="display:inline;enable-background:new;fill:url(#linearGradient697);fill-rule:nonzero;stroke-width:0.660954" />
       <path
-         style="display:inline;opacity:1;fill:url(#linearGradient8590-3);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 336,134 c -7.73199,0 -14,6.26802 -14,14 0,7.73198 6.26801,14 14,14 7.73199,0 14,-6.26802 14,-14 0,-7.73198 -6.26801,-14 -14,-14 z m 0,1 a 13,13 0 0 1 13,13 13,13 0 0 1 -13,13 13,13 0 0 1 -13,-13 13,13 0 0 1 13,-13 z"
-         id="path9498-1-6-7"
-         inkscape:connector-curvature="0" />
+         d="m 336.27265,137.5695 c -0.65567,-0.01 -1.32257,0.0251 -1.99344,0.11104 -0.41441,0.0529 -0.80041,0.14012 -1.19368,0.22671 l 1.40717,2.79649 c 0.50827,-0.10245 1.04298,-0.16127 1.59686,-0.16127 2.7846,0 5.11578,1.388 5.76351,3.25916 l 4.12964,-0.52877 c -1.06215,-3.32129 -5.11842,-5.63528 -9.71006,-5.70336 z m -0.0919,3.89301 c -0.43094,0 -0.84668,0.0469 -1.24259,0.12691 l 0.93063,1.85 c 0.0859,-0.009 0.17118,-0.0198 0.26041,-0.0198 0.82289,0 1.52812,0.36353 1.8282,0.88039 l 2.6914,-0.34435 c -0.52414,-1.43427 -2.32325,-2.49312 -4.46805,-2.49312 z"
+         fill="url(#g)"
+         id="path683"
+         style="display:inline;enable-background:new;fill:url(#linearGradient699);fill-rule:nonzero;stroke-width:0.660954" />
       <path
-         style="display:inline;opacity:1;fill:url(#linearGradient8590-3-3);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 332,189 c -6.07513,0 -11,4.92488 -11,11 0,6.07513 4.92487,11 11,11 6.07513,0 11,-4.92487 11,-11 0,-6.07512 -4.92487,-11 -11,-11 z m 0,1 a 10,10 0 0 1 10,10 10,10 0 0 1 -10,10 10,10 0 0 1 -10,-10 10,10 0 0 1 10,-10 z"
-         id="path9498-1-6-7-2"
-         inkscape:connector-curvature="0" />
+         d="m 336.81014,209.96284 c 0,-0.0841 -0.0335,-0.1652 -0.0932,-0.22499 -0.0598,-0.0593 -0.14087,-0.0932 -0.22499,-0.0932 h -8.91289 c -0.0846,0 -0.1657,0.034 -0.22498,0.0932 -0.0598,0.0598 -0.0932,0.14087 -0.0932,0.22499 v 0.004 c 0,0.0846 0.0334,0.1657 0.0932,0.22499 0.0593,0.0598 0.14036,0.0932 0.22498,0.0932 h 8.91289 c 0.0841,0 0.1652,-0.0334 0.22499,-0.0932 0.0598,-0.0593 0.0932,-0.14036 0.0932,-0.22499 z"
+         fill="url(#c)"
+         id="path705"
+         style="display:inline;enable-background:new;fill:url(#linearGradient723);stroke-width:0.506731" />
+      <circle
+         cx="338.87659"
+         cy="209.8549"
+         fill="url(#d)"
+         id="circle707"
+         style="display:inline;enable-background:new;fill:url(#linearGradient725);stroke-width:0.506731"
+         r="0.8842451" />
       <path
-         style="display:inline;opacity:1;fill:url(#linearGradient8590-3-3-4);fill-opacity:1;stroke:none;stroke-width:1.86940372;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 328,237 c -3.86599,0 -7,3.13402 -7,7 0,3.86599 3.13401,7 7,7 3.866,0 7,-3.13401 7,-7 0,-3.86598 -3.134,-7 -7,-7 z m 0,1 a 6,6 0 0 1 6,6 6,6 0 0 1 -6,6 6,6 0 0 1 -6,-6 6,6 0 0 1 6,-6 z"
-         id="path9498-1-6-7-2-0"
-         inkscape:connector-curvature="0" />
+         d="m 339.27031,209.68059 c -0.0309,-0.0618 -0.0745,-0.11351 -0.13022,-0.15506 -0.0162,-0.0127 -0.0345,-0.0172 -0.0547,-0.0147 -0.0203,0.003 -0.0365,0.0122 -0.0486,0.0289 -0.0122,0.0162 -0.0167,0.034 -0.0137,0.0542 0.003,0.0203 0.0122,0.0365 0.0284,0.0486 0.0375,0.0284 0.0664,0.0633 0.0872,0.10439 0.0203,0.041 0.0309,0.0846 0.0309,0.13124 0,0.04 -0.008,0.078 -0.0233,0.11402 -0.0157,0.0365 -0.0365,0.0679 -0.0633,0.0942 -0.0264,0.0264 -0.0578,0.0476 -0.0937,0.0628 -0.0365,0.0157 -0.0745,0.0233 -0.11452,0.0233 -0.04,0 -0.078,-0.008 -0.11402,-0.0233 -0.0365,-0.0152 -0.0679,-0.0365 -0.0942,-0.0628 -0.0263,-0.0264 -0.0476,-0.0578 -0.0628,-0.0942 -0.0157,-0.036 -0.0233,-0.074 -0.0233,-0.11402 0,-0.0466 0.0101,-0.0902 0.0304,-0.13124 0.0208,-0.0411 0.0497,-0.076 0.0872,-0.10439 0.0162,-0.0122 0.0258,-0.0284 0.0289,-0.0486 0.003,-0.0198 -0.002,-0.038 -0.0142,-0.0542 -0.0122,-0.0167 -0.0279,-0.0263 -0.0481,-0.0289 -0.0203,-0.003 -0.0385,0.002 -0.0552,0.0147 -0.0557,0.0416 -0.0993,0.0932 -0.13023,0.15506 -0.0309,0.0618 -0.0461,0.12769 -0.0461,0.19762 0,0.0598 0.0117,0.11706 0.035,0.17128 0.0233,0.0547 0.0547,0.10185 0.0943,0.14138 0.0395,0.0395 0.0866,0.0709 0.14137,0.0943 0.0542,0.0233 0.11148,0.035 0.17128,0.035 0.0598,0 0.11705,-0.0117 0.17178,-0.035 0.0542,-0.0233 0.10135,-0.0547 0.14087,-0.0943 0.0395,-0.0395 0.0709,-0.0867 0.0942,-0.14138 0.0233,-0.0542 0.035,-0.11148 0.035,-0.17128 0,-0.0699 -0.0152,-0.1358 -0.0461,-0.19762 z m -0.39575,0.19762 c 0.0198,0 0.0375,-0.008 0.0517,-0.0218 0.0147,-0.0147 0.0223,-0.0319 0.0223,-0.0522 v -0.36839 c 0,-0.0198 -0.008,-0.037 -0.0223,-0.0517 -0.0142,-0.0147 -0.0319,-0.0218 -0.0517,-0.0218 -0.0198,0 -0.037,0.007 -0.0517,0.0218 -0.0147,0.0147 -0.0218,0.0319 -0.0218,0.0517 v 0.36839 c 0,0.0203 0.007,0.0375 0.0218,0.0522 0.0147,0.0142 0.0319,0.0218 0.0517,0.0218 z"
+         fill="#e3e8ea"
+         id="path709"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.506731" />
+      <path
+         d="m 339.78617,196.97229 -3.17214,0.40488 c 0.006,0.0699 0.0152,0.13884 0.0152,0.20978 -0.001,1.82423 -2.04264,3.30287 -4.56058,3.30287 -0.40032,0 -0.78645,-0.041 -1.15636,-0.11097 l -1.15281,2.28637 c 1.14065,0.25134 2.37859,0.3314 3.63326,0.17127 4.11364,-0.52497 6.89457,-3.29983 6.39342,-6.2642 z m -4.10402,0.52497 -2.08671,0.26604 c -0.11554,0.52497 -0.73882,0.92833 -1.49638,0.92833 -0.0441,0 -0.0856,-0.007 -0.12871,-0.0101 l -0.68864,1.36615 c 0.27515,0.0491 0.56095,0.079 0.85688,0.079 1.95902,0 3.54661,-1.14927 3.54711,-2.56811 0,-0.0208 -0.003,-0.0411 -0.004,-0.0613 z"
+         fill="url(#e)"
+         id="path711"
+         style="display:inline;enable-background:new;fill:url(#linearGradient727);fill-rule:nonzero;stroke-width:0.506731" />
+      <path
+         d="m 328.97253,192.45833 c -2.08013,0.64102 -3.65403,1.90531 -4.35332,3.41638 -0.40032,0.86499 -0.51078,1.81106 -0.27617,2.77232 0.47582,1.95396 2.29499,3.47972 4.64166,4.20536 l 1.14622,-2.27927 c -1.54806,-0.52802 -2.62284,-1.66461 -2.62284,-2.98617 -5.1e-4,-1.30229 1.04184,-2.42572 2.55342,-2.96386 z m 1.43709,2.85644 c -1.0844,0.43985 -1.81815,1.27899 -1.81815,2.24381 5.2e-4,0.99015 0.77581,1.84855 1.90936,2.27724 l 0.68764,-1.36766 c -0.36789,-0.20117 -0.60909,-0.51839 -0.6096,-0.87817 0,-0.34001 0.21739,-0.64 0.55132,-0.84218 z"
+         fill="url(#f)"
+         id="path713"
+         style="display:inline;enable-background:new;fill:url(#linearGradient729);fill-rule:nonzero;stroke-width:0.506731" />
+      <path
+         d="m 332.20902,192.00329 c -0.50267,-0.008 -1.01396,0.0192 -1.5283,0.0851 -0.31772,0.0405 -0.61365,0.10742 -0.91515,0.17381 l 1.07883,2.14397 c 0.38967,-0.0785 0.79962,-0.12364 1.22426,-0.12364 2.13485,0 3.92209,1.06414 4.41869,2.49869 l 3.16605,-0.40538 c -0.81431,-2.54632 -3.92412,-4.32039 -7.44438,-4.37258 z m -0.0704,2.98464 c -0.33039,0 -0.64912,0.036 -0.95266,0.0973 l 0.71348,1.41834 c 0.0659,-0.007 0.13124,-0.0152 0.19965,-0.0152 0.63088,0 1.17156,0.2787 1.40162,0.67497 l 2.06341,-0.26401 c -0.40184,-1.09961 -1.78116,-1.91139 -3.4255,-1.91139 z"
+         fill="url(#g)"
+         id="path715"
+         style="display:inline;enable-background:new;fill:url(#linearGradient731);fill-rule:nonzero;stroke-width:0.506731" />
+      <path
+         d="m 331.13705,250.4975 c 0,-0.0549 -0.0218,-0.10774 -0.0608,-0.14674 -0.039,-0.0387 -0.0919,-0.0608 -0.14673,-0.0608 h -5.81275 c -0.0552,0 -0.10807,0.0221 -0.14674,0.0608 -0.039,0.039 -0.0608,0.0919 -0.0608,0.14674 v 0.003 c 0,0.0552 0.0218,0.10807 0.0608,0.14673 0.0387,0.039 0.0916,0.0608 0.14674,0.0608 h 5.81275 c 0.0549,0 0.10773,-0.0218 0.14673,-0.0608 0.039,-0.0387 0.0608,-0.0915 0.0608,-0.14673 z"
+         fill="url(#c)"
+         id="path737"
+         style="display:inline;enable-background:new;fill:url(#linearGradient755);stroke-width:0.330477" />
+      <circle
+         cx="332.48474"
+         cy="250.42711"
+         fill="url(#d)"
+         id="circle739"
+         style="display:inline;enable-background:new;fill:url(#linearGradient757);stroke-width:0.330477"
+         r="0.57668161" />
+      <path
+         d="m 332.74151,250.31342 c -0.0202,-0.0403 -0.0486,-0.074 -0.0849,-0.10113 -0.0106,-0.008 -0.0225,-0.0112 -0.0357,-0.01 -0.0132,0.002 -0.0238,0.008 -0.0317,0.0188 -0.008,0.0106 -0.0109,0.0221 -0.009,0.0354 0.002,0.0132 0.008,0.0238 0.0185,0.0317 0.0245,0.0185 0.0433,0.0413 0.0568,0.0681 0.0132,0.0268 0.0202,0.0552 0.0202,0.0856 0,0.0261 -0.005,0.0509 -0.0152,0.0744 -0.0102,0.0238 -0.0238,0.0443 -0.0413,0.0615 -0.0172,0.0172 -0.0377,0.0311 -0.0611,0.041 -0.0238,0.0102 -0.0486,0.0152 -0.0747,0.0152 -0.0261,0 -0.0509,-0.005 -0.0744,-0.0152 -0.0238,-0.01 -0.0443,-0.0238 -0.0615,-0.041 -0.0172,-0.0172 -0.0311,-0.0377 -0.041,-0.0615 -0.0102,-0.0235 -0.0152,-0.0482 -0.0152,-0.0744 0,-0.0304 0.007,-0.0588 0.0198,-0.0856 0.0135,-0.0268 0.0324,-0.0496 0.0568,-0.0681 0.0106,-0.008 0.0169,-0.0185 0.0188,-0.0317 0.002,-0.0129 -10e-4,-0.0248 -0.009,-0.0354 -0.008,-0.0109 -0.0182,-0.0172 -0.0314,-0.0188 -0.0132,-0.002 -0.0251,0.001 -0.036,0.01 -0.0364,0.0271 -0.0648,0.0608 -0.0849,0.10113 -0.0202,0.0403 -0.0301,0.0833 -0.0301,0.12889 0,0.039 0.008,0.0763 0.0228,0.1117 0.0152,0.0357 0.0357,0.0664 0.0615,0.0922 0.0258,0.0258 0.0565,0.0463 0.0922,0.0615 0.0354,0.0152 0.0727,0.0228 0.1117,0.0228 0.039,0 0.0763,-0.008 0.11203,-0.0228 0.0354,-0.0152 0.0661,-0.0357 0.0919,-0.0615 0.0258,-0.0258 0.0463,-0.0565 0.0615,-0.0922 0.0152,-0.0354 0.0228,-0.0727 0.0228,-0.1117 0,-0.0456 -0.01,-0.0886 -0.0301,-0.12889 z m -0.2581,0.12889 c 0.0129,0 0.0245,-0.005 0.0337,-0.0142 0.01,-0.01 0.0145,-0.0208 0.0145,-0.034 v -0.24026 c 0,-0.0129 -0.005,-0.0241 -0.0145,-0.0337 -0.009,-0.01 -0.0208,-0.0142 -0.0337,-0.0142 -0.0129,0 -0.0241,0.005 -0.0337,0.0142 -0.01,0.01 -0.0142,0.0208 -0.0142,0.0337 v 0.24026 c 0,0.0132 0.005,0.0245 0.0142,0.034 0.01,0.009 0.0208,0.0142 0.0337,0.0142 z"
+         fill="#e3e8ea"
+         id="path741"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.330477" />
+      <path
+         d="m 333.07794,242.0254 -2.06879,0.26405 c 0.004,0.0456 0.01,0.0906 0.01,0.13682 -6.7e-4,1.18971 -1.33215,2.15404 -2.97429,2.15404 -0.26108,0 -0.5129,-0.0268 -0.75415,-0.0724 l -0.75183,1.49111 c 0.7439,0.16392 1.55125,0.21613 2.36951,0.1117 2.68281,-0.34237 4.49647,-2.15206 4.16963,-4.08535 z m -2.67653,0.34237 -1.36091,0.1735 c -0.0753,0.34238 -0.48183,0.60544 -0.97589,0.60544 -0.0288,0 -0.0559,-0.005 -0.0839,-0.007 l -0.44912,0.89096 c 0.17945,0.0321 0.36584,0.0515 0.55883,0.0515 1.27763,0 2.31301,-0.74952 2.31334,-1.67485 0,-0.0136 -0.002,-0.0268 -0.002,-0.04 z"
+         fill="url(#e)"
+         id="path743"
+         style="display:inline;enable-background:new;fill:url(#linearGradient759);fill-rule:nonzero;stroke-width:0.330477" />
+      <path
+         d="m 326.02557,239.08151 c -1.35661,0.41806 -2.38307,1.24259 -2.83913,2.22808 -0.26107,0.56412 -0.33312,1.18112 -0.18011,1.80803 0.31032,1.27432 1.49673,2.26939 3.02717,2.74263 l 0.74754,-1.48649 c -1.00961,-0.34435 -1.71055,-1.08561 -1.71055,-1.94749 -3.4e-4,-0.84933 0.67946,-1.582 1.66527,-1.93296 z m 0.93723,1.8629 c -0.70722,0.28685 -1.18575,0.83412 -1.18575,1.46335 3.3e-4,0.64575 0.50596,1.20558 1.24523,1.48516 l 0.44846,-0.89196 c -0.23993,-0.13119 -0.39723,-0.33807 -0.39756,-0.57271 0,-0.22175 0.14177,-0.41739 0.35955,-0.54925 z"
+         fill="url(#f)"
+         id="path745"
+         style="display:inline;enable-background:new;fill:url(#linearGradient761);fill-rule:nonzero;stroke-width:0.330477" />
+      <path
+         d="m 328.13632,238.78474 c -0.32783,-0.005 -0.66128,0.0126 -0.99672,0.0555 -0.20721,0.0264 -0.4002,0.0701 -0.59684,0.11335 l 0.70359,1.39824 c 0.25413,-0.0512 0.52149,-0.0806 0.79843,-0.0806 1.3923,0 2.55789,0.694 2.88175,1.62958 l 2.06482,-0.26438 c -0.53107,-1.66065 -2.55921,-2.81765 -4.85503,-2.85169 z m -0.0459,1.94651 c -0.21547,0 -0.42334,0.0235 -0.62129,0.0635 l 0.46531,0.92501 c 0.043,-0.004 0.0856,-0.01 0.13021,-0.01 0.41144,0 0.76406,0.18177 0.91409,0.4402 l 1.3457,-0.17218 c -0.26206,-0.71713 -1.16162,-1.24656 -2.23402,-1.24656 z"
+         fill="url(#g)"
+         id="path747"
+         style="display:inline;enable-background:new;fill:url(#linearGradient763);fill-rule:nonzero;stroke-width:0.330477" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/disk-utility-app.svg
+++ b/icons/src/fullcolor/default/apps/disk-utility-app.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="disk-utility-app.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\disk.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.8284271"
-     inkscape:cx="101.46982"
-     inkscape:cy="189.68139"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="222.03153"
+     inkscape:cy="152.02796"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -92,320 +92,191 @@
   </sodipodi:namedview>
   <defs
      id="defs3">
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4346"
-       x="-0.014454287"
-       width="1.0289086"
-       y="-0.011357288"
-       height="1.0227146">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.120027"
-         id="feGaussianBlur4348" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4380"
-       x="-0.057817147"
-       width="1.1156343"
-       y="-0.045429151"
-       height="1.0908583">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="8.4801079"
-         id="feGaussianBlur4382" />
-    </filter>
     <linearGradient
+       id="c"
+       x1="14.6558"
+       x2="33.486599"
+       y1="853.91302"
+       y2="853.91302"
        gradientUnits="userSpaceOnUse"
-       y2="169.65668"
-       x2="4.4137931"
-       y1="386.29544"
-       x1="494.34482"
-       id="linearGradient4226"
-       xlink:href="#linearGradient876"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.957,268)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       gradientTransform="matrix(4.8444271,0,0,4.8444271,144.54548,139.51507)">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#197cf1"
          offset="0"
-         id="stop923" />
+         id="stop22" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#20bcfa"
          offset="1"
-         id="stop925" />
+         id="stop24" />
     </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient876"
-       id="linearGradient916"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05921519,0.05978336,0,313.2699,214.63635)"
-       x1="441.37936"
-       y1="240.30258"
-       x2="52.965523"
-       y2="386.30795" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient876"
-       id="linearGradient920"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.0386186,0.03904659,0,315.4715,253.54546)"
-       x1="441.37933"
-       y1="240.28154"
-       x2="52.9655"
-       y2="401.42957" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient876"
-       id="linearGradient3194"
-       x1="335.23154"
-       y1="61.500046"
-       x2="352.27026"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004-8"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient876"
-       id="linearGradient3257"
-       x1="330.0751"
-       y1="133.5"
-       x2="341.92554"
-       y2="162.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient876">
+       id="b"
+       x2="1"
+       gradientTransform="matrix(-0.00746827,-187.67601,187.67601,-0.00746827,507.42504,333.54794)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#b3b3b3;stop-opacity:1"
+         stop-color="#bbbec4"
          offset="0"
-         id="stop872" />
+         id="stop17" />
       <stop
-         style="stop-color:#d9d9d9;stop-opacity:1"
+         stop-color="#dcdee1"
          offset="1"
-         id="stop874" />
+         id="stop19" />
+    </linearGradient>
+    <linearGradient
+       id="a"
+       x2="1"
+       gradientTransform="matrix(214.58099,-0.90466769,0.90466769,214.58099,186.7853,8227.3348)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#1a1a1a"
+         offset="0"
+         id="stop2" />
+      <stop
+         stop-color="#2c2c2e"
+         offset=".11"
+         id="stop4" />
+      <stop
+         stop-color="#2b2b2d"
+         offset=".29"
+         id="stop6" />
+      <stop
+         stop-color="#2a2b2d"
+         offset=".51"
+         id="stop8" />
+      <stop
+         stop-color="#2b2b2d"
+         offset=".75"
+         id="stop10" />
+      <stop
+         stop-color="#323232"
+         offset=".9"
+         id="stop12" />
+      <stop
+         stop-color="#171717"
+         offset="1"
+         id="stop14" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient1394"
-       x1="77"
-       y1="156"
-       x2="227"
-       y2="156"
+       xlink:href="#a"
+       id="linearGradient513"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,152,156)" />
+       gradientTransform="matrix(44.065741,-0.18577998,0.18577998,44.065741,328.37051,1720.5844)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient1392">
-      <stop
-         style="stop-color:#e6e6e6;stop-opacity:1;"
-         offset="0"
-         id="stop1388" />
-      <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
-         offset="1"
-         id="stop1390" />
-    </linearGradient>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1469"
-       x="-0.039928033"
-       width="1.0798561"
-       y="-0.12065239"
-       height="1.2413048">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.3209033"
-         id="feGaussianBlur1471" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1422"
-       x="-0.06"
-       width="1.12"
-       y="-0.059999993"
-       height="1.12">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="3.75"
-         id="feGaussianBlur1424" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient980"
-       id="linearGradient982"
-       x1="152"
-       y1="124"
-       x2="152"
-       y2="236"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient980">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop976" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop978" />
-    </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath999">
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#5d5d5d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.82599998;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 152,68 c -48.60106,0 -88,39.39894 -88,88 0,48.60106 39.39894,88 88,88 48.60106,0 88,-39.39894 88,-88 0,-48.60106 -39.39894,-88 -88,-88 z"
-         id="path1001"
-         sodipodi:nodetypes="sssss" />
-    </clipPath>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1003"
-       x="-0.091250001"
-       width="1.1825"
-       y="-0.091250001"
-       height="1.1825">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.4"
-         id="feGaussianBlur1005" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient2529"
+       xlink:href="#b"
+       id="linearGradient515"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.94666648,-0.94666648,0,299.68012,-3.8934703)"
-       x1="77"
-       y1="156"
-       x2="227"
-       y2="156" />
+       gradientTransform="matrix(-0.00153366,-38.540611,38.540611,-0.00153366,394.21617,99.538819)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient2531"
+       xlink:href="#c"
+       id="linearGradient517"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.18666666,-0.18666666,0,373.12017,52.626664)"
-       x1="77"
-       y1="156"
-       x2="227"
-       y2="156" />
+       gradientTransform="matrix(0.99483774,0,0,0.99483774,319.69626,59.692782)"
+       x1="14.6558"
+       y1="853.91302"
+       x2="33.486599"
+       y2="853.91302" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient2533"
+       xlink:href="#a"
+       id="linearGradient533"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,152,156)"
-       x1="77"
-       y1="156"
-       x2="227"
-       y2="156" />
+       gradientTransform="matrix(28.738525,-0.12116085,0.12116085,28.738525,325.80686,1215.3376)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient2535"
+       xlink:href="#b"
+       id="linearGradient535"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,152,156)"
-       x1="77"
-       y1="156"
-       x2="227"
-       y2="156" />
+       gradientTransform="matrix(-0.00100021,-25.13518,25.13518,-0.00100021,368.74968,158.13401)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient537"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.64880719,0,0,0.64880719,320.14974,132.14746)"
+       x1="14.6558"
+       y1="853.91302"
+       x2="33.486599"
+       y2="853.91302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient553"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(21.07492,-0.08885129,0.08885129,21.07492,324.52503,982.71429)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient555"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-7.3349084e-4,-18.432466,18.432466,-7.3349084e-4,356.01643,207.43161)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient557"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.47579197,0,0,0.47579197,320.37647,188.37481)"
+       x1="14.6558"
+       y1="853.91302"
+       x2="33.486599"
+       y2="853.91302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient573"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(13.411312,-0.05654173,0.05654173,13.411312,323.2432,742.09088)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient575"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-4.6676687e-4,-11.729751,11.729751,-4.6676687e-4,343.28318,248.72921)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient577"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30277669,0,0,0.30277669,320.60321,236.60215)"
+       x1="14.6558"
+       y1="853.91302"
+       x2="33.486599"
+       y2="853.91302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient743"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(214.58099,-0.90466769,0.90466769,214.58099,75.89117,8125.4542)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient745"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00746827,-187.67601,187.67601,-0.00746827,396.53091,231.66729)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.8444271,0,0,4.8444271,33.65135,37.63442)"
+       x1="14.6558"
+       y1="853.91302"
+       x2="33.486599"
+       y2="853.91302" />
   </defs>
   <metadata
      id="metadata4">
@@ -505,7 +376,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">disk-utility-app</tspan></text>
+           id="tspan924">disk-utility-app</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -540,1016 +411,204 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86523,189 c -1.12014,0 -2.01524,0.0241 -2.79101,0.1543 -0.77577,0.13022 -1.48014,0.38763 -2.00977,0.91601 -0.52962,0.52838 -0.79079,1.23687 -0.91992,2.01367 -0.12912,0.77681 -0.15002,1.67169 -0.14453,2.79493 V 201 v 6.125 c -0.005,1.12104 0.0156,2.01529 0.14453,2.79102 0.12912,0.77681 0.39029,1.48529 0.91992,2.01367 0.52964,0.52838 1.234,0.78579 2.00977,0.91601 0.77577,0.13022 1.67087,0.1543 2.79101,0.1543 h 8.26954 c 1.12013,0 2.01264,-0.024 2.78711,-0.1543 0.77446,-0.13033 1.48001,-0.38927 2.00781,-0.91797 0.5278,-0.52869 0.78594,-1.23438 0.91601,-2.00976 C 341.97577,209.14258 342,208.24735 342,207.125 V 201 194.875 c 0,-1.12235 -0.0242,-2.01758 -0.1543,-2.79297 -0.13007,-0.77538 -0.38821,-1.48107 -0.91601,-2.00976 -0.5278,-0.5287 -1.23334,-0.78764 -2.00781,-0.91797 C 338.1474,189.02397 337.25491,189 336.13477,189 Z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         d="M 238.808,263.80135 H 61.04174 c -9.25285,0 -17.57073,-5.72127 -18.14237,-14.94991 -0.46023,-7.48948 -2.91151,-33.26668 -2.91635,-33.31996 h 219.8837 c -0.005,0.0533 -2.45612,25.83048 -2.91634,33.31996 -0.57165,9.22864 -8.88953,14.94991 -18.14238,14.94991 z"
+         fill="url(#a)"
+         fill-rule="nonzero"
+         id="path32"
+         style="display:inline;fill:url(#linearGradient743);stroke-width:4.84443;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
+         d="M 247.13072,59.70079 C 246.39437,50.8258 238.9824,44 230.07834,44 H 69.7714 c -8.90405,0 -16.31603,6.8258 -17.05238,15.70079 -2.84368,34.45356 -9.63072,116.56176 -12.67787,153.45692 -0.3924,4.76691 1.22564,9.48054 4.46172,12.99759 3.24092,3.5219 7.80437,5.52265 12.58582,5.52265 h 185.67236 c 4.78145,0 9.3449,-2.00075 12.58582,-5.52265 3.23608,-3.51705 4.85412,-8.23068 4.46172,-12.99759 C 256.76144,176.26255 249.9744,94.15435 247.13072,59.70079 Z"
+         fill="url(#b)"
+         id="path34"
+         style="display:inline;fill:url(#linearGradient745);stroke-width:4.84443;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 330.19336,134 c -1.42096,0 -2.54883,0.0308 -3.50586,0.19141 -0.95703,0.16064 -1.79146,0.4726 -2.41211,1.09179 -0.62065,0.61919 -0.93647,1.45612 -1.0957,2.41407 -0.15924,0.95795 -0.18666,2.08705 -0.17969,3.51171 V 149 v 7.79688 c -0.007,1.42131 0.0207,2.5495 0.17969,3.50585 0.15923,0.95796 0.47505,1.79488 1.0957,2.41407 0.62065,0.61919 1.45508,0.93115 2.41211,1.09179 0.95703,0.16065 2.0849,0.19141 3.50586,0.19141 h 11.61523 c 1.42097,0 2.54669,-0.0307 3.50196,-0.19141 0.95527,-0.16075 1.78779,-0.47425 2.40625,-1.09375 0.61845,-0.6195 0.93134,-1.45363 1.09179,-2.41015 C 348.96905,159.34816 349,158.22066 349,156.79688 V 149 141.20312 c 0,-1.42378 -0.031,-2.55128 -0.19141,-3.50781 -0.16045,-0.95653 -0.47334,-1.79065 -1.09179,-2.41015 -0.61846,-0.61951 -1.45098,-0.933 -2.40625,-1.09375 C 344.35528,134.03065 343.22956,134 341.80859,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
+         d="m 361.82664,106.13778 h -36.50557 c -1.90014,0 -3.60827,-1.17491 -3.72567,-3.07007 -0.0945,-1.53802 -0.59789,-6.831553 -0.59889,-6.842495 h 45.15469 c -0.001,0.01095 -0.50438,5.304475 -0.59889,6.842495 -0.11739,1.89516 -1.82553,3.07007 -3.72567,3.07007 z"
+         fill="url(#a)"
+         fill-rule="nonzero"
+         id="path499"
+         style="display:inline;fill:url(#linearGradient513);stroke-width:0.994838;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.23093,61.500047 c -2.22316,0 -3.97368,0.05118 -5.41406,0.292969 -1.44039,0.241784 -2.61905,0.695299 -3.48243,1.55664 -0.86337,0.861342 -1.31906,2.039471 -1.55859,3.480469 -0.23953,1.440999 -0.28629,3.195341 -0.27539,5.423828 V 85 97.752143 c -0.0108,2.225063 0.0361,3.978517 0.27539,5.417967 0.23953,1.441 0.69522,2.61913 1.55859,3.48047 0.86338,0.86134 2.04204,1.31486 3.48243,1.55664 1.44039,0.24179 3.1909,0.29297 5.41406,0.29297 h 17.53883 c 2.22317,0 3.97276,-0.0511 5.41017,-0.29297 1.4374,-0.24189 2.61246,-0.69694 3.47265,-1.55859 0.8602,-0.86165 1.31319,-2.03894 1.55468,-3.47852 0.24149,-1.43957 0.29297,-3.190353 0.29297,-5.417967 V 85 72.248094 c 0,-2.227614 -0.0515,-3.978392 -0.29297,-5.417969 -0.24149,-1.439576 -0.69449,-2.616863 -1.55469,-3.478516 -0.86019,-0.861652 -2.03525,-1.316704 -3.47265,-1.558593 -1.4374,-0.24189 -3.187,-0.292969 -5.41016,-0.292969 z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
+         d="M 363.53577,64.224269 C 363.38456,62.401726 361.86246,61 360.03394,61 h -32.92017 c -1.82851,0 -3.35062,1.401726 -3.50183,3.224269 -0.58397,7.075285 -1.97774,23.936791 -2.60349,31.513476 -0.0806,0.978919 0.25169,1.946896 0.91625,2.669148 0.66554,0.723247 1.60268,1.134115 2.58458,1.134115 h 38.12915 c 0.9819,0 1.91904,-0.410868 2.58459,-1.134115 0.66455,-0.722252 0.99683,-1.690229 0.91624,-2.669148 -0.62575,-7.576685 -2.01952,-24.438191 -2.60349,-31.513476 z"
+         fill="url(#b)"
+         id="path501"
+         style="display:inline;fill:url(#linearGradient515);stroke-width:0.994838;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
+         d="M 347.62608,162.43768 H 323.8181 c -1.23923,0 -2.35323,-0.76624 -2.42979,-2.00222 -0.0616,-1.00306 -0.38993,-4.45536 -0.39058,-4.4625 h 29.44871 c -6.7e-4,0.007 -0.32894,3.45944 -0.39058,4.4625 -0.0766,1.23598 -1.19056,2.00222 -2.42978,2.00222 z"
+         fill="url(#a)"
+         fill-rule="nonzero"
+         id="path519"
+         style="display:inline;fill:url(#linearGradient533);stroke-width:0.648808;enable-background:new" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path4350"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 464,514.75001 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4380);enable-background:accumulate"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
+         d="M 348.74073,135.10278 C 348.64211,133.91417 347.64943,133 346.45693,133 h -21.46968 c -1.19251,0 -2.18519,0.91417 -2.2838,2.10278 -0.38085,4.61432 -1.28983,15.61095 -1.69793,20.55227 -0.0526,0.63842 0.16414,1.26971 0.59755,1.74075 0.43405,0.47168 1.04523,0.73964 1.6856,0.73964 h 24.86683 c 0.64038,0 1.25155,-0.26796 1.6856,-0.73964 0.43341,-0.47104 0.65011,-1.10233 0.59756,-1.74075 -0.40811,-4.94132 -1.31708,-15.93795 -1.69793,-20.55227 z"
+         fill="url(#b)"
+         id="path521"
+         style="display:inline;fill:url(#linearGradient535);stroke-width:0.648808;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.02028775;marker:none;enable-background:accumulate"
-         d="M 101.8116,42 C 65.712789,42 61.828597,45.690158 62.005519,81.689842 V 156 230.31016 C 61.828597,266.30985 65.712789,270 101.8116,270 h 100.38732 c 36.09881,0 39.80608,-3.68973 39.80608,-39.68984 V 156 81.689842 C 242.005,45.689729 238.29773,42 202.19892,42 Z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 340.52579,210.58764 H 323.0666 c -0.90876,0 -1.7257,-0.56191 -1.78184,-1.4683 -0.0452,-0.73557 -0.28595,-3.26726 -0.28643,-3.27249 h 21.59572 c -4.9e-4,0.005 -0.24122,2.53692 -0.28642,3.27249 -0.0562,0.90639 -0.87308,1.4683 -1.78184,1.4683 z"
+         fill="url(#a)"
+         fill-rule="nonzero"
+         id="path539"
+         style="display:inline;fill:url(#linearGradient553);stroke-width:0.475792;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 341.3432,190.54205 C 341.27088,189.6704 340.54291,189 339.66841,189 h -15.74443 c -0.87451,0 -1.60247,0.6704 -1.67479,1.54205 -0.27929,3.38383 -0.94587,11.44803 -1.24515,15.07166 -0.0385,0.46818 0.12038,0.93112 0.43821,1.27655 0.3183,0.3459 0.7665,0.5424 1.2361,0.5424 h 18.23568 c 0.46961,0 0.91781,-0.1965 1.23611,-0.5424 0.31783,-0.34543 0.47674,-0.80837 0.4382,-1.27655 -0.29927,-3.62363 -0.96585,-11.68783 -1.24514,-15.07166 z"
+         fill="url(#b)"
+         id="path541"
+         style="display:inline;fill:url(#linearGradient555);stroke-width:0.475792;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 201.07298,44 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 156 229.00647 C 240.16759,264.37459 236.36971,268 201.07298,268 H 102.91622 C 67.619504,268 63.994604,264.375 63.994604,229.00647 V 156 82.99353 C 63.994604,47.624997 67.619504,44 102.91622,44 Z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 333.4255,250.73759 h -11.11039 c -0.5783,0 -1.09817,-0.35758 -1.1339,-0.93437 -0.0288,-0.4681 -0.18197,-2.07917 -0.18227,-2.0825 h 13.74273 c -3.1e-4,0.003 -0.1535,1.6144 -0.18227,2.0825 -0.0357,0.57679 -0.55559,0.93437 -1.1339,0.93437 z"
+         fill="url(#a)"
+         fill-rule="nonzero"
+         id="path559"
+         style="display:inline;fill:url(#linearGradient573);stroke-width:0.302777;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188,44 C 67.625152,44 63.82701,47.626029 64,82.994141 v 2 C 63.82701,49.626029 67.625152,46 102.92188,46 h 98.15624 C 236.37485,46 240,49.625608 240,84.994141 v -2 C 240,47.625608 236.37485,44 201.07812,44 Z"
-         id="path931"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 327.636,188.49999 c -4.65703,0 -5.15812,0.47378 -5.1353,5.09575 v 6.40425 6.40426 c -0.0229,4.62196 0.47827,5.09574 5.1353,5.09574 h 8.72869 c 4.65703,0 5.1353,-0.47372 5.1353,-5.09574 v -6.40426 -6.40425 c 0,-4.62202 -0.47828,-5.09575 -5.13531,-5.09575 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.8545,236.50001 c -3.04166,0 -3.36894,0.30899 -3.35403,3.32331 v 4.17669 4.17668 c -0.0149,3.01433 0.31237,3.32332 3.35403,3.32332 h 6.29146 c 3.04167,0 3.35404,-0.30895 3.35404,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.31238,-3.32331 -3.35404,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 63.994141,156 v 73.00586 C 63.994141,264.37439 67.6193,268 102.91602,268 h 98.15625 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 156 Z"
-         id="rect4158-8"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3257);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         transform="matrix(0.66664182,0,0,0.63636364,106.67522,94.545454)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004-8);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-1)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:1.85638201;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983)"
-         transform="matrix(1.0833332,0,0,1.0714286,-27.333287,-17.428571)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 152,44 v 224 h 49.07227 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 156 82.994141 C 240.16713,47.626029 236.369,44 201.07227,44 Z"
-         id="rect4158-3"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92728,268 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 C 63.832405,262.37397 67.630549,266 102.92728,266 h 98.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 C 240.0054,264.37439 236.38025,268 201.08352,268 Z"
-         id="path931-8"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 336.50849,211.51179 c 4.23214,0 5.02499,-0.46371 5.00275,-4.98757 v -6.5241 -6.52423 c 0.0222,-4.52386 -0.77061,-4.98757 -5.00275,-4.98757 h -9.01743 c -4.23108,0 -5.00275,0.46366 -5.00275,4.98757 v 6.52423 6.5241 c 0,4.52391 0.77167,4.98757 5.00275,4.98757 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.08651,251.51179 c 2.89732,0 3.44011,-0.30259 3.42488,-3.25454 v -4.25716 -4.25724 c 0.0152,-2.95195 -0.52756,-3.25453 -3.42488,-3.25453 h -6.17331 c -2.8966,0 -3.42488,0.30255 -3.42488,3.25453 v 4.25724 4.25716 c 0,2.95199 0.52828,3.25454 3.42488,3.25454 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 333.94567,237.9813 C 333.89965,237.42661 333.4364,237 332.8799,237 h -10.01918 c -0.55651,0 -1.01976,0.42661 -1.06578,0.9813 -0.17773,2.15335 -0.60192,7.28511 -0.79237,9.59106 -0.0245,0.29793 0.0766,0.59253 0.27886,0.81235 0.20256,0.22012 0.48778,0.34516 0.78662,0.34516 h 11.60452 c 0.29884,0 0.58405,-0.12504 0.78661,-0.34516 0.20226,-0.21982 0.30338,-0.51442 0.27886,-0.81235 -0.19045,-2.30595 -0.61464,-7.43771 -0.79237,-9.59106 z"
+         fill="url(#b)"
+         id="path561"
+         style="display:inline;fill:url(#linearGradient575);stroke-width:0.302777;enable-background:new" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
+      <path
+         d="m 195.9106,249.14695 c 0,-0.80417 -0.31974,-1.57928 -0.89138,-2.15092 -0.57164,-0.5668 -1.34675,-0.89138 -2.15092,-0.89138 h -85.20863 c -0.80902,0 -1.58413,0.32458 -2.15093,0.89138 -0.57164,0.57164 -0.89137,1.34675 -0.89137,2.15092 v 0.0388 c 0,0.80902 0.31973,1.58413 0.89137,2.15093 0.5668,0.57164 1.34191,0.89137 2.15093,0.89137 h 85.20863 c 0.80417,0 1.57928,-0.31973 2.15092,-0.89137 0.57164,-0.5668 0.89138,-1.34191 0.89138,-2.15093 z"
+         fill="url(#c)"
+         id="path36"
+         style="display:inline;enable-background:new;fill:url(#linearGradient747);stroke-width:4.84443" />
+      <path
+         d="m 149.9176,86.07869 c 26.75578,0 48.44428,21.6885 48.44428,48.44427 0,26.75578 -21.6885,48.44428 -48.44428,48.44428 h -48.44427 v -48.44428 c 0,-26.75577 21.6885,-48.44427 48.44427,-48.44427 z m 0,24.22214 c -13.37546,0 -24.22213,10.84667 -24.22213,24.22213 0,13.37547 10.84667,24.22214 24.22213,24.22214 13.37547,0 24.22214,-10.84667 24.22214,-24.22214 0,-13.37546 -10.84667,-24.22213 -24.22214,-24.22213 z"
+         fill="#a1a7ae"
+         fill-rule="nonzero"
+         id="path42"
+         style="display:inline;enable-background:new;stroke-width:4.84443" />
       <circle
-         r="5"
-         cy="243"
-         cx="328"
-         id="circle1588"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.23913042;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.71739128, 0.71739128;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         cx="216.35406"
+         cy="220.3371"
+         r="47.662903"
+         fill="#8645fb"
+         stroke-width="4.33299"
+         id="circle44"
+         style="display:inline;enable-background:new" />
+      <path
+         d="m 209.0293,191.26574 -0.6443,7.65419 c -2.45128,0.90107 -4.72817,2.20422 -6.7386,3.86101 l -7.01958,-3.27483 -7.32962,12.58582 6.37043,4.38905 c -0.22285,1.26924 -0.34396,2.55786 -0.3488,3.85132 0,1.29831 0.11142,2.59177 0.33426,3.8707 l -6.36557,4.37452 7.33446,12.58582 7.00019,-3.26999 c 2.01529,1.64711 4.29701,2.94541 6.74829,3.83679 l 0.64431,7.67357 h 14.66408 l 0.64915,-7.6542 c 2.44644,-0.90106 4.72817,-2.20421 6.73376,-3.861 l 7.01957,3.27483 7.33447,-12.58582 -6.37527,-4.38905 c 0.22769,-1.26924 0.34395,-2.55786 0.35364,-3.85132 -0.005,-1.29831 -0.11626,-2.59177 -0.33911,-3.86586 l 6.36074,-4.36482 -7.32962,-12.59067 -7.00504,3.26999 c -2.01529,-1.64711 -4.29701,-2.94541 -6.74829,-3.83679 l -0.64915,-7.67357 h -14.66408 z m 7.33447,15.15337 c 7.69779,0 14.0343,6.28322 14.0343,13.91319 0,7.62998 -6.33651,13.9132 -14.0343,13.9132 -7.70264,0 -14.03915,-6.28322 -14.03915,-13.9132 0,-7.62997 6.33651,-13.91319 14.03915,-13.91319 z"
+         fill="#ffffff"
+         fill-rule="nonzero"
+         id="path46"
+         style="display:inline;enable-background:new;stroke-width:4.84443" />
+      <path
+         d="m 353.01735,103.12839 c 0,-0.16514 -0.0657,-0.32431 -0.18305,-0.4417 -0.11739,-0.1164 -0.27656,-0.18306 -0.4417,-0.18306 h -17.4982 c -0.16614,0 -0.32532,0.0667 -0.44171,0.18306 -0.11739,0.11739 -0.18305,0.27656 -0.18305,0.4417 v 0.008 c 0,0.16614 0.0657,0.32531 0.18305,0.44171 0.11639,0.11739 0.27557,0.18305 0.44171,0.18305 h 17.4982 c 0.16514,0 0.32431,-0.0657 0.4417,-0.18305 0.11739,-0.1164 0.18305,-0.27557 0.18305,-0.44171 z"
+         fill="url(#c)"
+         id="path503"
+         style="display:inline;enable-background:new;fill:url(#linearGradient517);stroke-width:0.994838" />
+      <path
+         d="m 343.57236,69.641159 c 5.49449,0 9.94838,4.453889 9.94838,9.948378 0,5.49449 -4.45389,9.948379 -9.94838,9.948379 h -9.94837 v -9.948379 c 0,-5.494489 4.45388,-9.948378 9.94837,-9.948378 z m 0,4.97419 c -2.74674,0 -4.97418,2.227441 -4.97418,4.974188 0,2.746748 2.22744,4.974189 4.97418,4.974189 2.74675,0 4.97419,-2.227441 4.97419,-4.974189 0,-2.746747 -2.22744,-4.974188 -4.97419,-4.974188 z"
+         fill="#a1a7ae"
+         fill-rule="nonzero"
+         id="path505"
+         style="display:inline;enable-background:new;stroke-width:0.994838" />
       <circle
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#5d5d5d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.82608676;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:11.47826029, 11.47826029;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="path4238"
-         cx="152.00017"
-         cy="-139.99983"
-         transform="scale(1,-1)"
-         r="80" />
+         cx="357.21558"
+         cy="97.212082"
+         r="9.7879181"
+         fill="#8645fb"
+         stroke-width="0.889811"
+         id="circle507"
+         style="display:inline;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.82608676;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:11.4782603, 11.4782603;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 72.00017,139.99984 a 80,80 0 0 1 80,-80.000016 80,80 0 0 1 80,80.000016 z"
-         id="circle1007"
-         inkscape:connector-curvature="0" />
+         d="m 355.71137,91.242072 -0.13231,1.571843 c -0.50339,0.185041 -0.97096,0.452652 -1.38382,0.792886 l -1.44152,-0.67251 -1.50519,2.584588 1.30822,0.901323 c -0.0458,0.260648 -0.0706,0.525275 -0.0716,0.790896 0,0.266617 0.0229,0.532239 0.0686,0.794876 l -1.30722,0.898339 1.50619,2.584587 1.43754,-0.67151 c 0.41385,0.33824 0.88242,0.60486 1.38581,0.78791 l 0.13231,1.57582 h 3.01137 l 0.13331,-1.57184 c 0.5024,-0.18504 0.97096,-0.45265 1.38283,-0.79289 l 1.44152,0.67251 1.50618,-2.584587 -1.30921,-0.901323 c 0.0468,-0.260647 0.0706,-0.525275 0.0726,-0.790896 -10e-4,-0.266617 -0.0239,-0.532238 -0.0696,-0.793882 l 1.30622,-0.896347 -1.50519,-2.585584 -1.43853,0.671516 c -0.41386,-0.338246 -0.88242,-0.604861 -1.38581,-0.787912 l -0.13331,-1.575823 h -3.01137 z m 1.50619,3.111853 c 1.5808,0 2.88204,1.290304 2.88204,2.857173 0,1.566871 -1.30124,2.857172 -2.88204,2.857172 -1.58179,0 -2.88304,-1.290301 -2.88304,-2.857172 0,-1.566869 1.30125,-2.857173 2.88304,-2.857173 z"
+         fill="#ffffff"
+         fill-rule="nonzero"
+         id="path509"
+         style="display:inline;enable-background:new;stroke-width:0.994838" />
       <path
-         transform="matrix(0.90909091,0,0,0.90909091,13.818341,-1.818182)"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient982);stroke-width:11;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1003);enable-background:accumulate"
-         d="m 152,70 c -48.60106,0 -88,39.39894 -88,88 0,48.60106 39.39894,88 88,88 48.60106,0 88,-39.39894 88,-88 0,-48.60106 -39.39894,-88 -88,-88 z"
-         id="path962"
-         clip-path="url(#clipPath999)"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sssss" />
+         d="m 341.88089,160.47503 c 0,-0.1077 -0.0428,-0.21151 -0.11938,-0.28807 -0.0766,-0.0759 -0.18037,-0.11938 -0.28807,-0.11938 h -11.41187 c -0.10835,0 -0.21216,0.0435 -0.28807,0.11938 -0.0766,0.0766 -0.11938,0.18037 -0.11938,0.28807 v 0.005 c 0,0.10835 0.0428,0.21216 0.11938,0.28807 0.0759,0.0766 0.17972,0.11938 0.28807,0.11938 h 11.41187 c 0.1077,0 0.21151,-0.0428 0.28807,-0.11938 0.0766,-0.0759 0.11938,-0.17972 0.11938,-0.28807 z"
+         fill="url(#c)"
+         id="path523"
+         style="display:inline;enable-background:new;fill:url(#linearGradient537);stroke-width:0.648808" />
       <path
-         sodipodi:nodetypes="sssss"
-         inkscape:connector-curvature="0"
-         id="path1414"
-         d="m 152.00017,216.99984 c -41.42135,0 -75,-33.57864 -75,-75 0,-41.42136 33.57865,-75.000018 75,-75.000018 41.42135,0 75,33.578658 75,75.000018 0,41.42136 -33.57865,75 -75,75 z"
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter1422);enable-background:new" />
-      <path
-         style="display:inline;opacity:1;fill:url(#linearGradient2529);fill-opacity:1;stroke:none;stroke-width:15.99999905;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 152.00015,210.99983 c -39.21221,0 -70.99999,-31.78777 -70.99999,-70.99999 0,-39.21221 31.78778,-70.999985 70.99999,-70.999985 39.2122,0 70.99998,31.787775 70.99998,70.999985 0,39.21222 -31.78778,70.99999 -70.99998,70.99999 z"
-         id="path949"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sssss" />
-      <ellipse
-         style="display:inline;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:15.99999809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="ellipse971"
-         cx="152.00008"
-         cy="139.99948"
-         rx="32"
-         ry="32.000008" />
-      <ellipse
-         ry="20.000004"
-         rx="20"
-         cy="139.99948"
-         cx="152.00008"
-         id="ellipse966"
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:15.99999905;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      <g
-         id="g1374"
-         style="opacity:0.1;fill:#000000;fill-opacity:1"
-         transform="translate(1.5981281e-4,-16.000173)">
-        <circle
-           transform="rotate(-30)"
-           r="2"
-           cy="185.09996"
-           cx="53.63586"
-           id="path973-2"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <circle
-           transform="rotate(-30)"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle975"
-           cx="53.63586"
-           cy="237.09996"
-           r="2" />
-        <circle
-           transform="rotate(-60)"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1308"
-           cx="-59.099964"
-           cy="183.63586"
-           r="2" />
-        <circle
-           transform="rotate(-60)"
-           r="2"
-           cy="235.63586"
-           cx="-59.099964"
-           id="circle1310"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <circle
-           transform="rotate(-90)"
-           r="2"
-           cy="126"
-           cx="-156"
-           id="circle1314"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <circle
-           transform="rotate(-90)"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1316"
-           cx="-156"
-           cy="178"
-           r="2" />
-        <circle
-           transform="rotate(-120)"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1320"
-           cx="-211.09996"
-           cy="27.63586"
-           r="2" />
-        <circle
-           transform="rotate(-120)"
-           r="2"
-           cy="79.635864"
-           cx="-211.09996"
-           id="circle1322"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <circle
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1326"
-           cx="152"
-           cy="130"
-           r="2"
-           transform="rotate(-150,152,156)" />
-        <circle
-           r="2"
-           cy="182"
-           cx="152"
-           id="circle1328"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           transform="rotate(-150,152,156)" />
-        <circle
-           transform="scale(-1)"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1332"
-           cx="-152"
-           cy="-182"
-           r="2" />
-        <circle
-           transform="scale(-1)"
-           r="2"
-           cy="-130"
-           cx="-152"
-           id="circle1334"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      </g>
-      <ellipse
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:15.99999809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="ellipse1434"
-         cx="152.00008"
-         cy="139.99948"
-         rx="16"
-         ry="16.000004" />
-      <ellipse
-         style="display:inline;opacity:1;fill:#888888;fill-opacity:1;stroke:none;stroke-width:15.99998379;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="ellipse1438"
-         cx="152.00052"
-         cy="139.99995"
-         rx="4"
-         ry="4.000001" />
+         d="m 335.72111,138.63554 c 3.58337,0 6.48808,2.90471 6.48808,6.48807 0,3.58336 -2.90471,6.48807 -6.48808,6.48807 h -6.48807 v -6.48807 c 0,-3.58336 2.90471,-6.48807 6.48807,-6.48807 z m 0,3.24403 c -1.79135,0 -3.24403,1.45268 -3.24403,3.24404 0,1.79136 1.45268,3.24403 3.24403,3.24403 1.79136,0 3.24404,-1.45267 3.24404,-3.24403 0,-1.79136 -1.45268,-3.24404 -3.24404,-3.24404 z"
+         fill="#a1a7ae"
+         fill-rule="nonzero"
+         id="path525"
+         style="display:inline;enable-background:new;stroke-width:0.648808" />
       <circle
-         r="16"
-         cy="81"
-         cx="344.00018"
-         id="circle1507"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.78260863;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.34782591, 2.34782591;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         cx="344.61887"
+         cy="156.61658"
+         r="6.3834243"
+         fill="#8645fb"
+         stroke-width="0.580311"
+         id="circle527"
+         style="display:inline;enable-background:new" />
+      <path
+         d="m 343.63786,152.72309 -0.0863,1.02511 c -0.3283,0.12068 -0.63324,0.29521 -0.90249,0.5171 l -0.94013,-0.43859 -0.98164,1.6856 0.85318,0.58782 c -0.0298,0.16999 -0.0461,0.34257 -0.0467,0.5158 0,0.17388 0.0149,0.34711 0.0448,0.5184 l -0.85253,0.58587 0.9823,1.6856 0.93752,-0.43794 c 0.26991,0.22059 0.57549,0.39447 0.90379,0.51385 l 0.0863,1.02771 h 1.96394 l 0.0869,-1.02511 c 0.32765,-0.12068 0.63324,-0.29521 0.90184,-0.5171 l 0.94012,0.43859 0.9823,-1.6856 -0.85383,-0.58782 c 0.0305,-0.16999 0.0461,-0.34257 0.0474,-0.5158 -6.7e-4,-0.17388 -0.0156,-0.34711 -0.0454,-0.51775 l 0.85189,-0.58457 -0.98165,-1.68625 -0.93817,0.43794 c -0.26991,-0.22059 -0.57549,-0.39447 -0.90379,-0.51386 l -0.0869,-1.02771 h -1.96394 z m 0.98229,2.02947 c 1.03096,0 1.8796,0.8415 1.8796,1.86337 0,1.02187 -0.84864,1.86337 -1.8796,1.86337 -1.0316,0 -1.88024,-0.8415 -1.88024,-1.86337 0,-1.02187 0.84864,-1.86337 1.88024,-1.86337 z"
+         fill="#ffffff"
+         fill-rule="nonzero"
+         id="path529"
+         style="display:inline;enable-background:new;stroke-width:0.648808" />
+      <path
+         d="m 336.31265,209.14837 c 0,-0.079 -0.0314,-0.15511 -0.0876,-0.21125 -0.0561,-0.0557 -0.13227,-0.0875 -0.21125,-0.0875 h -8.3687 c -0.0795,0 -0.15559,0.0319 -0.21126,0.0875 -0.0561,0.0561 -0.0875,0.13227 -0.0875,0.21125 v 0.004 c 0,0.0795 0.0314,0.15558 0.0875,0.21125 0.0557,0.0561 0.1318,0.0875 0.21126,0.0875 h 8.3687 c 0.079,0 0.15511,-0.0314 0.21125,-0.0875 0.0562,-0.0557 0.0876,-0.1318 0.0876,-0.21125 z"
+         fill="url(#c)"
+         id="path543"
+         style="display:inline;enable-background:new;fill:url(#linearGradient557);stroke-width:0.475792" />
+      <path
+         d="m 331.79548,193.13273 c 2.6278,0 4.75792,2.13012 4.75792,4.75792 0,2.6278 -2.13012,4.75792 -4.75792,4.75792 h -4.75792 v -4.75792 c 0,-2.6278 2.13012,-4.75792 4.75792,-4.75792 z m 0,2.37896 c -1.31366,0 -2.37896,1.0653 -2.37896,2.37896 0,1.31366 1.0653,2.37896 2.37896,2.37896 1.31366,0 2.37896,-1.0653 2.37896,-2.37896 0,-1.31366 -1.0653,-2.37896 -2.37896,-2.37896 z"
+         fill="#a1a7ae"
+         fill-rule="nonzero"
+         id="path545"
+         style="display:inline;enable-background:new;stroke-width:0.475792" />
       <circle
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.47826084;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.43478257, 1.43478257;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="circle1535"
-         cx="336.00018"
-         cy="146.99998"
-         r="11" />
+         cx="338.3205"
+         cy="206.31883"
+         r="4.6811781"
+         fill="#8645fb"
+         stroke-width="0.425562"
+         id="circle547"
+         style="display:inline;enable-background:new" />
+      <path
+         d="m 337.60109,203.4636 -0.0633,0.75176 c -0.24075,0.0885 -0.46437,0.21648 -0.66182,0.3792 l -0.68943,-0.32163 -0.71987,1.2361 0.62567,0.43107 c -0.0219,0.12466 -0.0338,0.25122 -0.0343,0.37826 0,0.12751 0.0109,0.25454 0.0328,0.38015 l -0.62519,0.42964 0.72035,1.23611 0.68752,-0.32116 c 0.19793,0.16177 0.42202,0.28928 0.66278,0.37683 l 0.0633,0.75365 h 1.44022 l 0.0637,-0.75175 c 0.24028,-0.0885 0.46438,-0.21648 0.66135,-0.3792 l 0.68943,0.32163 0.72035,-1.23611 -0.62615,-0.43106 c 0.0224,-0.12466 0.0338,-0.25122 0.0347,-0.37826 -4.9e-4,-0.12751 -0.0114,-0.25455 -0.0333,-0.37968 l 0.62472,-0.42869 -0.71988,-1.23658 -0.68799,0.32116 c -0.19793,-0.16177 -0.42203,-0.28928 -0.66278,-0.37683 l -0.0638,-0.75365 h -1.44022 z m 0.72035,1.48828 c 0.75604,0 1.37837,0.6171 1.37837,1.36648 0,0.74937 -0.62233,1.36647 -1.37837,1.36647 -0.75651,0 -1.37884,-0.6171 -1.37884,-1.36647 0,-0.74938 0.62233,-1.36648 1.37884,-1.36648 z"
+         fill="#ffffff"
+         fill-rule="nonzero"
+         id="path549"
+         style="display:inline;enable-background:new;stroke-width:0.475792" />
+      <path
+         d="m 330.74442,249.82168 c 0,-0.0503 -0.02,-0.0987 -0.0557,-0.13443 -0.0357,-0.0354 -0.0842,-0.0557 -0.13443,-0.0557 h -5.32554 c -0.0506,0 -0.099,0.0203 -0.13443,0.0557 -0.0357,0.0357 -0.0557,0.0842 -0.0557,0.13443 v 0.002 c 0,0.0506 0.02,0.099 0.0557,0.13443 0.0354,0.0357 0.0839,0.0557 0.13443,0.0557 h 5.32554 c 0.0503,0 0.0987,-0.02 0.13443,-0.0557 0.0357,-0.0354 0.0557,-0.0839 0.0557,-0.13443 z"
+         fill="url(#c)"
+         id="path563"
+         style="display:inline;enable-background:new;fill:url(#linearGradient577);stroke-width:0.302777" />
+      <path
+         d="m 327.86985,239.62992 c 1.67224,0 3.02777,1.35553 3.02777,3.02777 0,1.67223 -1.35553,3.02776 -3.02777,3.02776 h -3.02776 v -3.02776 c 0,-1.67224 1.35553,-3.02777 3.02776,-3.02777 z m 0,1.51388 c -0.83596,0 -1.51388,0.67792 -1.51388,1.51389 0,0.83596 0.67792,1.51388 1.51388,1.51388 0.83597,0 1.51389,-0.67792 1.51389,-1.51388 0,-0.83597 -0.67792,-1.51389 -1.51389,-1.51389 z"
+         fill="#a1a7ae"
+         fill-rule="nonzero"
+         id="path565"
+         style="display:inline;enable-background:new;stroke-width:0.302777" />
       <circle
-         r="8"
-         cy="199"
-         cx="332.00018"
-         id="circle1602"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.34782606;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.04347819, 1.04347819;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         cx="332.02213"
+         cy="248.02107"
+         r="2.9789314"
+         fill="#8645fb"
+         stroke-width="0.270812"
+         id="circle567"
+         style="display:inline;enable-background:new" />
       <path
-         inkscape:connector-curvature="0"
-         style="display:inline;opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:15.99999905;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 152.00016,68.999851 c -39.21221,0 -70.99999,31.787789 -70.99999,70.999999 0,0.31752 0.01988,0.63015 0.02405,0.94667 0.509032,-38.77386 32.08126,-70.053337 70.97596,-70.053337 38.89468,0 70.4669,31.279477 70.97595,70.053337 0.004,-0.31652 0.024,-0.62915 0.024,-0.94667 0,-39.21221 -31.78778,-70.999999 -70.99999,-70.999999 z"
-         id="path1446" />
-      <path
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 92.00017,59.999822 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
-         id="path2571"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 212.00017,59.999822 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
-         id="path2569"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="sssss"
-         inkscape:connector-curvature="0"
-         id="path1516"
-         d="m 344.00017,94.999996 c -7.73199,0 -14,-6.268012 -14,-14 0,-7.731986 6.26801,-13.999999 14,-13.999999 7.73198,0 14,6.268013 14,13.999999 0,7.731988 -6.26802,14 -14,14 z"
-         style="display:inline;opacity:1;fill:url(#linearGradient2531);fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      <ellipse
-         ry="6.8266683"
-         rx="6.8266664"
-         cy="80.999924"
-         cx="344.00015"
-         id="ellipse1518"
-         style="display:inline;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:15.99999809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      <ellipse
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:15.99999809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="ellipse1520"
-         cx="344.00015"
-         cy="80.999924"
-         rx="4.2666664"
-         ry="4.2666674" />
-      <g
-         style="opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:4.6875"
-         id="g1546"
-         transform="matrix(0.21333333,0,0,0.21333333,311.5735,47.719997)">
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1522"
-           cx="53.63586"
-           cy="185.09996"
-           r="2"
-           transform="rotate(-30)" />
-        <circle
-           r="2"
-           cy="237.09996"
-           cx="53.63586"
-           id="circle1524"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-30)" />
-        <circle
-           r="2"
-           cy="183.63586"
-           cx="-59.099964"
-           id="circle1526"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-60)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1528"
-           cx="-59.099964"
-           cy="235.63586"
-           r="2"
-           transform="rotate(-60)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1530"
-           cx="-156"
-           cy="126"
-           r="2"
-           transform="rotate(-90)" />
-        <circle
-           r="2"
-           cy="178"
-           cx="-156"
-           id="circle1532"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-90)" />
-        <circle
-           r="2"
-           cy="27.63586"
-           cx="-211.09996"
-           id="circle1534"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-120)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1536"
-           cx="-211.09996"
-           cy="79.635864"
-           r="2"
-           transform="rotate(-120)" />
-        <circle
-           transform="rotate(-150,152,156)"
-           r="2"
-           cy="130"
-           cx="152"
-           id="circle1538"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <circle
-           transform="rotate(-150,152,156)"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1540"
-           cx="152"
-           cy="182"
-           r="2" />
-        <circle
-           r="2"
-           cy="-182"
-           cx="-152"
-           id="circle1542"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="scale(-1)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1544"
-           cx="-152"
-           cy="-130"
-           r="2"
-           transform="scale(-1)" />
-      </g>
-      <ellipse
-         ry="3.4133341"
-         rx="3.4133332"
-         cy="80.999924"
-         cx="344.00015"
-         id="ellipse1548"
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:15.99999809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      <ellipse
-         ry="0.85333353"
-         rx="0.85333329"
-         cy="81.000023"
-         cx="344.00024"
-         id="ellipse1550"
-         style="display:inline;opacity:1;fill:#888888;fill-opacity:1;stroke:none;stroke-width:15.99998379;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      <g
-         style="display:inline;stroke-width:7.89473677;enable-background:new"
-         transform="matrix(0.12666667,0,0,0.12666667,316.74684,127.24)"
-         id="g1592">
-        <path
-           sodipodi:nodetypes="sssss"
-           inkscape:connector-curvature="0"
-           id="path1556"
-           d="m 152,231 c -41.42135,0 -75,-33.57864 -75,-75 0,-41.42136 33.57865,-75 75,-75 41.42135,0 75,33.57864 75,75 0,41.42136 -33.57865,75 -75,75 z"
-           style="display:inline;opacity:1;fill:url(#linearGradient2533);fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <ellipse
-           ry="32.000008"
-           rx="32"
-           cy="155.99965"
-           cx="151.99992"
-           id="ellipse1558"
-           style="display:inline;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31577301;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <ellipse
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:126.31577301;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="ellipse1560"
-           cx="151.99992"
-           cy="155.99965"
-           rx="20"
-           ry="20.000004" />
-        <g
-           style="opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:7.89473677"
-           id="g1586">
-          <circle
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1562"
-             cx="53.63586"
-             cy="185.09996"
-             r="2"
-             transform="rotate(-30)" />
-          <circle
-             r="2"
-             cy="237.09996"
-             cx="53.63586"
-             id="circle1564"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             transform="rotate(-30)" />
-          <circle
-             r="2"
-             cy="183.63586"
-             cx="-59.099964"
-             id="circle1566"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             transform="rotate(-60)" />
-          <circle
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1568"
-             cx="-59.099964"
-             cy="235.63586"
-             r="2"
-             transform="rotate(-60)" />
-          <circle
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1570"
-             cx="-156"
-             cy="126"
-             r="2"
-             transform="rotate(-90)" />
-          <circle
-             r="2"
-             cy="178"
-             cx="-156"
-             id="circle1572"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             transform="rotate(-90)" />
-          <circle
-             r="2"
-             cy="27.63586"
-             cx="-211.09996"
-             id="circle1574"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             transform="rotate(-120)" />
-          <circle
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1576"
-             cx="-211.09996"
-             cy="79.635864"
-             r="2"
-             transform="rotate(-120)" />
-          <circle
-             transform="rotate(-150,152,156)"
-             r="2"
-             cy="130"
-             cx="152"
-             id="circle1578"
-             style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-          <circle
-             transform="rotate(-150,152,156)"
-             style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-             id="circle1580"
-             cx="152"
-             cy="182"
-             r="2" />
-          <circle
-             r="2"
-             cy="-182"
-             cx="-152"
-             id="circle1582"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             transform="scale(-1)" />
-          <circle
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31578827;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1584"
-             cx="-152"
-             cy="-130"
-             r="2"
-             transform="scale(-1)" />
-        </g>
-        <ellipse
-           ry="16.000004"
-           rx="16"
-           cy="155.99965"
-           cx="151.99992"
-           id="ellipse1588"
-           style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.31577301;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <ellipse
-           ry="4.000001"
-           rx="4"
-           cy="156.00012"
-           cx="152.00037"
-           id="ellipse1590"
-           style="display:inline;opacity:1;fill:#888888;fill-opacity:1;stroke:none;stroke-width:126.31565094;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
-      <g
-         id="g1633"
-         transform="matrix(0.09333333,0,0,0.09333333,317.8135,184.44001)"
-         style="display:inline;stroke-width:10.71428585;enable-background:new">
-        <path
-           style="display:inline;opacity:1;fill:url(#linearGradient2535);fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 152,231 c -41.42135,0 -75,-33.57864 -75,-75 0,-41.42136 33.57865,-75 75,-75 41.42135,0 75,33.57864 75,75 0,41.42136 -33.57865,75 -75,75 z"
-           id="path1596"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="sssss" />
-        <ellipse
-           style="display:inline;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42855835;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="ellipse1598"
-           cx="151.99992"
-           cy="155.99965"
-           rx="32"
-           ry="32.000008" />
-        <ellipse
-           ry="20.000004"
-           rx="20"
-           cy="155.99965"
-           cx="151.99992"
-           id="ellipse1600"
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:171.42855835;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <g
-           id="g1627"
-           style="opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:10.71428585">
-          <circle
-             transform="rotate(-30)"
-             r="2"
-             cy="185.09996"
-             cx="53.63586"
-             id="circle1603"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-          <circle
-             transform="rotate(-30)"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1605"
-             cx="53.63586"
-             cy="237.09996"
-             r="2" />
-          <circle
-             transform="rotate(-60)"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1607"
-             cx="-59.099964"
-             cy="183.63586"
-             r="2" />
-          <circle
-             transform="rotate(-60)"
-             r="2"
-             cy="235.63586"
-             cx="-59.099964"
-             id="circle1609"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-          <circle
-             transform="rotate(-90)"
-             r="2"
-             cy="126"
-             cx="-156"
-             id="circle1611"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-          <circle
-             transform="rotate(-90)"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1613"
-             cx="-156"
-             cy="178"
-             r="2" />
-          <circle
-             transform="rotate(-120)"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1615"
-             cx="-211.09996"
-             cy="27.63586"
-             r="2" />
-          <circle
-             transform="rotate(-120)"
-             r="2"
-             cy="79.635864"
-             cx="-211.09996"
-             id="circle1617"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-          <circle
-             style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-             id="circle1619"
-             cx="152"
-             cy="130"
-             r="2"
-             transform="rotate(-150,152,156)" />
-          <circle
-             r="2"
-             cy="182"
-             cx="152"
-             id="circle1621"
-             style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-             transform="rotate(-150,152,156)" />
-          <circle
-             transform="scale(-1)"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1623"
-             cx="-152"
-             cy="-182"
-             r="2" />
-          <circle
-             transform="scale(-1)"
-             r="2"
-             cy="-130"
-             cx="-152"
-             id="circle1625"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42857361;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        </g>
-        <ellipse
-           style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.42855835;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="ellipse1629"
-           cx="151.99992"
-           cy="155.99965"
-           rx="16"
-           ry="16.000004" />
-        <ellipse
-           style="display:inline;opacity:1;fill:#888888;fill-opacity:1;stroke:none;stroke-width:171.4283905;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="ellipse1631"
-           cx="152.00037"
-           cy="156.00012"
-           rx="4"
-           ry="4.000001" />
-      </g>
-      <g
-         style="display:inline;stroke-width:18.75;enable-background:new"
-         transform="matrix(0.05333333,0,0,0.05333333,319.8935,234.67982)"
-         id="g1673">
-        <path
-           sodipodi:nodetypes="sssss"
-           inkscape:connector-curvature="0"
-           id="path1637"
-           d="m 152,231 c -41.42135,0 -75,-33.57864 -75,-75 0,-41.42136 33.57865,-75 75,-75 41.42135,0 75,33.57864 75,75 0,41.42136 -33.57865,75 -75,75 z"
-           style="display:inline;opacity:1;fill:url(#linearGradient1394);fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <ellipse
-           ry="32.000008"
-           rx="32"
-           cy="155.99965"
-           cx="151.99992"
-           id="ellipse1639"
-           style="display:inline;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:299.99996948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <ellipse
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:299.99996948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="ellipse1641"
-           cx="151.99992"
-           cy="155.99965"
-           rx="20"
-           ry="20.000004" />
-        <g
-           style="opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:18.75"
-           id="g1667">
-          <circle
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1643"
-             cx="53.63586"
-             cy="185.09996"
-             r="2"
-             transform="rotate(-30)" />
-          <circle
-             r="2"
-             cy="237.09996"
-             cx="53.63586"
-             id="circle1645"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             transform="rotate(-30)" />
-          <circle
-             r="2"
-             cy="183.63586"
-             cx="-59.099964"
-             id="circle1647"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             transform="rotate(-60)" />
-          <circle
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1649"
-             cx="-59.099964"
-             cy="235.63586"
-             r="2"
-             transform="rotate(-60)" />
-          <circle
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1651"
-             cx="-156"
-             cy="126"
-             r="2"
-             transform="rotate(-90)" />
-          <circle
-             r="2"
-             cy="178"
-             cx="-156"
-             id="circle1653"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             transform="rotate(-90)" />
-          <circle
-             r="2"
-             cy="27.63586"
-             cx="-211.09996"
-             id="circle1655"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             transform="rotate(-120)" />
-          <circle
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1657"
-             cx="-211.09996"
-             cy="79.635864"
-             r="2"
-             transform="rotate(-120)" />
-          <circle
-             transform="rotate(-150,152,156)"
-             r="2"
-             cy="130"
-             cx="152"
-             id="circle1659"
-             style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-          <circle
-             transform="rotate(-150,152,156)"
-             style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-             id="circle1661"
-             cx="152"
-             cy="182"
-             r="2" />
-          <circle
-             r="2"
-             cy="-182"
-             cx="-152"
-             id="circle1663"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             transform="scale(-1)" />
-          <circle
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1665"
-             cx="-152"
-             cy="-130"
-             r="2"
-             transform="scale(-1)" />
-        </g>
-        <ellipse
-           ry="16.000004"
-           rx="16"
-           cy="155.99965"
-           cx="151.99992"
-           id="ellipse1669"
-           style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:299.99996948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <ellipse
-           ry="4.000001"
-           rx="4"
-           cy="156.00012"
-           cx="152.00037"
-           id="ellipse1671"
-           style="display:inline;opacity:1;fill:#888888;fill-opacity:1;stroke:none;stroke-width:299.99963379;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
-      <g
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:5.33333349;enable-background:new;"
-         transform="matrix(0.18111109,-0.04852857,0.04852857,0.18111109,274.93213,78.003037)"
-         id="g1733">
-        <path
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:85.33333588;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 392.7526,156.91646 c 0,0 -117.99478,44.0399 -124.39639,45.7552 -6.40159,1.71532 -12.98163,-2.08367 -14.69694,-8.48526 -1.7153,-6.40159 2.08369,-12.98164 8.48528,-14.69695 6.40161,-1.71529 130.60805,-22.57299 130.60805,-22.57299 z"
-           id="path1729"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssc" />
-        <circle
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:85.33333588;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1731"
-           cx="265.24741"
-           cy="191.08354"
-           r="4" />
-      </g>
-      <g
-         id="g1709"
-         transform="matrix(0.18111109,-0.04852857,0.04852857,0.18111109,274.93213,77.003255)"
-         style="display:inline;stroke-width:5.33333349;enable-background:new"
-         inkscape:transform-center-x="-9.6330497"
-         inkscape:transform-center-y="-5.0900557">
-        <path
-           sodipodi:nodetypes="csssc"
-           inkscape:connector-curvature="0"
-           id="path1038-3"
-           d="m 392.7526,156.91646 c 0,0 -117.99478,44.0399 -124.39639,45.7552 -6.40159,1.71532 -12.98163,-2.08367 -14.69694,-8.48526 -1.7153,-6.40159 2.08369,-12.98164 8.48528,-14.69695 6.40161,-1.71529 130.60805,-22.57299 130.60805,-22.57299 z"
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:85.33333588;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <circle
-           r="4"
-           cy="191.08354"
-           cx="265.24741"
-           id="path1041-6"
-           style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:85.33333588;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
-      <g
-         id="g1739"
-         transform="matrix(0.07853257,-0.0247671,0.0247671,0.07853257,300.44496,200.16417)"
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:12.14396286;enable-background:new">
-        <path
-           sodipodi:nodetypes="csssc"
-           inkscape:connector-curvature="0"
-           id="path1735"
-           d="m 392.7526,156.91646 c 0,0 -117.99478,44.0399 -124.39639,45.7552 -6.40159,1.71532 -12.98163,-2.08367 -14.69694,-8.48526 -1.7153,-6.40159 2.08369,-12.98164 8.48528,-14.69695 6.40161,-1.71529 130.60805,-22.57299 130.60805,-22.57299 z"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:194.30340576;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <circle
-           r="4"
-           cy="191.08354"
-           cx="265.24741"
-           id="circle1737"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:194.30340576;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
-      <g
-         style="display:inline;stroke-width:12.14396286;enable-background:new"
-         transform="matrix(0.07837764,-0.02525309,0.02525309,0.07837764,300.38139,199.34845)"
-         id="g1715"
-         inkscape:transform-center-x="-4.096619"
-         inkscape:transform-center-y="-2.432834">
-        <path
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:194.30340576;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 392.7526,156.91646 c 0,0 -117.99478,44.0399 -124.39639,45.7552 -6.40159,1.71532 -12.98163,-2.08367 -14.69694,-8.48526 -1.7153,-6.40159 2.08369,-12.98164 8.48528,-14.69695 6.40161,-1.71529 130.60805,-22.57299 130.60805,-22.57299 z"
-           id="path1711"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssc" />
-        <circle
-           style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:194.30340576;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1713"
-           cx="265.24741"
-           cy="191.08354"
-           r="4" />
-      </g>
-      <g
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:7.61116982;enable-background:new"
-         transform="matrix(0.12411971,-0.04308758,0.04308758,0.12411971,286.79532,145.95914)"
-         id="g1745">
-        <path
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:121.77871704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 391.48498,166.76206 c 0,0 -119.46113,39.89136 -125.91875,41.382 -6.4576,1.49066 -12.90092,-2.53586 -14.39157,-8.99346 -1.49064,-6.4576 2.53588,-12.90094 8.99348,-14.39159 6.45762,-1.49063 131.31684,-17.99695 131.31684,-17.99695 z"
-           id="path1741"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssc" />
-        <circle
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:121.77871704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1743"
-           cx="265.24741"
-           cy="191.08354"
-           r="4" />
-      </g>
-      <g
-         id="g1721"
-         transform="matrix(0.13127024,-0.00551051,0.00551051,0.13127024,291.84825,134.15374)"
-         style="display:inline;stroke-width:7.61116982;enable-background:new">
-        <path
-           sodipodi:nodetypes="csssc"
-           inkscape:connector-curvature="0"
-           id="path1717"
-           d="m 381.92298,128.90588 c 0,0 -104.7647,69.9045 -110.60296,73.04098 -5.83825,3.13649 -13.1137,0.94626 -16.25017,-4.89199 -3.13647,-5.83825 -0.94625,-13.11371 4.892,-16.25019 5.83827,-3.13646 121.96113,-51.8988 121.96113,-51.8988 z"
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:121.77871704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           inkscape:transform-center-x="-6.891158"
-           inkscape:transform-center-y="-3.3061164" />
-        <circle
-           r="4"
-           cy="191.08354"
-           cx="265.24741"
-           id="circle1719"
-           style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:121.77871704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
-      <g
-         style="display:inline;stroke-width:17.77777863;enable-background:new"
-         transform="matrix(0.05233474,-0.02061886,0.02061886,0.05233474,305.85292,244.29336)"
-         id="g1727"
-         inkscape:transform-center-x="-2.6475068"
-         inkscape:transform-center-y="-1.8731172">
-        <path
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:284.44445801;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 392.7526,156.91646 c 0,0 -117.99478,44.0399 -124.39639,45.7552 -6.40159,1.71532 -12.98163,-2.08367 -14.69694,-8.48526 -1.7153,-6.40159 2.08369,-12.98164 8.48528,-14.69695 6.40161,-1.71529 130.60805,-22.57299 130.60805,-22.57299 z"
-           id="path1723"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssc" />
-        <circle
-           style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:284.44445801;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1725"
-           cx="265.24741"
-           cy="191.08354"
-           r="4" />
-      </g>
-      <path
-         sodipodi:nodetypes="csssc"
-         inkscape:connector-curvature="0"
-         id="path1467"
-         d="m 211.50536,215.83276 c 0,0 -117.99478,44.0399 -124.39638,45.7552 -6.4016,1.71532 -12.98164,-2.08367 -14.69694,-8.48526 -1.71531,-6.40159 2.08368,-12.98164 8.48528,-14.69695 6.4016,-1.71529 130.60804,-22.57299 130.60804,-22.57299 z"
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter1469);enable-background:new"
-         transform="rotate(-15,90.582512,216.7248)" />
-      <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 206.6365,182.63416 c 0,0 -102.57584,73.07858 -108.315358,76.39228 -5.739513,3.31373 -13.078595,1.34723 -16.392301,-4.39228 -3.313715,-5.73951 -1.347215,-13.0786 4.392301,-16.39232 5.739521,-3.31369 120.315358,-55.60768 120.315358,-55.60768 z"
-         id="path1038"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csssc" />
-      <circle
-         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="path1041"
-         cx="24.821136"
-         cy="264.05957"
-         r="4"
-         transform="rotate(-15)" />
-      <path
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 212.00017,243.99984 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
-         id="circle1473"
-         inkscape:connector-curvature="0" />
+         d="m 331.56433,246.20411 -0.0403,0.47839 c -0.15321,0.0563 -0.29551,0.13776 -0.42117,0.24131 l -0.43872,-0.20468 -0.4581,0.78662 0.39815,0.27431 c -0.0139,0.0793 -0.0215,0.15987 -0.0218,0.24071 0,0.0811 0.007,0.16199 0.0209,0.24192 l -0.39785,0.27341 0.45841,0.78661 0.43751,-0.20438 c 0.12595,0.10295 0.26856,0.18409 0.42177,0.2398 l 0.0403,0.4796 h 0.9165 l 0.0406,-0.47838 c 0.15291,-0.0563 0.29551,-0.13777 0.42086,-0.24132 l 0.43873,0.20468 0.4584,-0.78661 -0.39845,-0.27432 c 0.0142,-0.0793 0.0215,-0.15987 0.0221,-0.24071 -3.1e-4,-0.0811 -0.007,-0.16198 -0.0212,-0.24161 l 0.39755,-0.2728 -0.4581,-0.78692 -0.43782,0.20437 c -0.12595,-0.10294 -0.26856,-0.18409 -0.42176,-0.2398 l -0.0406,-0.47959 h -0.9165 z m 0.45841,0.94708 c 0.48111,0 0.87714,0.39271 0.87714,0.86958 0,0.47687 -0.39603,0.86957 -0.87714,0.86957 -0.48142,0 -0.87745,-0.3927 -0.87745,-0.86957 0,-0.47687 0.39603,-0.86958 0.87745,-0.86958 z"
+         fill="#ffffff"
+         fill-rule="nonzero"
+         id="path569"
+         style="display:inline;enable-background:new;stroke-width:0.302777" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/evince.svg
+++ b/icons/src/fullcolor/default/apps/evince.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="evince.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="/home/stuart/Pictures/evince rearranged.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="4"
-     inkscape:cx="192.75"
-     inkscape:cy="225.125"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="2"
+     inkscape:cx="335"
+     inkscape:cy="223.5"
+     inkscape:current-layer="layer7"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -55,7 +55,7 @@
      inkscape:window-maximized="1"
      inkscape:bbox-paths="true"
      inkscape:snap-bbox-midpoints="true"
-     inkscape:snap-global="false"
+     inkscape:snap-global="true"
      inkscape:object-paths="true"
      inkscape:snap-intersection-paths="true"
      inkscape:snap-smooth-nodes="true"
@@ -92,388 +92,226 @@
   </sodipodi:namedview>
   <defs
      id="defs3">
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4346"
-       x="-0.014454287"
-       width="1.0289086"
-       y="-0.011357288"
-       height="1.0227146">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.120027"
-         id="feGaussianBlur4348" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4380"
-       x="-0.057817147"
-       width="1.1156343"
-       y="-0.045429151"
-       height="1.0908583">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="8.4801079"
-         id="feGaussianBlur4382" />
-    </filter>
     <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940-3"
+       id="linearGradient1011"
+       x1="500"
+       y1="272.36218"
+       x2="500"
+       y2="812.36218"
        gradientUnits="userSpaceOnUse"
-       y2="169.65668"
-       x2="4.4137931"
-       y1="386.29544"
-       x1="494.34482"
-       id="linearGradient4226"
-       xlink:href="#linearGradient4245"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.957,268)" />
+       gradientTransform="translate(-621,-415.36218)" />
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="linearGradient940-3">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop936"
          offset="0"
-         id="stop923" />
+         style="stop-color:#f6f7f7;stop-opacity:1" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         id="stop938"
          offset="1"
-         id="stop925" />
-    </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient916"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05921519,0.05978336,0,313.2699,214.63635)"
-       x1="441.37936"
-       y1="240.30258"
-       x2="52.965523"
-       y2="386.30795" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient920"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.0386186,0.03904659,0,315.4715,253.54546)"
-       x1="441.37933"
-       y1="240.28154"
-       x2="52.9655"
-       y2="401.42957" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient3194"
-       x1="335.23154"
-       y1="61.500046"
-       x2="352.27026"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004-8"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient3257"
-       x1="330.0751"
-       y1="133.5"
-       x2="341.92554"
-       y2="162.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4245"
-       inkscape:collect="always">
-      <stop
-         id="stop4241"
-         offset="0"
-         style="stop-color:#e8e8e8;stop-opacity:1" />
-      <stop
-         id="stop4243"
-         offset="1"
-         style="stop-color:#f5f5f5;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4285"
-       id="linearGradient1269"
-       gradientUnits="userSpaceOnUse"
-       x1="252.43637"
-       y1="260.07782"
-       x2="346.827"
-       y2="354.46844"
-       spreadMethod="reflect" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4285">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4287" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4289" />
+         style="stop-color:#dce7f0;stop-opacity:1" />
     </linearGradient>
     <filter
-       inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
-       id="filter4293"
-       x="-0.087219745"
-       width="1.1744395"
-       y="-0.24914967"
-       height="1.4982993">
+       inkscape:label="Drop Shadow"
+       id="filter977"
+       x="-0.013090909"
+       y="-0.015945539"
+       width="1.0261818"
+       height="1.0385351">
+      <feFlood
+         flood-opacity="0.294118"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood967" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite969" />
       <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="10.787499"
-         id="feGaussianBlur4295" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4279"
-       x="-0.010902468"
-       width="1.0218049"
-       y="-0.031143709"
-       height="1.0622874">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.3484374"
-         id="feGaussianBlur4281" />
+         in="composite1"
+         stdDeviation="3"
+         result="blur"
+         id="feGaussianBlur971" />
+      <feOffset
+         dx="0"
+         dy="3"
+         result="offset"
+         id="feOffset973" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite975" />
     </filter>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4254"
-       id="linearGradient1271"
+       xlink:href="#linearGradient966"
+       id="linearGradient4835"
+       x1="102.29776"
+       y1="-0.42686829"
+       x2="102.29776"
+       y2="199.16539"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)"
-       x1="140.44914"
-       y1="291.43301"
-       x2="217.68591"
-       y2="214.19624" />
+       gradientTransform="matrix(1.12,0,0,1.12,40.00001,43.657145)" />
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4254">
+       id="linearGradient966">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop960"
          offset="0"
-         id="stop4256" />
+         style="stop-color:#ff577e;stop-opacity:1" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:0.3"
+         id="stop964"
          offset="1"
-         id="stop4258" />
+         style="stop-color:#f73358;stop-opacity:1" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4254"
-       id="linearGradient1273"
+       xlink:href="#linearGradient4903"
+       id="linearGradient1009"
+       x1="520"
+       y1="32.362179"
+       x2="520"
+       y2="1052.3622"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)"
-       x1="299.56567"
-       y1="298.92688"
-       x2="373.3111"
-       y2="225.18146" />
+       gradientTransform="matrix(0.29166668,0,0,0.29166668,4.2483795,-3.5487751)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4285"
-       id="linearGradient2648"
-       gradientUnits="userSpaceOnUse"
-       x1="252.43637"
-       y1="260.07782"
-       x2="346.827"
-       y2="354.46844"
-       spreadMethod="reflect" />
+       id="linearGradient4903">
+      <stop
+         style="stop-color:#e8ebec;stop-opacity:1"
+         offset="0"
+         id="stop4905" />
+      <stop
+         style="stop-color:#fdfeff;stop-opacity:1"
+         offset="1"
+         id="stop4907" />
+    </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4254"
-       id="linearGradient2650"
+       xlink:href="#linearGradient940-3"
+       id="linearGradient1046"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)"
-       x1="140.44914"
-       y1="291.43301"
-       x2="217.68591"
-       y2="214.19624" />
+       gradientTransform="translate(-621,-415.36218)"
+       x1="500"
+       y1="272.36218"
+       x2="500"
+       y2="812.36218" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4254"
-       id="linearGradient2652"
+       xlink:href="#linearGradient966"
+       id="linearGradient1048"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)"
-       x1="299.56567"
-       y1="298.92688"
-       x2="373.3111"
-       y2="225.18146" />
+       gradientTransform="matrix(0.23,0,0,0.23,321,60.929592)"
+       x1="102.29776"
+       y1="-0.42686829"
+       x2="102.29776"
+       y2="199.16539" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4285"
-       id="linearGradient2654"
+       xlink:href="#linearGradient4903"
+       id="linearGradient1050"
        gradientUnits="userSpaceOnUse"
-       x1="252.43637"
-       y1="260.07782"
-       x2="346.827"
-       y2="354.46844"
-       spreadMethod="reflect" />
+       gradientTransform="matrix(0.05989584,0,0,0.05989584,313.65815,51.23552)"
+       x1="520"
+       y1="32.362179"
+       x2="520"
+       y2="1052.3622" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4254"
-       id="linearGradient2656"
+       xlink:href="#linearGradient940-3"
+       id="linearGradient1058"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)"
-       x1="140.44914"
-       y1="291.43301"
-       x2="217.68591"
-       y2="214.19624" />
+       gradientTransform="translate(-621,-415.36218)"
+       x1="500"
+       y1="272.36218"
+       x2="500"
+       y2="812.36218" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4254"
-       id="linearGradient2658"
+       xlink:href="#linearGradient966"
+       id="linearGradient1060"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)"
-       x1="299.56567"
-       y1="298.92688"
-       x2="373.3111"
-       y2="225.18146" />
+       gradientTransform="matrix(0.15,0,0,0.15,320.99999,133)"
+       x1="102.29776"
+       y1="-0.42686829"
+       x2="102.29776"
+       y2="199.16539" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4285"
-       id="linearGradient2660"
+       xlink:href="#linearGradient4903"
+       id="linearGradient1062"
        gradientUnits="userSpaceOnUse"
-       x1="252.43637"
-       y1="260.07782"
-       x2="346.827"
-       y2="354.46844"
-       spreadMethod="reflect" />
+       gradientTransform="matrix(0.0390625,0,0,0.0390625,316.21182,126.67778)"
+       x1="520"
+       y1="32.362179"
+       x2="520"
+       y2="1052.3622" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4254"
-       id="linearGradient2662"
+       xlink:href="#linearGradient940-3"
+       id="linearGradient1070"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)"
-       x1="140.44914"
-       y1="291.43301"
-       x2="217.68591"
-       y2="214.19624" />
+       gradientTransform="translate(-621,-415.36218)"
+       x1="500"
+       y1="272.36218"
+       x2="500"
+       y2="812.36218" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4254"
-       id="linearGradient2664"
+       xlink:href="#linearGradient966"
+       id="linearGradient1072"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)"
-       x1="299.56567"
-       y1="298.92688"
-       x2="373.3111"
-       y2="225.18146" />
+       gradientTransform="matrix(0.11499999,0,0,0.11499999,320.49998,188.49999)"
+       x1="102.29776"
+       y1="-0.42686829"
+       x2="102.29776"
+       y2="199.16539" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4285"
-       id="linearGradient2666"
+       xlink:href="#linearGradient4903"
+       id="linearGradient1074"
        gradientUnits="userSpaceOnUse"
-       x1="252.43637"
-       y1="260.07782"
-       x2="346.827"
-       y2="354.46844"
-       spreadMethod="reflect" />
+       gradientTransform="matrix(0.02994791,0,0,0.02994791,316.82905,183.65296)"
+       x1="520"
+       y1="32.362179"
+       x2="520"
+       y2="1052.3622" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4254"
-       id="linearGradient2668"
+       xlink:href="#linearGradient940-3"
+       id="linearGradient1082"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)"
-       x1="140.44914"
-       y1="291.43301"
-       x2="217.68591"
-       y2="214.19624" />
+       gradientTransform="translate(-621,-415.36218)"
+       x1="500"
+       y1="272.36218"
+       x2="500"
+       y2="812.36218" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4254"
-       id="linearGradient2670"
+       xlink:href="#linearGradient966"
+       id="linearGradient1084"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)"
-       x1="299.56567"
-       y1="298.92688"
-       x2="373.3111"
-       y2="225.18146" />
+       gradientTransform="matrix(0.07499999,0,0,0.07499999,320.49999,236.49999)"
+       x1="102.29776"
+       y1="-0.42686829"
+       x2="102.29776"
+       y2="199.16539" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4903"
+       id="linearGradient1086"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01953125,0,0,0.01953125,318.1059,233.33889)"
+       x1="520"
+       y1="32.362179"
+       x2="520"
+       y2="1052.3622" />
   </defs>
   <metadata
      id="metadata4">
@@ -549,7 +387,8 @@
        style="display:none"
        inkscape:label="Baseplate"
        id="layer7"
-       inkscape:groupmode="layer">
+       inkscape:groupmode="layer"
+       sodipodi:insensitive="true">
       <text
          y="-8.2548828"
          xml:space="preserve"
@@ -573,7 +412,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">evince</tspan></text>
+           id="tspan924">evince</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -608,737 +447,119 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86523,189 c -1.12014,0 -2.01524,0.0241 -2.79101,0.1543 -0.77577,0.13022 -1.48014,0.38763 -2.00977,0.91601 -0.52962,0.52838 -0.79079,1.23687 -0.91992,2.01367 -0.12912,0.77681 -0.15002,1.67169 -0.14453,2.79493 V 201 v 6.125 c -0.005,1.12104 0.0156,2.01529 0.14453,2.79102 0.12912,0.77681 0.39029,1.48529 0.91992,2.01367 0.52964,0.52838 1.234,0.78579 2.00977,0.91601 0.77577,0.13022 1.67087,0.1543 2.79101,0.1543 h 8.26954 c 1.12013,0 2.01264,-0.024 2.78711,-0.1543 0.77446,-0.13033 1.48001,-0.38927 2.00781,-0.91797 0.5278,-0.52869 0.78594,-1.23438 0.91601,-2.00976 C 341.97577,209.14258 342,208.24735 342,207.125 V 201 194.875 c 0,-1.12235 -0.0242,-2.01758 -0.1543,-2.79297 -0.13007,-0.77538 -0.38821,-1.48107 -0.91601,-2.00976 -0.5278,-0.5287 -1.23334,-0.78764 -2.00781,-0.91797 C 338.1474,189.02397 337.25491,189 336.13477,189 Z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 330.19336,134 c -1.42096,0 -2.54883,0.0308 -3.50586,0.19141 -0.95703,0.16064 -1.79146,0.4726 -2.41211,1.09179 -0.62065,0.61919 -0.93647,1.45612 -1.0957,2.41407 -0.15924,0.95795 -0.18666,2.08705 -0.17969,3.51171 V 149 v 7.79688 c -0.007,1.42131 0.0207,2.5495 0.17969,3.50585 0.15923,0.95796 0.47505,1.79488 1.0957,2.41407 0.62065,0.61919 1.45508,0.93115 2.41211,1.09179 0.95703,0.16065 2.0849,0.19141 3.50586,0.19141 h 11.61523 c 1.42097,0 2.54669,-0.0307 3.50196,-0.19141 0.95527,-0.16075 1.78779,-0.47425 2.40625,-1.09375 0.61845,-0.6195 0.93134,-1.45363 1.09179,-2.41015 C 348.96905,159.34816 349,158.22066 349,156.79688 V 149 141.20312 c 0,-1.42378 -0.031,-2.55128 -0.19141,-3.50781 -0.16045,-0.95653 -0.47334,-1.79065 -1.09179,-2.41015 -0.61846,-0.61951 -1.45098,-0.933 -2.40625,-1.09375 C 344.35528,134.03065 343.22956,134 341.80859,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.23093,61.500047 c -2.22316,0 -3.97368,0.05118 -5.41406,0.292969 -1.44039,0.241784 -2.61905,0.695299 -3.48243,1.55664 -0.86337,0.861342 -1.31906,2.039471 -1.55859,3.480469 -0.23953,1.440999 -0.28629,3.195341 -0.27539,5.423828 V 85 97.752143 c -0.0108,2.225063 0.0361,3.978517 0.27539,5.417967 0.23953,1.441 0.69522,2.61913 1.55859,3.48047 0.86338,0.86134 2.04204,1.31486 3.48243,1.55664 1.44039,0.24179 3.1909,0.29297 5.41406,0.29297 h 17.53883 c 2.22317,0 3.97276,-0.0511 5.41017,-0.29297 1.4374,-0.24189 2.61246,-0.69694 3.47265,-1.55859 0.8602,-0.86165 1.31319,-2.03894 1.55468,-3.47852 0.24149,-1.43957 0.29297,-3.190353 0.29297,-5.417967 V 85 72.248094 c 0,-2.227614 -0.0515,-3.978392 -0.29297,-5.417969 -0.24149,-1.439576 -0.69449,-2.616863 -1.55469,-3.478516 -0.86019,-0.861652 -2.03525,-1.316704 -3.47265,-1.558593 -1.4374,-0.24189 -3.187,-0.292969 -5.41016,-0.292969 z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path4350"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 464,514.75001 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4380);enable-background:accumulate"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.02028775;marker:none;enable-background:accumulate"
-         d="M 101.8116,42 C 65.712789,42 61.828597,45.690158 62.005519,81.689842 V 156 230.31016 C 61.828597,266.30985 65.712789,270 101.8116,270 h 100.38732 c 36.09881,0 39.80608,-3.68973 39.80608,-39.68984 V 156 81.689842 C 242.005,45.689729 238.29773,42 202.19892,42 Z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 201.07298,44 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 156 229.00647 C 240.16759,264.37459 236.36971,268 201.07298,268 H 102.91622 C 67.619504,268 63.994604,264.375 63.994604,229.00647 V 156 82.99353 C 63.994604,47.624997 67.619504,44 102.91622,44 Z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 239.99414,216.00586 188,268 h 13.07227 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 z"
-         id="rect4158-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188,44 C 67.625152,44 63.82701,47.626029 64,82.994141 v 2 C 63.82701,49.626029 67.625152,46 102.92188,46 h 98.15624 C 236.37485,46 240,49.625608 240,84.994141 v -2 C 240,47.625608 236.37485,44 201.07812,44 Z"
-         id="path931"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 327.636,188.49999 c -4.65703,0 -5.15812,0.47378 -5.1353,5.09575 v 6.40425 6.40426 c -0.0229,4.62196 0.47827,5.09574 5.1353,5.09574 h 8.72869 c 4.65703,0 5.1353,-0.47372 5.1353,-5.09574 v -6.40426 -6.40425 c 0,-4.62202 -0.47828,-5.09575 -5.13531,-5.09575 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.8545,236.50001 c -3.04166,0 -3.36894,0.30899 -3.35403,3.32331 v 4.17669 4.17668 c -0.0149,3.01433 0.31237,3.32332 3.35403,3.32332 h 6.29146 c 3.04167,0 3.35404,-0.30895 3.35404,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.31238,-3.32331 -3.35404,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92728,268 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 C 63.832405,262.37397 67.630549,266 102.92728,266 h 98.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 C 240.0054,264.37439 236.38025,268 201.08352,268 Z"
-         id="path931-8"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3257);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         transform="matrix(0.66664182,0,0,0.63636364,106.67521,94.748969)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004-8);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-1)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:1.85638201;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983)"
-         transform="matrix(1.0833332,0,0,1.0714286,-27.333287,-17.428571)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 152,44 v 224 h 49.07227 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 156 82.994141 C 240.16713,47.626029 236.369,44 201.07227,44 Z"
-         id="rect4158-3"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 63.994141,156 v 73.00586 C 63.994141,264.37439 67.6193,268 102.91602,268 h 98.15625 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 156 Z"
-         id="rect4158-8"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 336.50849,211.51179 c 4.23214,0 5.02499,-0.46371 5.00275,-4.98757 v -6.5241 -6.52423 c 0.0222,-4.52386 -0.77061,-4.98757 -5.00275,-4.98757 h -9.01743 c -4.23108,0 -5.00275,0.46366 -5.00275,4.98757 v 6.52423 6.5241 c 0,4.52391 0.77167,4.98757 5.00275,4.98757 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.08651,251.51179 c 2.89732,0 3.44011,-0.30259 3.42488,-3.25454 v -4.25716 -4.25724 c 0.0152,-2.95195 -0.52756,-3.25453 -3.42488,-3.25453 h -6.17331 c -2.8966,0 -3.42488,0.30255 -3.42488,3.25453 v 4.25724 4.25716 c 0,2.95199 0.52828,3.25454 3.42488,3.25454 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <rect
-         style="fill:#f66151;stroke-width:0.35630482"
-         id="rect6351-6"
-         ry="0"
-         rx="0"
-         height="10"
-         width="13"
-         y="78.000366"
-         x="345" />
-      <path
-         style="overflow:visible;fill:#ffffff;stroke-width:0.42883056"
-         inkscape:connector-curvature="0"
-         id="path6353-7"
-         overflow="visible"
-         d="m 345,87.00037 a 17.988157,17.988157 0 0 0 6.14514,-3.085006 c 0.61795,-0.477719 1.21702,-1.010754 1.59397,-1.694739 0.18869,-0.342206 0.31776,-0.719578 0.35335,-1.108526 0.0352,-0.38895 -0.0266,-0.789479 -0.20069,-1.138974 a 2.0532408,2.0532408 0 0 0 -0.65397,-0.752598 2.4679199,2.4679199 0 0 0 -0.91941,-0.393666 c -0.65739,-0.137228 -1.34824,-0.02744 -1.97648,0.210126 -0.7556,0.286888 -1.44687,0.765463 -1.93274,1.411282 -0.48629,0.646247 -0.75732,1.46317 -0.69471,2.269371 0.0412,0.522315 0.21999,1.031338 0.49573,1.476892 0.27574,0.445984 0.64711,0.829789 1.07036,1.138975 0.84695,0.618373 1.88472,0.930991 2.92463,1.064357 2.36714,0.302753 4.83935,-0.306614 6.79482,-1.674584 l -0.0106,-2.224772 c -1.53264,1.690879 -3.71239,2.780109 -5.98476,2.991093 -0.98074,0.09091 -2.00264,0.01672 -2.8886,-0.414252 -0.44299,-0.215272 -0.84609,-0.518885 -1.15442,-0.903115 -0.30875,-0.383803 -0.5206,-0.849086 -0.58107,-1.337952 -0.0883,-0.713146 0.15353,-1.449446 0.59951,-2.012932 0.44599,-0.563482 1.08366,-0.96015 1.76978,-1.174996 0.37866,-0.117927 0.77962,-0.183966 1.17329,-0.133365 0.39323,0.0506 0.77918,0.225994 1.03562,0.528749 0.20756,0.24529 0.32163,0.563053 0.34135,0.883819 0.0202,0.320765 -0.0502,0.643674 -0.17797,0.93871 -0.25514,0.589642 -0.726,1.05664 -1.20587,1.483754 a 20.079134,20.079134 0 0 1 -5.91609,3.652349 z" />
-      <rect
-         style="display:inline;fill:#f66151;stroke-width:0.26516503;enable-background:new"
-         id="rect6351-6-5"
-         ry="0"
-         rx="0"
-         height="8"
-         width="9"
-         y="143.00037"
-         x="337" />
-      <path
-         style="display:inline;overflow:visible;fill:#ffffff;stroke-width:0.29688287;enable-background:new"
-         inkscape:connector-curvature="0"
-         id="path6353-7-3"
-         overflow="visible"
-         d="m 337,149.50034 a 12.453346,12.453346 0 0 0 4.25433,-2.13577 c 0.42781,-0.33074 0.84254,-0.69976 1.10351,-1.17328 0.13063,-0.23692 0.21999,-0.49818 0.24464,-0.76745 0.0244,-0.26927 -0.0184,-0.54656 -0.13895,-0.78852 a 1.4214752,1.4214752 0 0 0 -0.45274,-0.52103 1.7085609,1.7085609 0 0 0 -0.63652,-0.27253 c -0.45512,-0.095 -0.9334,-0.019 -1.36833,0.14546 -0.52312,0.19862 -1.00169,0.52994 -1.33806,0.97704 -0.33666,0.44741 -0.52429,1.01297 -0.48095,1.57111 0.0285,0.36161 0.1523,0.714 0.3432,1.02246 0.1909,0.30876 0.448,0.57447 0.74101,0.78853 0.58635,0.4281 1.30482,0.64453 2.02475,0.73686 1.63879,0.2096 3.35032,-0.21227 4.70411,-1.15933 l -0.007,-1.54023 c -1.06107,1.17061 -2.57012,1.9247 -4.1433,2.07076 -0.67897,0.063 -1.38645,0.0115 -1.9998,-0.28678 -0.30669,-0.14904 -0.58576,-0.35923 -0.79921,-0.62524 -0.21376,-0.26571 -0.36043,-0.58783 -0.40228,-0.92627 -0.0612,-0.49372 0.10628,-1.00347 0.41504,-1.39357 0.30876,-0.39011 0.75023,-0.66473 1.22524,-0.81346 0.26215,-0.0817 0.53973,-0.12737 0.81226,-0.0923 0.27224,0.0351 0.53944,0.15645 0.71698,0.36606 0.14369,0.16981 0.22266,0.3898 0.23632,0.61187 0.0139,0.22207 -0.0348,0.44562 -0.12321,0.64987 -0.17664,0.40823 -0.50262,0.73153 -0.83484,1.02722 a 13.900946,13.900946 0 0 1 -4.09578,2.52855 z" />
+      <circle
+         style="display:inline;fill:url(#linearGradient1009);fill-opacity:1;stroke:none;stroke-width:0.513883;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill;enable-background:new"
+         id="path1001"
+         cx="152"
+         cy="155.65715"
+         r="112" />
+      <circle
+         r="112"
+         cy="155.65715"
+         cx="152"
+         id="circle1013"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4835);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.2305;marker:none;enable-background:accumulate" />
+      <circle
+         style="display:inline;fill:url(#linearGradient1050);fill-opacity:1;stroke:none;stroke-width:0.10553;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill;enable-background:new"
+         id="circle1040"
+         cx="344"
+         cy="83.929596"
+         r="23" />
+      <circle
+         r="23"
+         cy="83.929596"
+         cx="344"
+         id="circle1042"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1048);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.10091;marker:none;enable-background:accumulate" />
+      <circle
+         style="display:inline;fill:url(#linearGradient1062);fill-opacity:1;stroke:none;stroke-width:0.0688239;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill;enable-background:new"
+         id="circle1052"
+         cx="336"
+         cy="148"
+         r="15" />
+      <circle
+         r="15"
+         cy="148"
+         cx="336"
+         id="circle1054"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1060);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.37016;marker:none;enable-background:accumulate" />
+      <circle
+         style="display:inline;fill:url(#linearGradient1074);fill-opacity:1;stroke:none;stroke-width:0.052765;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill;enable-background:new"
+         id="circle1064"
+         cx="332"
+         cy="200"
+         r="11.5" />
+      <circle
+         r="11.5"
+         cy="200"
+         cx="332"
+         id="circle1066"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1072);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.05045;marker:none;enable-background:accumulate" />
+      <circle
+         style="display:inline;fill:url(#linearGradient1086);fill-opacity:1;stroke:none;stroke-width:0.034412;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill;enable-background:new"
+         id="circle1076"
+         cx="328"
+         cy="244"
+         r="7.5" />
+      <circle
+         r="7.5"
+         cy="244"
+         cx="328"
+         id="circle1078"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1084);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.685076;marker:none;enable-background:accumulate" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         sodipodi:nodetypes="ccccc"
+         id="path787"
+         class="shp34"
+         d="m 34.28072,-100.76847 c -102.6737,0 -124.37675,71.96489 -124.37675,71.96489 -4.07693,2.35286 -3.69155,6.36894 -3.69155,6.36894 -2.02832,3.52928 -3.67126,9.6751 -3.67126,13.75202 v 356.76169 c 0,4.70571 3.48871,1.80521 3.48871,1.80521 1.92691,1.01416 3.93495,0.1217 4.52316,-1.96747 0,0 16.79451,-83.48577 123.72769,-83.48577 69.73374,0 131.71928,41.33722 131.71928,41.33722 V -39.10746 c 0,0 -29.06587,-61.66101 -131.71928,-61.66101 z m -286.54116,0 c 102.65342,0 124.35647,71.96489 124.35647,71.96489 4.07693,2.35286 3.69155,6.36894 3.69155,6.36894 2.02832,3.52928 3.67126,9.6751 3.67126,13.75202 v 356.76169 c 0,4.70571 -3.44815,1.78493 -3.44815,1.78493 -1.9269,0.97359 -3.93494,0.10141 -4.50287,-1.96747 0,0 -16.85536,-85.49381 -123.76826,-85.49381 -69.75402,0 -131.73956,47.42219 -131.73956,47.42219 V -39.10746 c 0,0 29.06587,-61.66101 131.73956,-61.66101 z"
+         style="display:inline;fill:url(#linearGradient1011);fill-opacity:1;stroke-width:2.02832;filter:url(#filter977);enable-background:new"
          inkscape:connector-curvature="0"
-         id="path4633"
-         d="m 72,115.92652 v -7.92689 h 71.33333 v 7.92689 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate" />
+         transform="matrix(0.22857143,0,0,0.22857143,176.91429,127.08571)" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:2.99999332;marker:none;enable-background:accumulate"
-         d="m 72,131.92652 v -7.92689 h 71.333 v 7.92689 z"
-         id="path4725"
+         id="path1044"
+         class="shp34"
+         d="m 34.28072,-100.76847 c -102.6737,0 -124.37675,71.96489 -124.37675,71.96489 -4.07693,2.35286 -3.69155,6.36894 -3.69155,6.36894 -2.02832,3.52928 -3.67126,9.6751 -3.67126,13.75202 v 356.76169 c 0,4.70571 3.48871,1.80521 3.48871,1.80521 1.92691,1.01416 3.93495,0.1217 4.52316,-1.96747 0,0 16.79451,-83.48577 123.72769,-83.48577 69.73374,0 131.71928,41.33722 131.71928,41.33722 V -39.10746 c 0,0 -29.06587,-61.66101 -131.71928,-61.66101 z m -286.54116,0 c 102.65342,0 124.35647,71.96489 124.35647,71.96489 4.07693,2.35286 3.69155,6.36894 3.69155,6.36894 2.02832,3.52928 3.67126,9.6751 3.67126,13.75202 v 356.76169 c 0,4.70571 -3.44815,1.78493 -3.44815,1.78493 -1.9269,0.97359 -3.93494,0.10141 -4.50287,-1.96747 0,0 -16.85536,-85.49381 -123.76826,-85.49381 -69.75402,0 -131.73956,47.42219 -131.73956,47.42219 V -39.10746 c 0,0 29.06587,-61.66101 131.73956,-61.66101 z"
+         style="display:inline;fill:url(#linearGradient1046);fill-opacity:1;stroke-width:2.02832;filter:url(#filter977);enable-background:new"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
+         transform="matrix(0.04693878,0,0,0.04693878,349.11633,78.062244)" />
       <path
-         sodipodi:nodetypes="ccccc"
+         id="path1056"
+         class="shp34"
+         d="m 34.28072,-100.76847 c -102.6737,0 -124.37675,71.96489 -124.37675,71.96489 -4.07693,2.35286 -3.69155,6.36894 -3.69155,6.36894 -2.02832,3.52928 -3.67126,9.6751 -3.67126,13.75202 v 356.76169 c 0,4.70571 3.48871,1.80521 3.48871,1.80521 1.92691,1.01416 3.93495,0.1217 4.52316,-1.96747 0,0 16.79451,-83.48577 123.72769,-83.48577 69.73374,0 131.71928,41.33722 131.71928,41.33722 V -39.10746 c 0,0 -29.06587,-61.66101 -131.71928,-61.66101 z m -286.54116,0 c 102.65342,0 124.35647,71.96489 124.35647,71.96489 4.07693,2.35286 3.69155,6.36894 3.69155,6.36894 2.02832,3.52928 3.67126,9.6751 3.67126,13.75202 v 356.76169 c 0,4.70571 -3.44815,1.78493 -3.44815,1.78493 -1.9269,0.97359 -3.93494,0.10141 -4.50287,-1.96747 0,0 -16.85536,-85.49381 -123.76826,-85.49381 -69.75402,0 -131.73956,47.42219 -131.73956,47.42219 V -39.10746 c 0,0 29.06587,-61.66101 131.73956,-61.66101 z"
+         style="display:inline;fill:url(#linearGradient1058);fill-opacity:1;stroke-width:2.02832;filter:url(#filter977);enable-background:new"
          inkscape:connector-curvature="0"
-         id="path14979"
-         d="M 72,99.99963 V 91.999629 H 232 V 99.99963 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.24601126;marker:none;enable-background:accumulate" />
+         transform="matrix(0.03061224,0,0,0.03061224,339.33673,144.17347)" />
       <path
-         sodipodi:nodetypes="ccccc"
+         id="path1068"
+         class="shp34"
+         d="m 34.28072,-100.76847 c -102.6737,0 -124.37675,71.96489 -124.37675,71.96489 -4.07693,2.35286 -3.69155,6.36894 -3.69155,6.36894 -2.02832,3.52928 -3.67126,9.6751 -3.67126,13.75202 v 356.76169 c 0,4.70571 3.48871,1.80521 3.48871,1.80521 1.92691,1.01416 3.93495,0.1217 4.52316,-1.96747 0,0 16.79451,-83.48577 123.72769,-83.48577 69.73374,0 131.71928,41.33722 131.71928,41.33722 V -39.10746 c 0,0 -29.06587,-61.66101 -131.71928,-61.66101 z m -286.54116,0 c 102.65342,0 124.35647,71.96489 124.35647,71.96489 4.07693,2.35286 3.69155,6.36894 3.69155,6.36894 2.02832,3.52928 3.67126,9.6751 3.67126,13.75202 v 356.76169 c 0,4.70571 -3.44815,1.78493 -3.44815,1.78493 -1.9269,0.97359 -3.93494,0.10141 -4.50287,-1.96747 0,0 -16.85536,-85.49381 -123.76826,-85.49381 -69.75402,0 -131.73956,47.42219 -131.73956,47.42219 V -39.10746 c 0,0 29.06587,-61.66101 131.73956,-61.66101 z"
+         style="display:inline;fill:url(#linearGradient1070);fill-opacity:1;stroke-width:2.02832;filter:url(#filter977);enable-background:new"
          inkscape:connector-curvature="0"
-         id="path4235"
-         d="m 72,155.99963 v -8 h 71.33333 v 8 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.00000048;marker:none;enable-background:accumulate" />
+         transform="matrix(0.02346939,0,0,0.02346939,334.55816,197.06633)" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.67423487;marker:none;enable-background:accumulate"
-         d="m 72,171.99963 v -8 h 48 v 8 z"
-         id="path4631"
+         id="path1080"
+         class="shp34"
+         d="m 34.28072,-100.76847 c -102.6737,0 -124.37675,71.96489 -124.37675,71.96489 -4.07693,2.35286 -3.69155,6.36894 -3.69155,6.36894 -2.02832,3.52928 -3.67126,9.6751 -3.67126,13.75202 v 356.76169 c 0,4.70571 3.48871,1.80521 3.48871,1.80521 1.92691,1.01416 3.93495,0.1217 4.52316,-1.96747 0,0 16.79451,-83.48577 123.72769,-83.48577 69.73374,0 131.71928,41.33722 131.71928,41.33722 V -39.10746 c 0,0 -29.06587,-61.66101 -131.71928,-61.66101 z m -286.54116,0 c 102.65342,0 124.35647,71.96489 124.35647,71.96489 4.07693,2.35286 3.69155,6.36894 3.69155,6.36894 2.02832,3.52928 3.67126,9.6751 3.67126,13.75202 v 356.76169 c 0,4.70571 -3.44815,1.78493 -3.44815,1.78493 -1.9269,0.97359 -3.93494,0.10141 -4.50287,-1.96747 0,0 -16.85536,-85.49381 -123.76826,-85.49381 -69.75402,0 -131.73956,47.42219 -131.73956,47.42219 V -39.10746 c 0,0 29.06587,-61.66101 131.73956,-61.66101 z"
+         style="display:inline;fill:url(#linearGradient1082);fill-opacity:1;stroke-width:2.02832;filter:url(#filter977);enable-background:new"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 72,203.99963 v -8 h 159.99998 v 8 z"
-         id="path4635"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path4727"
-         d="m 72,187.99963 v -7.92689 h 159.99999 v 7.92689 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 72,219.99963 v -8 h 96 v 8 z"
-         id="path14983"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#aea795;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.32379031;marker:none;enable-background:accumulate"
-         d="m 72,83.99963 v -8 h 96 v 8 z"
-         id="path14977"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#aea795;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.44383955;marker:none;enable-background:accumulate"
-         d="m 326,139 v 1 h 12 v -1 z"
-         id="path920"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.00000048;marker:none;enable-background:accumulate"
-         d="m 326,144 v -1 h 9 v 1 z"
-         id="path922"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path926"
-         d="m 326,146 v -1 h 9 v 1 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.67423487;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="M 326,148.99086 V 148 h 9 v 0.99086 z"
-         id="path928"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path934"
-         d="m 326,151 v -1 h 6 v 1 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:2.44949007;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 326,153 v -1 h 20 v 1 z"
-         id="path936"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path938"
-         d="m 326,155 v -1 h 13 v 1 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path940"
-         d="m 326,141 v 1 h 20 v -1 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path1089"
-         d="m 325,192.99963 v 1 h 9 v -1 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#aea795;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.58910227;marker:none;enable-background:accumulate" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path1091"
-         d="m 325,197.99963 v -1 h 6 v 1 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.00000048;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 325,200.99049 v 1 h 4 v -1 z"
-         id="path1095"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path1097"
-         d="m 325,198.99963 v 0.99086 h 6 v -0.99086 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path1101"
-         d="m 325,203.99963 v -1 h 14 v 1 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 325,205.99963 v -1 h 8 v 1 z"
-         id="path1103"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 325,194.99963 v 1 h 14 v -1 z"
-         id="path1105"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f66151;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 333,196.99964 v 4.99999 l 6,1e-5 v -5 z"
-         id="path1093"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#aea795;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.58910251;marker:none;enable-background:accumulate"
-         d="m 330,70 v 2 h 18 v -2 z"
-         id="path1155"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.00000048;marker:none;enable-background:accumulate"
-         d="m 330,80 v -2 h 13 v 2 z"
-         id="path1157"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path1159"
-         d="m 330,85.98172 v 2 h 9 v -2 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 330,82 v 1.98172 h 13 V 82 Z"
-         id="path1161"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 330,92 v -2 h 28 v 2 z"
-         id="path1163"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path1165"
-         d="m 330,96 v -2 h 16 v 2 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path1167"
-         d="m 330,74 v 2 h 28 v -2 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#aea795;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4995873;marker:none;enable-background:accumulate"
-         d="m 323,241 v -1 h 7 v 1 z"
-         id="path1213"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.35410261;marker:none;enable-background:accumulate"
-         d="m 323,243 v -1 h 5 v 1 z"
-         id="path1215"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path1217"
-         d="m 323,245 v -1 h 4 v 1 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.24264097;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 323,247 v -1 h 10 v 1 z"
-         id="path1221"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path1223"
-         d="m 323,249 v -1 h 8 v 1 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate" />
-      <g
-         id="g1247"
-         transform="matrix(0.6,0,0,0.6,135.2,97.4)"
-         style="display:inline;stroke-width:1.66666663;enable-background:new">
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f66151;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;marker:none;enable-background:accumulate"
-           d="M 323,241.00001 V 246 l 6.66667,1e-5 v -5 z"
-           id="path1227"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-      </g>
-      <g
-         style="display:inline;stroke-width:8.64894009;enable-background:new"
-         transform="matrix(0.0578211,-4.2973005e-5,-0.00151977,0.05780115,319.82918,142.67508)"
-         id="g1040">
-        <path
-           style="opacity:0.4;fill:url(#linearGradient2654);fill-opacity:1;stroke-width:8.64894009;filter:url(#filter4293)"
-           d="m 402.59658,214.13101 c -0.0574,-0.0429 -0.12197,-0.0718 -0.19498,-0.0934 -2.608,-0.772 -18.88194,-3.53248 -27.48694,-4.66148 -12.7125,-1.668 -27.56759,-2.61728 -39.21823,-2.60466 -3.88355,0.004 -7.41157,0.11464 -10.38432,0.34188 -15.226,1.16301 -35.22173,4.54881 -50.53073,8.5568 -9.541,2.49701 -9.83346,2.54427 -17.21247,2.80925 -9.047,0.32501 -12.61808,-0.1225 -23.79208,-2.9795 -11.15,-2.851 -19.85037,-4.54175 -33.41438,-6.49175 -13.59899,-1.956 -20.24215,-2.37935 -33.30315,-2.12135 -14.096,0.279 -26.42535,1.40271 -41.75835,3.8047 -6.09748,0.95461 -17.31892,2.98787 -18.53471,3.3571 0,0 -0.004,0.001 -0.004,0.001 l -0.001,0.001 c -0.66715,0.2042 -0.68688,0.62249 -0.44211,10.07264 l 0.25676,7.86067 0.99682,0.85129 c 0.54901,0.47 1.60167,1.17003 2.33967,1.55703 3.112,1.633 4.38453,6.83059 6.99154,19.57959 2.877,14.065 4.54005,19.64214 7.94305,26.65214 0.97371,2.00625 2.06271,3.91685 3.25136,5.73933 -10.43519,8.24593 -17.08742,15.02236 -16.24859,17.11085 4.11614,10.24817 19.75965,9.2767 29.11263,-1.13276 0.48346,-0.53807 0.97532,-1.07149 1.4623,-1.60784 0.92355,0.60807 1.86788,1.19489 2.84082,1.75063 4.746,2.711 11.15353,4.4665 19.53154,5.3535 3.77499,0.4 16.78511,0.16903 20.95813,-0.36797 8.39399,-1.087 16.7474,-3.29702 22.51241,-5.95901 12.49999,-5.773 21.83047,-17.88534 27.98948,-36.32934 1.3928,-4.17249 3.52041,-12.30539 4.87018,-18.34797 4.37032,-0.80291 8.85058,-1.5658 13.41737,-2.2875 4.64306,0.73318 9.19585,1.50748 13.6357,2.32457 1.3273,5.90044 3.29591,13.52088 4.58458,17.48569 5.14401,15.82601 12.74839,27.36097 22.26939,33.78098 6.64399,4.48 14.60963,7.20464 26.39263,9.02364 6.98499,1.079 20.84272,1.17485 27.12172,0.19085 7.59978,-1.19163 12.79632,-2.9978 18.22165,-6.5755 0.47688,0.52535 0.95858,1.04789 1.43208,1.57487 9.35298,10.40946 24.99512,11.38232 29.11125,1.13414 0.83753,-2.08522 -5.78935,-8.84395 -16.19641,-17.07241 2.36335,-3.62482 4.39857,-7.65257 5.95901,-11.8933 1.81099,-4.923 2.87227,-8.99523 4.89627,-18.78322 1.921,-9.29001 3.27735,-16.53868 4.23035,-18.38368 0.58199,-1.124 1.55617,-1.96056 4.44316,-3.81156 l 1.84949,-1.18769 0.0206,-0.38033 c 6.2e-4,-1e-5 0.0728,-0.001 0.0728,-0.001 l -0.0124,-1.12452 0.14966,-2.75021 c 0.125,-2.342 0.24761,-4.86951 0.27461,-8.06251 0.0376,-4.57975 -0.002,-5.6035 -0.40367,-5.90408 z m -23.12753,18.764 c 0.54643,0.79932 1.03354,1.60512 1.43345,2.40832 1.60991,3.23541 2.0067,6.97465 2.017,15.03894 a 2.6822779,2.6217047 0 0 0 10e-4,10e-4 c 0.0153,13.37672 -2.24912,23.77872 -7.20984,31.91638 -19.50486,-14.56321 -48.1054,-31.835 -68.2169,-36.4584 -7.39806,-1.70073 -15.75321,-3.42569 -24.6928,-5.14891 36.38891,-4.36254 73.57759,-6.64953 96.66772,-7.7577 z m -18.42762,-13.42149 c -23.84291,3.24193 -54.61551,7.61074 -85.08884,12.51254 0.33209,-0.82495 0.71624,-1.61669 1.18081,-2.36987 2.10391,-3.41091 5.48061,-5.81382 10.08363,-7.98837 11.23948,-5.30991 25.29205,-7.90192 39.31709,-7.93481 12.13543,-0.0285 24.24704,1.86174 34.50731,5.78051 z m -2.85318,72.17811 c 1.26685,1.29064 2.51662,2.59584 3.75802,3.90906 -4.04053,2.23793 -8.65704,3.82947 -13.99681,4.87156 -3.53387,0.69019 -6.15883,0.86823 -13.68923,0.95563 -10.11559,0.11706 -10.96872,0.057 -16.68384,-0.98446 -9.17898,-1.6736 -16.61026,-4.90474 -22.70601,-10.4063 -6.09576,-5.50156 -10.79816,-13.13912 -15.04581,-23.46256 -2.60008,-6.3234 -4.31271,-12.55404 -5.03495,-18.40015 11.92242,2.38085 22.81982,5.09305 31.90541,8.19295 19.96497,6.81183 36.6362,20.18829 51.49322,35.32427 z m -94.49693,-59.28112 c 0.45556,0.39231 0.84537,0.86757 1.18768,1.43209 -3.48304,0.57783 -6.90453,1.16019 -10.32528,1.7465 -3.38557,-0.58017 -6.77164,-1.15541 -10.21819,-1.72728 1.64638,-2.767 4.42919,-3.30217 10.27173,-3.30217 4.62351,0 7.33375,0.3436 9.08406,1.85086 z m -32.68942,-5.4757 c 0.67995,0.73491 1.28188,1.51896 1.80419,2.36713 0.5611,0.91117 1.00993,1.8762 1.37853,2.89437 -31.29677,-5.04729 -62.94396,-9.53344 -87.1841,-12.82284 4.60548,-1.77215 10.06484,-3.32197 15.3465,-4.35667 6.36791,-1.2472 13.05485,-1.8553 19.73749,-1.8742 14.70239,-0.0414 29.38807,2.7435 40.67914,8.17373 3.44964,1.6593 6.19843,3.41376 8.23825,5.61848 z m 4.16994,21.06385 c -0.94086,7.99703 -3.71526,16.44186 -8.34673,25.67728 -3.42867,6.83543 -6.70019,11.68869 -10.54085,15.44262 -7.87446,7.69663 -18.26943,11.73164 -32.3228,12.83932 -14.74994,1.1616 -27.71844,-0.79761 -37.15454,-5.9288 15.9027,-16.88703 33.80578,-32.21705 55.66178,-39.67408 9.29091,-3.16995 20.46328,-5.93724 32.70314,-8.35634 z m -8.8781,-7.30459 c -8.91398,1.71891 -17.24609,3.44012 -24.62552,5.13656 -20.26091,4.65775 -49.13548,22.15247 -68.64803,36.78245 -0.97111,-1.54323 -1.83004,-3.12512 -2.53326,-4.71091 l -0.001,-10e-4 c -3.43058,-7.7347 -4.74336,-15.69469 -4.74936,-27.95653 -0.003,-4.09603 0.0102,-6.38568 0.13593,-8.10508 0.12572,-1.71861 0.41917,-2.92041 0.83207,-4.20426 0.50976,-1.58532 1.30783,-3.17106 2.33554,-4.72189 23.02249,1.09543 60.53797,3.38201 97.254,7.78103 z"
-           id="path1022"
-           inkscape:connector-curvature="0" />
-        <path
-           transform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)"
-           inkscape:connector-curvature="0"
-           id="path1024"
-           d="m 402.59658,214.13101 c -0.0574,-0.0429 -0.12197,-0.0718 -0.19498,-0.0934 -2.608,-0.772 -18.88194,-3.53248 -27.48694,-4.66148 -12.7125,-1.668 -27.56759,-2.61728 -39.21823,-2.60466 -3.88355,0.004 -7.41157,0.11464 -10.38432,0.34188 -15.226,1.16301 -35.22173,4.54881 -50.53073,8.5568 -9.541,2.49701 -9.83346,2.54427 -17.21247,2.80925 -9.047,0.32501 -12.61808,-0.1225 -23.79208,-2.9795 -11.15,-2.851 -19.85037,-4.54175 -33.41438,-6.49175 -13.59899,-1.956 -20.24215,-2.37935 -33.30315,-2.12135 -14.096,0.279 -26.42535,1.40271 -41.75835,3.8047 -6.09748,0.95461 -17.31892,2.98787 -18.53471,3.3571 0,0 -0.004,0.001 -0.004,0.001 l -0.001,0.001 c -0.66715,0.2042 -0.68688,0.62249 -0.44211,10.07264 l 0.25676,7.86067 0.99682,0.85129 c 0.54901,0.47 1.60167,1.17003 2.33967,1.55703 3.112,1.633 4.38453,6.83059 6.99154,19.57959 2.877,14.065 4.54005,19.64214 7.94305,26.65214 0.97371,2.00625 2.06271,3.91685 3.25136,5.73933 -10.43519,8.24593 -17.08742,15.02236 -16.24859,17.11085 4.11614,10.24817 19.75965,9.2767 29.11263,-1.13276 0.48346,-0.53807 0.97532,-1.07149 1.4623,-1.60784 0.92355,0.60807 1.86788,1.19489 2.84082,1.75063 4.746,2.711 11.15353,4.4665 19.53154,5.3535 3.77499,0.4 16.78511,0.16903 20.95813,-0.36797 8.39399,-1.087 16.7474,-3.29702 22.51241,-5.95901 12.49999,-5.773 21.83047,-17.88534 27.98948,-36.32934 1.3928,-4.17249 3.52041,-12.30539 4.87018,-18.34797 4.37032,-0.80291 8.85058,-1.5658 13.41737,-2.2875 4.64306,0.73318 9.19585,1.50748 13.6357,2.32457 1.3273,5.90044 3.29591,13.52088 4.58458,17.48569 5.14401,15.82601 12.74839,27.36097 22.26939,33.78098 6.64399,4.48 14.60963,7.20464 26.39263,9.02364 6.98499,1.079 20.84272,1.17485 27.12172,0.19085 7.59978,-1.19163 12.79632,-2.9978 18.22165,-6.5755 0.47688,0.52535 0.95858,1.04789 1.43208,1.57487 9.35298,10.40946 24.99512,11.38232 29.11125,1.13414 0.83753,-2.08522 -5.78935,-8.84395 -16.19641,-17.07241 2.36335,-3.62482 4.39857,-7.65257 5.95901,-11.8933 1.81099,-4.923 2.87227,-8.99523 4.89627,-18.78322 1.921,-9.29001 3.27735,-16.53868 4.23035,-18.38368 0.58199,-1.124 1.55617,-1.96056 4.44316,-3.81156 l 1.84949,-1.18769 0.0206,-0.38033 c 6.2e-4,-1e-5 0.0728,-0.001 0.0728,-0.001 l -0.0124,-1.12452 0.14966,-2.75021 c 0.125,-2.342 0.24761,-4.86951 0.27461,-8.06251 0.0376,-4.57975 -0.002,-5.6035 -0.40367,-5.90408 z m -23.12753,18.764 c 0.54643,0.79932 1.03354,1.60512 1.43345,2.40832 1.60991,3.23541 2.0067,6.97465 2.017,15.03894 a 2.6822779,2.6217047 0 0 0 10e-4,10e-4 c 0.0153,13.37672 -2.24912,23.77872 -7.20984,31.91638 -19.50486,-14.56321 -48.1054,-31.835 -68.2169,-36.4584 -7.39806,-1.70073 -15.75321,-3.42569 -24.6928,-5.14891 36.38891,-4.36254 73.57759,-6.64953 96.66772,-7.7577 z m -18.42762,-13.42149 c -23.84291,3.24193 -54.61551,7.61074 -85.08884,12.51254 0.33209,-0.82495 0.71624,-1.61669 1.18081,-2.36987 2.10391,-3.41091 5.48061,-5.81382 10.08363,-7.98837 11.23948,-5.30991 25.29205,-7.90192 39.31709,-7.93481 12.13543,-0.0285 24.24704,1.86174 34.50731,5.78051 z m -2.85318,72.17811 c 1.26685,1.29064 2.51662,2.59584 3.75802,3.90906 -4.04053,2.23793 -8.65704,3.82947 -13.99681,4.87156 -3.53387,0.69019 -6.15883,0.86823 -13.68923,0.95563 -10.11559,0.11706 -10.96872,0.057 -16.68384,-0.98446 -9.17898,-1.6736 -16.61026,-4.90474 -22.70601,-10.4063 -6.09576,-5.50156 -10.79816,-13.13912 -15.04581,-23.46256 -2.60008,-6.3234 -4.31271,-12.55404 -5.03495,-18.40015 11.92242,2.38085 22.81982,5.09305 31.90541,8.19295 19.96497,6.81183 36.6362,20.18829 51.49322,35.32427 z m -94.49693,-59.28112 c 0.45556,0.39231 0.84537,0.86757 1.18768,1.43209 -3.48304,0.57783 -6.90453,1.16019 -10.32528,1.7465 -3.38557,-0.58017 -6.77164,-1.15541 -10.21819,-1.72728 1.64638,-2.767 4.42919,-3.30217 10.27173,-3.30217 4.62351,0 7.33375,0.3436 9.08406,1.85086 z m -32.68942,-5.4757 c 0.67995,0.73491 1.28188,1.51896 1.80419,2.36713 0.5611,0.91117 1.00993,1.8762 1.37853,2.89437 -31.29677,-5.04729 -62.94396,-9.53344 -87.1841,-12.82284 4.60548,-1.77215 10.06484,-3.32197 15.3465,-4.35667 6.36791,-1.2472 13.05485,-1.8553 19.73749,-1.8742 14.70239,-0.0414 29.38807,2.7435 40.67914,8.17373 3.44964,1.6593 6.19843,3.41376 8.23825,5.61848 z m 4.16994,21.06385 c -0.94086,7.99703 -3.71526,16.44186 -8.34673,25.67728 -3.42867,6.83543 -6.70019,11.68869 -10.54085,15.44262 -7.87446,7.69663 -18.26943,11.73164 -32.3228,12.83932 -14.74994,1.1616 -27.71844,-0.79761 -37.15454,-5.9288 15.9027,-16.88703 33.80578,-32.21705 55.66178,-39.67408 9.29091,-3.16995 20.46328,-5.93724 32.70314,-8.35634 z m -8.8781,-7.30459 c -8.91398,1.71891 -17.24609,3.44012 -24.62552,5.13656 -20.26091,4.65775 -49.13548,22.15247 -68.64803,36.78245 -0.97111,-1.54323 -1.83004,-3.12512 -2.53326,-4.71091 l -0.001,-10e-4 c -3.43058,-7.7347 -4.74336,-15.69469 -4.74936,-27.95653 -0.003,-4.09603 0.0102,-6.38568 0.13593,-8.10508 0.12572,-1.71861 0.41917,-2.92041 0.83207,-4.20426 0.50976,-1.58532 1.30783,-3.17106 2.33554,-4.72189 23.02249,1.09543 60.53797,3.38201 97.254,7.78103 z"
-           style="opacity:0.1;fill:#000000;stroke-width:7.98027802;filter:url(#filter4279)" />
-        <path
-           sodipodi:nodetypes="csssscc"
-           inkscape:connector-curvature="0"
-           id="path1026"
-           d="m 416.31018,192.73042 c 0,0 -147.26638,18.25561 -217.55148,34.41335 -36.82764,8.46625 -99.935182,56.07178 -97.34615,62.51784 4.46103,11.10685 21.41493,10.05312 31.55159,-1.22854 18.80646,-20.93077 40.02902,-40.79638 66.6602,-49.88264 65.50893,-22.35094 216.88742,-26.38224 216.88742,-26.38224 z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#636363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:553.53216553;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#636363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:553.53216553;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 95.898652,192.74234 c 0,0 147.266378,18.25561 217.551488,34.41335 36.82763,8.46625 99.93517,56.07178 97.34614,62.51784 -4.46103,11.10686 -21.41493,10.05312 -31.55159,-1.22854 -18.80646,-20.93076 -40.02902,-40.79638 -66.6602,-49.88264 C 247.07556,216.21141 95.697067,212.18011 95.697067,212.18011 Z"
-           id="path1028"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssscc" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path1030"
-           d="m 344.0153,184.8556 c -4.20895,0.004 -8.03305,0.12415 -11.25489,0.37044 -16.50178,1.26045 -38.17139,4.92977 -54.76312,9.2736 -10.34044,2.70622 -10.65787,2.75884 -18.65515,3.04603 -9.80505,0.35223 -13.67631,-0.1338 -25.78657,-3.23019 -12.08426,-3.08988 -21.51329,-4.92278 -36.21381,-7.03617 -14.73846,-2.11989 -21.93779,-2.57843 -36.09316,-2.29881 -15.2771,0.30237 -28.63893,1.52021 -45.25668,4.12347 -6.61111,1.03502 -18.783218,3.2399 -20.092436,3.63874 -0.725055,0.22109 -0.746037,0.66677 -0.480509,10.91833 l 0.277298,8.52003 1.081666,0.92291 c 0.595,0.50938 1.736068,1.26764 2.535904,1.68707 3.372757,1.76983 4.750497,7.40345 7.575937,21.22069 3.11806,15.24349 4.9208,21.28817 8.60893,28.88553 4.91499,10.12693 12.38768,18.12678 22.12878,23.69096 5.14367,2.93815 12.08989,4.84077 21.16988,5.80209 4.09131,0.43351 18.19036,0.18404 22.71302,-0.39796 9.09733,-1.17808 18.14991,-3.57324 24.39795,-6.45828 13.54737,-6.25672 23.66047,-19.38475 30.33553,-39.37416 2.03536,-6.0974 5.53221,-20.02767 6.435,-25.63628 1.68313,-10.45749 3.34139,-11.93015 13.45423,-11.93015 10.0218,0 11.74958,1.48754 13.44788,11.58088 0.9559,5.6758 4.30703,19.17482 6.22967,25.09015 5.57502,17.15205 13.81673,29.65383 24.13549,36.61177 7.20069,4.85538 15.83371,7.80809 28.604,9.7795 7.57027,1.16941 22.58844,1.2739 29.39355,0.20745 10.76203,-1.68746 17.07464,-4.4983 25.30819,-11.26548 6.84955,-5.63246 12.8199,-14.45938 16.44735,-24.31753 1.96274,-5.3355 3.11316,-9.74892 5.30675,-20.35705 2.08196,-10.0684 3.55209,-17.9235 4.58494,-19.92309 0.63077,-1.21818 1.68677,-2.12586 4.81567,-4.13195 l 2.00459,-1.287 0.24978,-4.61246 c 0.13547,-2.53823 0.2692,-5.27751 0.29846,-8.73805 0.0466,-5.67255 -0.0169,-6.31312 -0.64985,-6.50061 -2.82652,-0.83669 -20.46339,-3.82704 -29.7894,-5.05064 -13.77767,-1.80776 -29.87802,-2.83744 -42.50487,-2.82378 z m -166.48234,6.86048 c 15.93429,-0.0449 31.85107,2.97349 44.08822,8.85871 4.98491,2.39777 8.61804,4.97853 10.88235,8.6555 2.2643,3.67695 2.96782,8.08954 2.96348,13.74634 -0.009,10.58683 -3.15069,21.79551 -9.44505,34.34682 -3.71597,7.40817 -7.26178,12.66676 -11.42425,16.73523 -8.53425,8.34152 -19.79963,12.71519 -35.03052,13.91568 -16.37668,1.28971 -30.73991,-0.95881 -41.02314,-6.82872 -6.88721,-3.93261 -13.52812,-11.56164 -16.93421,-19.24361 h 0.002 c -3.71861,-8.38335 -5.1415,-17.00934 -5.148,-30.29954 -0.003,-4.43923 0.01,-6.92117 0.14605,-8.78462 0.13626,-1.86262 0.45425,-3.166 0.90175,-4.55741 1.82508,-5.67583 7.02787,-11.35488 13.52832,-15.66838 5.33188,-3.53887 15.51862,-6.96631 25.10284,-8.8439 6.90148,-1.3517 14.14746,-2.01162 21.39003,-2.0321 z m 156.55255,0.64138 c 15.20007,-0.0357 30.37154,2.6982 42.44348,8.4036 6.80473,3.21546 13.57292,9.1753 16.48122,15.01641 1.7448,3.50651 2.17547,7.55918 2.18663,16.29918 a 2.9070246,2.841376 0 0 0 0,0.002 c 0.0216,18.87798 -4.12628,32.30326 -13.49233,41.93968 -6.23627,6.416 -14.07525,10.32844 -24.40855,12.34504 -3.82998,0.74803 -6.67512,0.9425 -14.83649,1.03722 -10.96317,0.12686 -11.88751,0.0597 -18.0815,-1.06897 -9.94808,-1.81382 -18.00312,-5.31565 -24.60964,-11.27819 -6.60652,-5.96253 -11.70197,-14.23828 -16.30553,-25.42672 -3.77388,-9.17809 -5.82859,-18.18073 -5.8804,-26.23532 -0.0353,-5.63599 0.68332,-10.08139 2.96348,-13.7781 2.28019,-3.69669 5.94022,-6.30086 10.92892,-8.65761 12.18124,-5.75483 27.41052,-8.56269 42.61071,-8.59834 z"
-           style="fill:#1a5fb4;fill-opacity:1;stroke:#1a5fb4;stroke-width:8.64894009;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path1032"
-           d="m 177.53201,191.71607 c -7.24258,0.0205 -14.48683,0.6804 -21.38829,2.0321 -9.58424,1.87759 -19.77273,5.30504 -25.1046,8.8439 -6.50045,4.31352 -11.70178,9.99255 -13.52686,15.66838 -0.44749,1.39141 -0.76683,2.6948 -0.90308,4.55741 -0.13633,1.86346 -0.14789,4.34539 -0.1451,8.78462 0.007,13.2902 1.4292,21.91619 5.14781,30.29954 h -0.002 c 3.40609,7.68197 10.04625,15.31101 16.93346,19.24361 10.28322,5.86991 24.64788,8.11843 41.02455,6.82872 15.2309,-1.2005 26.49568,-5.57416 35.02993,-13.91568 4.16247,-4.06847 7.70801,-9.32705 11.42398,-16.73523 6.29436,-12.55131 9.43636,-23.75999 9.44454,-34.34682 0.004,-5.65679 -0.69835,-10.06938 -2.96265,-13.74634 -2.2643,-3.67697 -5.89765,-6.25772 -10.88256,-8.6555 -12.23716,-5.88521 -28.15469,-8.90362 -44.08898,-8.85871 z"
-           style="opacity:0.5;fill:url(#linearGradient2656);fill-opacity:1;stroke-width:8.55072594" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path1034"
-           d="m 334.08548,192.35746 c -15.20019,0.0357 -30.4286,2.84351 -42.60983,8.59834 -4.9887,2.35675 -8.65002,4.96091 -10.93021,8.65761 -2.28016,3.69671 -2.99801,8.14211 -2.96265,13.7781 0.0518,8.05459 2.10595,17.05723 5.87983,26.23532 4.60356,11.18844 9.69891,19.46419 16.30543,25.42672 6.60652,5.96254 14.66274,9.46437 24.61082,11.27819 6.19399,1.12869 7.11813,1.19583 18.0813,1.06897 8.16137,-0.0947 11.00495,-0.2892 14.83493,-1.03722 10.33329,-2.0166 18.17316,-5.92904 24.40942,-12.34504 9.36606,-9.63642 13.51373,-23.0617 13.4922,-41.93969 a 2.9070246,2.841376 0 0 0 0,-0.002 c -0.0112,-8.74 -0.44252,-12.79268 -2.18732,-16.29918 -2.9083,-5.84112 -9.67613,-11.80095 -16.48086,-15.01641 -12.07194,-5.70541 -27.24299,-8.43929 -42.44306,-8.4036 z"
-           style="opacity:0.5;fill:url(#linearGradient2658);fill-opacity:1;stroke-width:8.55072594" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path1036"
-           d="m 206.95237,275.67414 c -6.41044,3.41127 -14.17254,5.36014 -23.87717,6.02156 -16.03837,1.09202 -29.89753,-1.34792 -39.41908,-6.85147 l -0.002,0.002 c -6.09907,-3.52638 -12.59349,-10.90254 -15.7604,-17.90118 a 3.7245728,3.6455441 45 0 0 -0.003,-0.0129 c -3.60542,-7.97407 -5.05339,-16.01772 -5.20107,-29.18983 -0.0508,-4.47959 -0.0582,-6.94433 0.0456,-8.60559 0.0994,-1.59023 0.31481,-2.49282 0.70417,-3.74087 0.14912,-0.47811 0.34312,-0.96799 0.56426,-1.46335 -1.41765,1.86285 -2.46858,3.72031 -3.02255,5.44313 -0.39847,1.23895 -0.622,2.13345 -0.73718,3.70787 -0.12033,1.64473 -0.13796,4.08447 -0.13518,8.51599 0.006,13.03081 1.35228,20.97239 4.83485,28.82361 a 3.645544,3.645544 0 0 1 0.005,0.0142 c 3.05906,6.89079 9.40508,14.11854 15.40203,17.54281 l 0.002,-0.002 c 9.36214,5.34414 23.04888,7.61165 38.92868,6.36107 11.69965,-0.92217 20.57672,-3.69846 27.67149,-8.66532 z"
-           style="opacity:0.5;fill:#ffffff;stroke-width:8.55072594" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path1038"
-           d="m 374.53886,274.24538 c -4.01013,2.27662 -8.67937,3.88151 -14.34264,4.94016 -3.581,0.66995 -5.94679,0.81581 -14.1163,0.84091 -11.03447,0.0335 -11.15179,0.0304 -17.36049,-1.15212 -9.44444,-1.80008 -16.6439,-5.03337 -22.62915,-10.4446 -6.00368,-5.42787 -10.88249,-13.13968 -15.46649,-24.09249 l 0.002,-0.002 c -3.70073,-8.84811 -5.68355,-17.41535 -5.79364,-24.7715 -0.0624,-4.21199 0.34623,-7.25767 1.34074,-9.67755 -0.66688,0.68136 -1.23909,1.38942 -1.70539,2.1455 -1.64067,2.65993 -2.30877,6.10048 -2.27597,11.32951 0.0469,7.29296 1.93976,15.77024 5.5343,24.51216 h -0.003 c 4.45251,10.82134 9.22632,18.42814 15.13326,23.75927 5.8888,5.31478 13.00008,8.45989 22.34937,10.16481 6.14615,1.11998 6.26194,1.12156 17.20331,0.99495 8.10059,-0.094 10.44834,-0.25792 14.0047,-0.95251 7.53712,-1.47091 13.31565,-3.89576 18.12596,-7.59492 z"
-           style="opacity:0.5;fill:#ffffff;stroke-width:8.55072594" />
-      </g>
-      <g
-         id="g1081"
-         transform="matrix(0.09108171,-0.00110956,-0.00110956,0.09108171,318.95761,76.559873)"
-         style="display:inline;stroke-width:5.48998356;enable-background:new">
-        <path
-           inkscape:connector-curvature="0"
-           id="path1063"
-           d="m 402.59658,214.13101 c -0.0574,-0.0429 -0.12197,-0.0718 -0.19498,-0.0934 -2.608,-0.772 -18.88194,-3.53248 -27.48694,-4.66148 -12.7125,-1.668 -27.56759,-2.61728 -39.21823,-2.60466 -3.88355,0.004 -7.41157,0.11464 -10.38432,0.34188 -15.226,1.16301 -35.22173,4.54881 -50.53073,8.5568 -9.541,2.49701 -9.83346,2.54427 -17.21247,2.80925 -9.047,0.32501 -12.61808,-0.1225 -23.79208,-2.9795 -11.15,-2.851 -19.85037,-4.54175 -33.41438,-6.49175 -13.59899,-1.956 -20.24215,-2.37935 -33.30315,-2.12135 -14.096,0.279 -26.42535,1.40271 -41.75835,3.8047 -6.09748,0.95461 -17.31892,2.98787 -18.53471,3.3571 0,0 -0.004,0.001 -0.004,0.001 l -0.001,0.001 c -0.66715,0.2042 -0.68688,0.62249 -0.44211,10.07264 l 0.25676,7.86067 0.99682,0.85129 c 0.54901,0.47 1.60167,1.17003 2.33967,1.55703 3.112,1.633 4.38453,6.83059 6.99154,19.57959 2.877,14.065 4.54005,19.64214 7.94305,26.65214 0.97371,2.00625 2.06271,3.91685 3.25136,5.73933 -10.43519,8.24593 -17.08742,15.02236 -16.24859,17.11085 4.11614,10.24817 19.75965,9.2767 29.11263,-1.13276 0.48346,-0.53807 0.97532,-1.07149 1.4623,-1.60784 0.92355,0.60807 1.86788,1.19489 2.84082,1.75063 4.746,2.711 11.15353,4.4665 19.53154,5.3535 3.77499,0.4 16.78511,0.16903 20.95813,-0.36797 8.39399,-1.087 16.7474,-3.29702 22.51241,-5.95901 12.49999,-5.773 21.83047,-17.88534 27.98948,-36.32934 1.3928,-4.17249 3.52041,-12.30539 4.87018,-18.34797 4.37032,-0.80291 8.85058,-1.5658 13.41737,-2.2875 4.64306,0.73318 9.19585,1.50748 13.6357,2.32457 1.3273,5.90044 3.29591,13.52088 4.58458,17.48569 5.14401,15.82601 12.74839,27.36097 22.26939,33.78098 6.64399,4.48 14.60963,7.20464 26.39263,9.02364 6.98499,1.079 20.84272,1.17485 27.12172,0.19085 7.59978,-1.19163 12.79632,-2.9978 18.22165,-6.5755 0.47688,0.52535 0.95858,1.04789 1.43208,1.57487 9.35298,10.40946 24.99512,11.38232 29.11125,1.13414 0.83753,-2.08522 -5.78935,-8.84395 -16.19641,-17.07241 2.36335,-3.62482 4.39857,-7.65257 5.95901,-11.8933 1.81099,-4.923 2.87227,-8.99523 4.89627,-18.78322 1.921,-9.29001 3.27735,-16.53868 4.23035,-18.38368 0.58199,-1.124 1.55617,-1.96056 4.44316,-3.81156 l 1.84949,-1.18769 0.0206,-0.38033 c 6.2e-4,-1e-5 0.0728,-0.001 0.0728,-0.001 l -0.0124,-1.12452 0.14966,-2.75021 c 0.125,-2.342 0.24761,-4.86951 0.27461,-8.06251 0.0376,-4.57975 -0.002,-5.6035 -0.40367,-5.90408 z m -23.12753,18.764 c 0.54643,0.79932 1.03354,1.60512 1.43345,2.40832 1.60991,3.23541 2.0067,6.97465 2.017,15.03894 a 2.6822779,2.6217047 0 0 0 10e-4,10e-4 c 0.0153,13.37672 -2.24912,23.77872 -7.20984,31.91638 -19.50486,-14.56321 -48.1054,-31.835 -68.2169,-36.4584 -7.39806,-1.70073 -15.75321,-3.42569 -24.6928,-5.14891 36.38891,-4.36254 73.57759,-6.64953 96.66772,-7.7577 z m -18.42762,-13.42149 c -23.84291,3.24193 -54.61551,7.61074 -85.08884,12.51254 0.33209,-0.82495 0.71624,-1.61669 1.18081,-2.36987 2.10391,-3.41091 5.48061,-5.81382 10.08363,-7.98837 11.23948,-5.30991 25.29205,-7.90192 39.31709,-7.93481 12.13543,-0.0285 24.24704,1.86174 34.50731,5.78051 z m -2.85318,72.17811 c 1.26685,1.29064 2.51662,2.59584 3.75802,3.90906 -4.04053,2.23793 -8.65704,3.82947 -13.99681,4.87156 -3.53387,0.69019 -6.15883,0.86823 -13.68923,0.95563 -10.11559,0.11706 -10.96872,0.057 -16.68384,-0.98446 -9.17898,-1.6736 -16.61026,-4.90474 -22.70601,-10.4063 -6.09576,-5.50156 -10.79816,-13.13912 -15.04581,-23.46256 -2.60008,-6.3234 -4.31271,-12.55404 -5.03495,-18.40015 11.92242,2.38085 22.81982,5.09305 31.90541,8.19295 19.96497,6.81183 36.6362,20.18829 51.49322,35.32427 z m -94.49693,-59.28112 c 0.45556,0.39231 0.84537,0.86757 1.18768,1.43209 -3.48304,0.57783 -6.90453,1.16019 -10.32528,1.7465 -3.38557,-0.58017 -6.77164,-1.15541 -10.21819,-1.72728 1.64638,-2.767 4.42919,-3.30217 10.27173,-3.30217 4.62351,0 7.33375,0.3436 9.08406,1.85086 z m -32.68942,-5.4757 c 0.67995,0.73491 1.28188,1.51896 1.80419,2.36713 0.5611,0.91117 1.00993,1.8762 1.37853,2.89437 -31.29677,-5.04729 -62.94396,-9.53344 -87.1841,-12.82284 4.60548,-1.77215 10.06484,-3.32197 15.3465,-4.35667 6.36791,-1.2472 13.05485,-1.8553 19.73749,-1.8742 14.70239,-0.0414 29.38807,2.7435 40.67914,8.17373 3.44964,1.6593 6.19843,3.41376 8.23825,5.61848 z m 4.16994,21.06385 c -0.94086,7.99703 -3.71526,16.44186 -8.34673,25.67728 -3.42867,6.83543 -6.70019,11.68869 -10.54085,15.44262 -7.87446,7.69663 -18.26943,11.73164 -32.3228,12.83932 -14.74994,1.1616 -27.71844,-0.79761 -37.15454,-5.9288 15.9027,-16.88703 33.80578,-32.21705 55.66178,-39.67408 9.29091,-3.16995 20.46328,-5.93724 32.70314,-8.35634 z m -8.8781,-7.30459 c -8.91398,1.71891 -17.24609,3.44012 -24.62552,5.13656 -20.26091,4.65775 -49.13548,22.15247 -68.64803,36.78245 -0.97111,-1.54323 -1.83004,-3.12512 -2.53326,-4.71091 l -0.001,-10e-4 c -3.43058,-7.7347 -4.74336,-15.69469 -4.74936,-27.95653 -0.003,-4.09603 0.0102,-6.38568 0.13593,-8.10508 0.12572,-1.71861 0.41917,-2.92041 0.83207,-4.20426 0.50976,-1.58532 1.30783,-3.17106 2.33554,-4.72189 23.02249,1.09543 60.53797,3.38201 97.254,7.78103 z"
-           style="opacity:0.4;fill:url(#linearGradient2660);fill-opacity:1;stroke-width:5.48998356;filter:url(#filter4293)" />
-        <path
-           style="opacity:0.1;fill:#000000;stroke-width:5.06554508;filter:url(#filter4279)"
-           d="m 402.59658,214.13101 c -0.0574,-0.0429 -0.12197,-0.0718 -0.19498,-0.0934 -2.608,-0.772 -18.88194,-3.53248 -27.48694,-4.66148 -12.7125,-1.668 -27.56759,-2.61728 -39.21823,-2.60466 -3.88355,0.004 -7.41157,0.11464 -10.38432,0.34188 -15.226,1.16301 -35.22173,4.54881 -50.53073,8.5568 -9.541,2.49701 -9.83346,2.54427 -17.21247,2.80925 -9.047,0.32501 -12.61808,-0.1225 -23.79208,-2.9795 -11.15,-2.851 -19.85037,-4.54175 -33.41438,-6.49175 -13.59899,-1.956 -20.24215,-2.37935 -33.30315,-2.12135 -14.096,0.279 -26.42535,1.40271 -41.75835,3.8047 -6.09748,0.95461 -17.31892,2.98787 -18.53471,3.3571 0,0 -0.004,0.001 -0.004,0.001 l -0.001,0.001 c -0.66715,0.2042 -0.68688,0.62249 -0.44211,10.07264 l 0.25676,7.86067 0.99682,0.85129 c 0.54901,0.47 1.60167,1.17003 2.33967,1.55703 3.112,1.633 4.38453,6.83059 6.99154,19.57959 2.877,14.065 4.54005,19.64214 7.94305,26.65214 0.97371,2.00625 2.06271,3.91685 3.25136,5.73933 -10.43519,8.24593 -17.08742,15.02236 -16.24859,17.11085 4.11614,10.24817 19.75965,9.2767 29.11263,-1.13276 0.48346,-0.53807 0.97532,-1.07149 1.4623,-1.60784 0.92355,0.60807 1.86788,1.19489 2.84082,1.75063 4.746,2.711 11.15353,4.4665 19.53154,5.3535 3.77499,0.4 16.78511,0.16903 20.95813,-0.36797 8.39399,-1.087 16.7474,-3.29702 22.51241,-5.95901 12.49999,-5.773 21.83047,-17.88534 27.98948,-36.32934 1.3928,-4.17249 3.52041,-12.30539 4.87018,-18.34797 4.37032,-0.80291 8.85058,-1.5658 13.41737,-2.2875 4.64306,0.73318 9.19585,1.50748 13.6357,2.32457 1.3273,5.90044 3.29591,13.52088 4.58458,17.48569 5.14401,15.82601 12.74839,27.36097 22.26939,33.78098 6.64399,4.48 14.60963,7.20464 26.39263,9.02364 6.98499,1.079 20.84272,1.17485 27.12172,0.19085 7.59978,-1.19163 12.79632,-2.9978 18.22165,-6.5755 0.47688,0.52535 0.95858,1.04789 1.43208,1.57487 9.35298,10.40946 24.99512,11.38232 29.11125,1.13414 0.83753,-2.08522 -5.78935,-8.84395 -16.19641,-17.07241 2.36335,-3.62482 4.39857,-7.65257 5.95901,-11.8933 1.81099,-4.923 2.87227,-8.99523 4.89627,-18.78322 1.921,-9.29001 3.27735,-16.53868 4.23035,-18.38368 0.58199,-1.124 1.55617,-1.96056 4.44316,-3.81156 l 1.84949,-1.18769 0.0206,-0.38033 c 6.2e-4,-1e-5 0.0728,-0.001 0.0728,-0.001 l -0.0124,-1.12452 0.14966,-2.75021 c 0.125,-2.342 0.24761,-4.86951 0.27461,-8.06251 0.0376,-4.57975 -0.002,-5.6035 -0.40367,-5.90408 z m -23.12753,18.764 c 0.54643,0.79932 1.03354,1.60512 1.43345,2.40832 1.60991,3.23541 2.0067,6.97465 2.017,15.03894 a 2.6822779,2.6217047 0 0 0 10e-4,10e-4 c 0.0153,13.37672 -2.24912,23.77872 -7.20984,31.91638 -19.50486,-14.56321 -48.1054,-31.835 -68.2169,-36.4584 -7.39806,-1.70073 -15.75321,-3.42569 -24.6928,-5.14891 36.38891,-4.36254 73.57759,-6.64953 96.66772,-7.7577 z m -18.42762,-13.42149 c -23.84291,3.24193 -54.61551,7.61074 -85.08884,12.51254 0.33209,-0.82495 0.71624,-1.61669 1.18081,-2.36987 2.10391,-3.41091 5.48061,-5.81382 10.08363,-7.98837 11.23948,-5.30991 25.29205,-7.90192 39.31709,-7.93481 12.13543,-0.0285 24.24704,1.86174 34.50731,5.78051 z m -2.85318,72.17811 c 1.26685,1.29064 2.51662,2.59584 3.75802,3.90906 -4.04053,2.23793 -8.65704,3.82947 -13.99681,4.87156 -3.53387,0.69019 -6.15883,0.86823 -13.68923,0.95563 -10.11559,0.11706 -10.96872,0.057 -16.68384,-0.98446 -9.17898,-1.6736 -16.61026,-4.90474 -22.70601,-10.4063 -6.09576,-5.50156 -10.79816,-13.13912 -15.04581,-23.46256 -2.60008,-6.3234 -4.31271,-12.55404 -5.03495,-18.40015 11.92242,2.38085 22.81982,5.09305 31.90541,8.19295 19.96497,6.81183 36.6362,20.18829 51.49322,35.32427 z m -94.49693,-59.28112 c 0.45556,0.39231 0.84537,0.86757 1.18768,1.43209 -3.48304,0.57783 -6.90453,1.16019 -10.32528,1.7465 -3.38557,-0.58017 -6.77164,-1.15541 -10.21819,-1.72728 1.64638,-2.767 4.42919,-3.30217 10.27173,-3.30217 4.62351,0 7.33375,0.3436 9.08406,1.85086 z m -32.68942,-5.4757 c 0.67995,0.73491 1.28188,1.51896 1.80419,2.36713 0.5611,0.91117 1.00993,1.8762 1.37853,2.89437 -31.29677,-5.04729 -62.94396,-9.53344 -87.1841,-12.82284 4.60548,-1.77215 10.06484,-3.32197 15.3465,-4.35667 6.36791,-1.2472 13.05485,-1.8553 19.73749,-1.8742 14.70239,-0.0414 29.38807,2.7435 40.67914,8.17373 3.44964,1.6593 6.19843,3.41376 8.23825,5.61848 z m 4.16994,21.06385 c -0.94086,7.99703 -3.71526,16.44186 -8.34673,25.67728 -3.42867,6.83543 -6.70019,11.68869 -10.54085,15.44262 -7.87446,7.69663 -18.26943,11.73164 -32.3228,12.83932 -14.74994,1.1616 -27.71844,-0.79761 -37.15454,-5.9288 15.9027,-16.88703 33.80578,-32.21705 55.66178,-39.67408 9.29091,-3.16995 20.46328,-5.93724 32.70314,-8.35634 z m -8.8781,-7.30459 c -8.91398,1.71891 -17.24609,3.44012 -24.62552,5.13656 -20.26091,4.65775 -49.13548,22.15247 -68.64803,36.78245 -0.97111,-1.54323 -1.83004,-3.12512 -2.53326,-4.71091 l -0.001,-10e-4 c -3.43058,-7.7347 -4.74336,-15.69469 -4.74936,-27.95653 -0.003,-4.09603 0.0102,-6.38568 0.13593,-8.10508 0.12572,-1.71861 0.41917,-2.92041 0.83207,-4.20426 0.50976,-1.58532 1.30783,-3.17106 2.33554,-4.72189 23.02249,1.09543 60.53797,3.38201 97.254,7.78103 z"
-           id="path1065"
-           inkscape:connector-curvature="0"
-           transform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#636363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:351.35894775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 416.31018,192.73042 c 0,0 -147.26638,18.25561 -217.55148,34.41335 -36.82764,8.46625 -99.935182,56.07178 -97.34615,62.51784 4.46103,11.10685 21.41493,10.05312 31.55159,-1.22854 18.80646,-20.93077 40.02902,-40.79638 66.6602,-49.88264 65.50893,-22.35094 216.88742,-26.38224 216.88742,-26.38224 z"
-           id="path1067"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssscc" />
-        <path
-           sodipodi:nodetypes="csssscc"
-           inkscape:connector-curvature="0"
-           id="path1069"
-           d="m 95.898652,192.74234 c 0,0 147.266378,18.25561 217.551488,34.41335 36.82763,8.46625 99.93517,56.07178 97.34614,62.51784 -4.46103,11.10686 -21.41493,10.05312 -31.55159,-1.22854 -18.80646,-20.93076 -40.02902,-40.79638 -66.6602,-49.88264 C 247.07556,216.21141 95.697067,212.18011 95.697067,212.18011 Z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#636363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:351.35894775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           style="fill:#1a5fb4;fill-opacity:1;stroke:#1a5fb4;stroke-width:5.48998356;stroke-opacity:1"
-           d="m 344.0153,184.8556 c -4.20895,0.004 -8.03305,0.12415 -11.25489,0.37044 -16.50178,1.26045 -38.17139,4.92977 -54.76312,9.2736 -10.34044,2.70622 -10.65787,2.75884 -18.65515,3.04603 -9.80505,0.35223 -13.67631,-0.1338 -25.78657,-3.23019 -12.08426,-3.08988 -21.51329,-4.92278 -36.21381,-7.03617 -14.73846,-2.11989 -21.93779,-2.57843 -36.09316,-2.29881 -15.2771,0.30237 -28.63893,1.52021 -45.25668,4.12347 -6.61111,1.03502 -18.783218,3.2399 -20.092436,3.63874 -0.725055,0.22109 -0.746037,0.66677 -0.480509,10.91833 l 0.277298,8.52003 1.081666,0.92291 c 0.595,0.50938 1.736068,1.26764 2.535904,1.68707 3.372757,1.76983 4.750497,7.40345 7.575937,21.22069 3.11806,15.24349 4.9208,21.28817 8.60893,28.88553 4.91499,10.12693 12.38768,18.12678 22.12878,23.69096 5.14367,2.93815 12.08989,4.84077 21.16988,5.80209 4.09131,0.43351 18.19036,0.18404 22.71302,-0.39796 9.09733,-1.17808 18.14991,-3.57324 24.39795,-6.45828 13.54737,-6.25672 23.66047,-19.38475 30.33553,-39.37416 2.03536,-6.0974 5.53221,-20.02767 6.435,-25.63628 1.68313,-10.45749 3.34139,-11.93015 13.45423,-11.93015 10.0218,0 11.74958,1.48754 13.44788,11.58088 0.9559,5.6758 4.30703,19.17482 6.22967,25.09015 5.57502,17.15205 13.81673,29.65383 24.13549,36.61177 7.20069,4.85538 15.83371,7.80809 28.604,9.7795 7.57027,1.16941 22.58844,1.2739 29.39355,0.20745 10.76203,-1.68746 17.07464,-4.4983 25.30819,-11.26548 6.84955,-5.63246 12.8199,-14.45938 16.44735,-24.31753 1.96274,-5.3355 3.11316,-9.74892 5.30675,-20.35705 2.08196,-10.0684 3.55209,-17.9235 4.58494,-19.92309 0.63077,-1.21818 1.68677,-2.12586 4.81567,-4.13195 l 2.00459,-1.287 0.24978,-4.61246 c 0.13547,-2.53823 0.2692,-5.27751 0.29846,-8.73805 0.0466,-5.67255 -0.0169,-6.31312 -0.64985,-6.50061 -2.82652,-0.83669 -20.46339,-3.82704 -29.7894,-5.05064 -13.77767,-1.80776 -29.87802,-2.83744 -42.50487,-2.82378 z m -166.48234,6.86048 c 15.93429,-0.0449 31.85107,2.97349 44.08822,8.85871 4.98491,2.39777 8.61804,4.97853 10.88235,8.6555 2.2643,3.67695 2.96782,8.08954 2.96348,13.74634 -0.009,10.58683 -3.15069,21.79551 -9.44505,34.34682 -3.71597,7.40817 -7.26178,12.66676 -11.42425,16.73523 -8.53425,8.34152 -19.79963,12.71519 -35.03052,13.91568 -16.37668,1.28971 -30.73991,-0.95881 -41.02314,-6.82872 -6.88721,-3.93261 -13.52812,-11.56164 -16.93421,-19.24361 h 0.002 c -3.71861,-8.38335 -5.1415,-17.00934 -5.148,-30.29954 -0.003,-4.43923 0.01,-6.92117 0.14605,-8.78462 0.13626,-1.86262 0.45425,-3.166 0.90175,-4.55741 1.82508,-5.67583 7.02787,-11.35488 13.52832,-15.66838 5.33188,-3.53887 15.51862,-6.96631 25.10284,-8.8439 6.90148,-1.3517 14.14746,-2.01162 21.39003,-2.0321 z m 156.55255,0.64138 c 15.20007,-0.0357 30.37154,2.6982 42.44348,8.4036 6.80473,3.21546 13.57292,9.1753 16.48122,15.01641 1.7448,3.50651 2.17547,7.55918 2.18663,16.29918 a 2.9070246,2.841376 0 0 0 0,0.002 c 0.0216,18.87798 -4.12628,32.30326 -13.49233,41.93968 -6.23627,6.416 -14.07525,10.32844 -24.40855,12.34504 -3.82998,0.74803 -6.67512,0.9425 -14.83649,1.03722 -10.96317,0.12686 -11.88751,0.0597 -18.0815,-1.06897 -9.94808,-1.81382 -18.00312,-5.31565 -24.60964,-11.27819 -6.60652,-5.96253 -11.70197,-14.23828 -16.30553,-25.42672 -3.77388,-9.17809 -5.82859,-18.18073 -5.8804,-26.23532 -0.0353,-5.63599 0.68332,-10.08139 2.96348,-13.7781 2.28019,-3.69669 5.94022,-6.30086 10.92892,-8.65761 12.18124,-5.75483 27.41052,-8.56269 42.61071,-8.59834 z"
-           id="path1071"
-           inkscape:connector-curvature="0" />
-        <path
-           style="opacity:0.5;fill:url(#linearGradient2662);fill-opacity:1;stroke-width:5.42764139"
-           d="m 177.53201,191.71607 c -7.24258,0.0205 -14.48683,0.6804 -21.38829,2.0321 -9.58424,1.87759 -19.77273,5.30504 -25.1046,8.8439 -6.50045,4.31352 -11.70178,9.99255 -13.52686,15.66838 -0.44749,1.39141 -0.76683,2.6948 -0.90308,4.55741 -0.13633,1.86346 -0.14789,4.34539 -0.1451,8.78462 0.007,13.2902 1.4292,21.91619 5.14781,30.29954 h -0.002 c 3.40609,7.68197 10.04625,15.31101 16.93346,19.24361 10.28322,5.86991 24.64788,8.11843 41.02455,6.82872 15.2309,-1.2005 26.49568,-5.57416 35.02993,-13.91568 4.16247,-4.06847 7.70801,-9.32705 11.42398,-16.73523 6.29436,-12.55131 9.43636,-23.75999 9.44454,-34.34682 0.004,-5.65679 -0.69835,-10.06938 -2.96265,-13.74634 -2.2643,-3.67697 -5.89765,-6.25772 -10.88256,-8.6555 -12.23716,-5.88521 -28.15469,-8.90362 -44.08898,-8.85871 z"
-           id="path1073"
-           inkscape:connector-curvature="0" />
-        <path
-           style="opacity:0.5;fill:url(#linearGradient2664);fill-opacity:1;stroke-width:5.42764139"
-           d="m 334.08548,192.35746 c -15.20019,0.0357 -30.4286,2.84351 -42.60983,8.59834 -4.9887,2.35675 -8.65002,4.96091 -10.93021,8.65761 -2.28016,3.69671 -2.99801,8.14211 -2.96265,13.7781 0.0518,8.05459 2.10595,17.05723 5.87983,26.23532 4.60356,11.18844 9.69891,19.46419 16.30543,25.42672 6.60652,5.96254 14.66274,9.46437 24.61082,11.27819 6.19399,1.12869 7.11813,1.19583 18.0813,1.06897 8.16137,-0.0947 11.00495,-0.2892 14.83493,-1.03722 10.33329,-2.0166 18.17316,-5.92904 24.40942,-12.34504 9.36606,-9.63642 13.51373,-23.0617 13.4922,-41.93969 a 2.9070246,2.841376 0 0 0 0,-0.002 c -0.0112,-8.74 -0.44252,-12.79268 -2.18732,-16.29918 -2.9083,-5.84112 -9.67613,-11.80095 -16.48086,-15.01641 -12.07194,-5.70541 -27.24299,-8.43929 -42.44306,-8.4036 z"
-           id="path1075"
-           inkscape:connector-curvature="0" />
-        <path
-           style="opacity:0.5;fill:#ffffff;stroke-width:5.42764139"
-           d="m 206.95237,275.67414 c -6.41044,3.41127 -14.17254,5.36014 -23.87717,6.02156 -16.03837,1.09202 -29.89753,-1.34792 -39.41908,-6.85147 l -0.002,0.002 c -6.09907,-3.52638 -12.59349,-10.90254 -15.7604,-17.90118 a 3.7245728,3.6455441 45 0 0 -0.003,-0.0129 c -3.60542,-7.97407 -5.05339,-16.01772 -5.20107,-29.18983 -0.0508,-4.47959 -0.0582,-6.94433 0.0456,-8.60559 0.0994,-1.59023 0.31481,-2.49282 0.70417,-3.74087 0.14912,-0.47811 0.34312,-0.96799 0.56426,-1.46335 -1.41765,1.86285 -2.46858,3.72031 -3.02255,5.44313 -0.39847,1.23895 -0.622,2.13345 -0.73718,3.70787 -0.12033,1.64473 -0.13796,4.08447 -0.13518,8.51599 0.006,13.03081 1.35228,20.97239 4.83485,28.82361 a 3.645544,3.645544 0 0 1 0.005,0.0142 c 3.05906,6.89079 9.40508,14.11854 15.40203,17.54281 l 0.002,-0.002 c 9.36214,5.34414 23.04888,7.61165 38.92868,6.36107 11.69965,-0.92217 20.57672,-3.69846 27.67149,-8.66532 z"
-           id="path1077"
-           inkscape:connector-curvature="0" />
-        <path
-           style="opacity:0.5;fill:#ffffff;stroke-width:5.42764139"
-           d="m 374.53886,274.24538 c -4.01013,2.27662 -8.67937,3.88151 -14.34264,4.94016 -3.581,0.66995 -5.94679,0.81581 -14.1163,0.84091 -11.03447,0.0335 -11.15179,0.0304 -17.36049,-1.15212 -9.44444,-1.80008 -16.6439,-5.03337 -22.62915,-10.4446 -6.00368,-5.42787 -10.88249,-13.13968 -15.46649,-24.09249 l 0.002,-0.002 c -3.70073,-8.84811 -5.68355,-17.41535 -5.79364,-24.7715 -0.0624,-4.21199 0.34623,-7.25767 1.34074,-9.67755 -0.66688,0.68136 -1.23909,1.38942 -1.70539,2.1455 -1.64067,2.65993 -2.30877,6.10048 -2.27597,11.32951 0.0469,7.29296 1.93976,15.77024 5.5343,24.51216 h -0.003 c 4.45251,10.82134 9.22632,18.42814 15.13326,23.75927 5.8888,5.31478 13.00008,8.45989 22.34937,10.16481 6.14615,1.11998 6.26194,1.12156 17.20331,0.99495 8.10059,-0.094 10.44834,-0.25792 14.0047,-0.95251 7.53712,-1.47091 13.31565,-3.89576 18.12596,-7.59492 z"
-           id="path1079"
-           inkscape:connector-curvature="0" />
-      </g>
-      <g
-         id="g1205"
-         transform="matrix(0.03867518,-6.6255905e-4,-6.6255905e-4,0.03867518,320.52419,198.26086)"
-         style="display:inline;stroke-width:12.93008804;enable-background:new">
-        <path
-           inkscape:connector-curvature="0"
-           id="path1187"
-           d="m 402.59658,214.13101 c -0.0574,-0.0429 -0.12197,-0.0718 -0.19498,-0.0934 -2.608,-0.772 -18.88194,-3.53248 -27.48694,-4.66148 -12.7125,-1.668 -27.56759,-2.61728 -39.21823,-2.60466 -3.88355,0.004 -7.41157,0.11464 -10.38432,0.34188 -15.226,1.16301 -35.22173,4.54881 -50.53073,8.5568 -9.541,2.49701 -9.83346,2.54427 -17.21247,2.80925 -9.047,0.32501 -12.61808,-0.1225 -23.79208,-2.9795 -11.15,-2.851 -19.85037,-4.54175 -33.41438,-6.49175 -13.59899,-1.956 -20.24215,-2.37935 -33.30315,-2.12135 -14.096,0.279 -26.42535,1.40271 -41.75835,3.8047 -6.09748,0.95461 -17.31892,2.98787 -18.53471,3.3571 0,0 -0.004,0.001 -0.004,0.001 l -0.001,0.001 c -0.66715,0.2042 -0.68688,0.62249 -0.44211,10.07264 l 0.25676,7.86067 0.99682,0.85129 c 0.54901,0.47 1.60167,1.17003 2.33967,1.55703 3.112,1.633 4.38453,6.83059 6.99154,19.57959 2.877,14.065 4.54005,19.64214 7.94305,26.65214 0.97371,2.00625 2.06271,3.91685 3.25136,5.73933 -10.43519,8.24593 -17.08742,15.02236 -16.24859,17.11085 4.11614,10.24817 19.75965,9.2767 29.11263,-1.13276 0.48346,-0.53807 0.97532,-1.07149 1.4623,-1.60784 0.92355,0.60807 1.86788,1.19489 2.84082,1.75063 4.746,2.711 11.15353,4.4665 19.53154,5.3535 3.77499,0.4 16.78511,0.16903 20.95813,-0.36797 8.39399,-1.087 16.7474,-3.29702 22.51241,-5.95901 12.49999,-5.773 21.83047,-17.88534 27.98948,-36.32934 1.3928,-4.17249 3.52041,-12.30539 4.87018,-18.34797 4.37032,-0.80291 8.85058,-1.5658 13.41737,-2.2875 4.64306,0.73318 9.19585,1.50748 13.6357,2.32457 1.3273,5.90044 3.29591,13.52088 4.58458,17.48569 5.14401,15.82601 12.74839,27.36097 22.26939,33.78098 6.64399,4.48 14.60963,7.20464 26.39263,9.02364 6.98499,1.079 20.84272,1.17485 27.12172,0.19085 7.59978,-1.19163 12.79632,-2.9978 18.22165,-6.5755 0.47688,0.52535 0.95858,1.04789 1.43208,1.57487 9.35298,10.40946 24.99512,11.38232 29.11125,1.13414 0.83753,-2.08522 -5.78935,-8.84395 -16.19641,-17.07241 2.36335,-3.62482 4.39857,-7.65257 5.95901,-11.8933 1.81099,-4.923 2.87227,-8.99523 4.89627,-18.78322 1.921,-9.29001 3.27735,-16.53868 4.23035,-18.38368 0.58199,-1.124 1.55617,-1.96056 4.44316,-3.81156 l 1.84949,-1.18769 0.0206,-0.38033 c 6.2e-4,-1e-5 0.0728,-0.001 0.0728,-0.001 l -0.0124,-1.12452 0.14966,-2.75021 c 0.125,-2.342 0.24761,-4.86951 0.27461,-8.06251 0.0376,-4.57975 -0.002,-5.6035 -0.40367,-5.90408 z m -23.12753,18.764 c 0.54643,0.79932 1.03354,1.60512 1.43345,2.40832 1.60991,3.23541 2.0067,6.97465 2.017,15.03894 a 2.6822779,2.6217047 0 0 0 10e-4,10e-4 c 0.0153,13.37672 -2.24912,23.77872 -7.20984,31.91638 -19.50486,-14.56321 -48.1054,-31.835 -68.2169,-36.4584 -7.39806,-1.70073 -15.75321,-3.42569 -24.6928,-5.14891 36.38891,-4.36254 73.57759,-6.64953 96.66772,-7.7577 z m -18.42762,-13.42149 c -23.84291,3.24193 -54.61551,7.61074 -85.08884,12.51254 0.33209,-0.82495 0.71624,-1.61669 1.18081,-2.36987 2.10391,-3.41091 5.48061,-5.81382 10.08363,-7.98837 11.23948,-5.30991 25.29205,-7.90192 39.31709,-7.93481 12.13543,-0.0285 24.24704,1.86174 34.50731,5.78051 z m -2.85318,72.17811 c 1.26685,1.29064 2.51662,2.59584 3.75802,3.90906 -4.04053,2.23793 -8.65704,3.82947 -13.99681,4.87156 -3.53387,0.69019 -6.15883,0.86823 -13.68923,0.95563 -10.11559,0.11706 -10.96872,0.057 -16.68384,-0.98446 -9.17898,-1.6736 -16.61026,-4.90474 -22.70601,-10.4063 -6.09576,-5.50156 -10.79816,-13.13912 -15.04581,-23.46256 -2.60008,-6.3234 -4.31271,-12.55404 -5.03495,-18.40015 11.92242,2.38085 22.81982,5.09305 31.90541,8.19295 19.96497,6.81183 36.6362,20.18829 51.49322,35.32427 z m -94.49693,-59.28112 c 0.45556,0.39231 0.84537,0.86757 1.18768,1.43209 -3.48304,0.57783 -6.90453,1.16019 -10.32528,1.7465 -3.38557,-0.58017 -6.77164,-1.15541 -10.21819,-1.72728 1.64638,-2.767 4.42919,-3.30217 10.27173,-3.30217 4.62351,0 7.33375,0.3436 9.08406,1.85086 z m -32.68942,-5.4757 c 0.67995,0.73491 1.28188,1.51896 1.80419,2.36713 0.5611,0.91117 1.00993,1.8762 1.37853,2.89437 -31.29677,-5.04729 -62.94396,-9.53344 -87.1841,-12.82284 4.60548,-1.77215 10.06484,-3.32197 15.3465,-4.35667 6.36791,-1.2472 13.05485,-1.8553 19.73749,-1.8742 14.70239,-0.0414 29.38807,2.7435 40.67914,8.17373 3.44964,1.6593 6.19843,3.41376 8.23825,5.61848 z m 4.16994,21.06385 c -0.94086,7.99703 -3.71526,16.44186 -8.34673,25.67728 -3.42867,6.83543 -6.70019,11.68869 -10.54085,15.44262 -7.87446,7.69663 -18.26943,11.73164 -32.3228,12.83932 -14.74994,1.1616 -27.71844,-0.79761 -37.15454,-5.9288 15.9027,-16.88703 33.80578,-32.21705 55.66178,-39.67408 9.29091,-3.16995 20.46328,-5.93724 32.70314,-8.35634 z m -8.8781,-7.30459 c -8.91398,1.71891 -17.24609,3.44012 -24.62552,5.13656 -20.26091,4.65775 -49.13548,22.15247 -68.64803,36.78245 -0.97111,-1.54323 -1.83004,-3.12512 -2.53326,-4.71091 l -0.001,-10e-4 c -3.43058,-7.7347 -4.74336,-15.69469 -4.74936,-27.95653 -0.003,-4.09603 0.0102,-6.38568 0.13593,-8.10508 0.12572,-1.71861 0.41917,-2.92041 0.83207,-4.20426 0.50976,-1.58532 1.30783,-3.17106 2.33554,-4.72189 23.02249,1.09543 60.53797,3.38201 97.254,7.78103 z"
-           style="opacity:0.4;fill:url(#linearGradient2666);fill-opacity:1;stroke-width:12.93008804;filter:url(#filter4293)" />
-        <path
-           style="opacity:0.1;fill:#000000;stroke-width:11.93044472;filter:url(#filter4279)"
-           d="m 402.59658,214.13101 c -0.0574,-0.0429 -0.12197,-0.0718 -0.19498,-0.0934 -2.608,-0.772 -18.88194,-3.53248 -27.48694,-4.66148 -12.7125,-1.668 -27.56759,-2.61728 -39.21823,-2.60466 -3.88355,0.004 -7.41157,0.11464 -10.38432,0.34188 -15.226,1.16301 -35.22173,4.54881 -50.53073,8.5568 -9.541,2.49701 -9.83346,2.54427 -17.21247,2.80925 -9.047,0.32501 -12.61808,-0.1225 -23.79208,-2.9795 -11.15,-2.851 -19.85037,-4.54175 -33.41438,-6.49175 -13.59899,-1.956 -20.24215,-2.37935 -33.30315,-2.12135 -14.096,0.279 -26.42535,1.40271 -41.75835,3.8047 -6.09748,0.95461 -17.31892,2.98787 -18.53471,3.3571 0,0 -0.004,0.001 -0.004,0.001 l -0.001,0.001 c -0.66715,0.2042 -0.68688,0.62249 -0.44211,10.07264 l 0.25676,7.86067 0.99682,0.85129 c 0.54901,0.47 1.60167,1.17003 2.33967,1.55703 3.112,1.633 4.38453,6.83059 6.99154,19.57959 2.877,14.065 4.54005,19.64214 7.94305,26.65214 0.97371,2.00625 2.06271,3.91685 3.25136,5.73933 -10.43519,8.24593 -17.08742,15.02236 -16.24859,17.11085 4.11614,10.24817 19.75965,9.2767 29.11263,-1.13276 0.48346,-0.53807 0.97532,-1.07149 1.4623,-1.60784 0.92355,0.60807 1.86788,1.19489 2.84082,1.75063 4.746,2.711 11.15353,4.4665 19.53154,5.3535 3.77499,0.4 16.78511,0.16903 20.95813,-0.36797 8.39399,-1.087 16.7474,-3.29702 22.51241,-5.95901 12.49999,-5.773 21.83047,-17.88534 27.98948,-36.32934 1.3928,-4.17249 3.52041,-12.30539 4.87018,-18.34797 4.37032,-0.80291 8.85058,-1.5658 13.41737,-2.2875 4.64306,0.73318 9.19585,1.50748 13.6357,2.32457 1.3273,5.90044 3.29591,13.52088 4.58458,17.48569 5.14401,15.82601 12.74839,27.36097 22.26939,33.78098 6.64399,4.48 14.60963,7.20464 26.39263,9.02364 6.98499,1.079 20.84272,1.17485 27.12172,0.19085 7.59978,-1.19163 12.79632,-2.9978 18.22165,-6.5755 0.47688,0.52535 0.95858,1.04789 1.43208,1.57487 9.35298,10.40946 24.99512,11.38232 29.11125,1.13414 0.83753,-2.08522 -5.78935,-8.84395 -16.19641,-17.07241 2.36335,-3.62482 4.39857,-7.65257 5.95901,-11.8933 1.81099,-4.923 2.87227,-8.99523 4.89627,-18.78322 1.921,-9.29001 3.27735,-16.53868 4.23035,-18.38368 0.58199,-1.124 1.55617,-1.96056 4.44316,-3.81156 l 1.84949,-1.18769 0.0206,-0.38033 c 6.2e-4,-1e-5 0.0728,-0.001 0.0728,-0.001 l -0.0124,-1.12452 0.14966,-2.75021 c 0.125,-2.342 0.24761,-4.86951 0.27461,-8.06251 0.0376,-4.57975 -0.002,-5.6035 -0.40367,-5.90408 z m -23.12753,18.764 c 0.54643,0.79932 1.03354,1.60512 1.43345,2.40832 1.60991,3.23541 2.0067,6.97465 2.017,15.03894 a 2.6822779,2.6217047 0 0 0 10e-4,10e-4 c 0.0153,13.37672 -2.24912,23.77872 -7.20984,31.91638 -19.50486,-14.56321 -48.1054,-31.835 -68.2169,-36.4584 -7.39806,-1.70073 -15.75321,-3.42569 -24.6928,-5.14891 36.38891,-4.36254 73.57759,-6.64953 96.66772,-7.7577 z m -18.42762,-13.42149 c -23.84291,3.24193 -54.61551,7.61074 -85.08884,12.51254 0.33209,-0.82495 0.71624,-1.61669 1.18081,-2.36987 2.10391,-3.41091 5.48061,-5.81382 10.08363,-7.98837 11.23948,-5.30991 25.29205,-7.90192 39.31709,-7.93481 12.13543,-0.0285 24.24704,1.86174 34.50731,5.78051 z m -2.85318,72.17811 c 1.26685,1.29064 2.51662,2.59584 3.75802,3.90906 -4.04053,2.23793 -8.65704,3.82947 -13.99681,4.87156 -3.53387,0.69019 -6.15883,0.86823 -13.68923,0.95563 -10.11559,0.11706 -10.96872,0.057 -16.68384,-0.98446 -9.17898,-1.6736 -16.61026,-4.90474 -22.70601,-10.4063 -6.09576,-5.50156 -10.79816,-13.13912 -15.04581,-23.46256 -2.60008,-6.3234 -4.31271,-12.55404 -5.03495,-18.40015 11.92242,2.38085 22.81982,5.09305 31.90541,8.19295 19.96497,6.81183 36.6362,20.18829 51.49322,35.32427 z m -94.49693,-59.28112 c 0.45556,0.39231 0.84537,0.86757 1.18768,1.43209 -3.48304,0.57783 -6.90453,1.16019 -10.32528,1.7465 -3.38557,-0.58017 -6.77164,-1.15541 -10.21819,-1.72728 1.64638,-2.767 4.42919,-3.30217 10.27173,-3.30217 4.62351,0 7.33375,0.3436 9.08406,1.85086 z m -32.68942,-5.4757 c 0.67995,0.73491 1.28188,1.51896 1.80419,2.36713 0.5611,0.91117 1.00993,1.8762 1.37853,2.89437 -31.29677,-5.04729 -62.94396,-9.53344 -87.1841,-12.82284 4.60548,-1.77215 10.06484,-3.32197 15.3465,-4.35667 6.36791,-1.2472 13.05485,-1.8553 19.73749,-1.8742 14.70239,-0.0414 29.38807,2.7435 40.67914,8.17373 3.44964,1.6593 6.19843,3.41376 8.23825,5.61848 z m 4.16994,21.06385 c -0.94086,7.99703 -3.71526,16.44186 -8.34673,25.67728 -3.42867,6.83543 -6.70019,11.68869 -10.54085,15.44262 -7.87446,7.69663 -18.26943,11.73164 -32.3228,12.83932 -14.74994,1.1616 -27.71844,-0.79761 -37.15454,-5.9288 15.9027,-16.88703 33.80578,-32.21705 55.66178,-39.67408 9.29091,-3.16995 20.46328,-5.93724 32.70314,-8.35634 z m -8.8781,-7.30459 c -8.91398,1.71891 -17.24609,3.44012 -24.62552,5.13656 -20.26091,4.65775 -49.13548,22.15247 -68.64803,36.78245 -0.97111,-1.54323 -1.83004,-3.12512 -2.53326,-4.71091 l -0.001,-10e-4 c -3.43058,-7.7347 -4.74336,-15.69469 -4.74936,-27.95653 -0.003,-4.09603 0.0102,-6.38568 0.13593,-8.10508 0.12572,-1.71861 0.41917,-2.92041 0.83207,-4.20426 0.50976,-1.58532 1.30783,-3.17106 2.33554,-4.72189 23.02249,1.09543 60.53797,3.38201 97.254,7.78103 z"
-           id="path1189"
-           inkscape:connector-curvature="0"
-           transform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#636363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:827.52563477;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 416.31018,192.73042 c 0,0 -147.26638,18.25561 -217.55148,34.41335 -36.82764,8.46625 -99.935182,56.07178 -97.34615,62.51784 4.46103,11.10685 21.41493,10.05312 31.55159,-1.22854 18.80646,-20.93077 40.02902,-40.79638 66.6602,-49.88264 65.50893,-22.35094 216.88742,-26.38224 216.88742,-26.38224 z"
-           id="path1191"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssscc" />
-        <path
-           sodipodi:nodetypes="csssscc"
-           inkscape:connector-curvature="0"
-           id="path1193"
-           d="m 95.898652,192.74234 c 0,0 147.266378,18.25561 217.551488,34.41335 36.82763,8.46625 99.93517,56.07178 97.34614,62.51784 -4.46103,11.10686 -21.41493,10.05312 -31.55159,-1.22854 -18.80646,-20.93076 -40.02902,-40.79638 -66.6602,-49.88264 C 247.07556,216.21141 95.697067,212.18011 95.697067,212.18011 Z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#636363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:827.52563477;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           style="fill:#1a5fb4;fill-opacity:1;stroke:#1a5fb4;stroke-width:12.93008804;stroke-opacity:1"
-           d="m 344.0153,184.8556 c -4.20895,0.004 -8.03305,0.12415 -11.25489,0.37044 -16.50178,1.26045 -38.17139,4.92977 -54.76312,9.2736 -10.34044,2.70622 -10.65787,2.75884 -18.65515,3.04603 -9.80505,0.35223 -13.67631,-0.1338 -25.78657,-3.23019 -12.08426,-3.08988 -21.51329,-4.92278 -36.21381,-7.03617 -14.73846,-2.11989 -21.93779,-2.57843 -36.09316,-2.29881 -15.2771,0.30237 -28.63893,1.52021 -45.25668,4.12347 -6.61111,1.03502 -18.783218,3.2399 -20.092436,3.63874 -0.725055,0.22109 -0.746037,0.66677 -0.480509,10.91833 l 0.277298,8.52003 1.081666,0.92291 c 0.595,0.50938 1.736068,1.26764 2.535904,1.68707 3.372757,1.76983 4.750497,7.40345 7.575937,21.22069 3.11806,15.24349 4.9208,21.28817 8.60893,28.88553 4.91499,10.12693 12.38768,18.12678 22.12878,23.69096 5.14367,2.93815 12.08989,4.84077 21.16988,5.80209 4.09131,0.43351 18.19036,0.18404 22.71302,-0.39796 9.09733,-1.17808 18.14991,-3.57324 24.39795,-6.45828 13.54737,-6.25672 23.66047,-19.38475 30.33553,-39.37416 2.03536,-6.0974 5.53221,-20.02767 6.435,-25.63628 1.68313,-10.45749 3.34139,-11.93015 13.45423,-11.93015 10.0218,0 11.74958,1.48754 13.44788,11.58088 0.9559,5.6758 4.30703,19.17482 6.22967,25.09015 5.57502,17.15205 13.81673,29.65383 24.13549,36.61177 7.20069,4.85538 15.83371,7.80809 28.604,9.7795 7.57027,1.16941 22.58844,1.2739 29.39355,0.20745 10.76203,-1.68746 17.07464,-4.4983 25.30819,-11.26548 6.84955,-5.63246 12.8199,-14.45938 16.44735,-24.31753 1.96274,-5.3355 3.11316,-9.74892 5.30675,-20.35705 2.08196,-10.0684 3.55209,-17.9235 4.58494,-19.92309 0.63077,-1.21818 1.68677,-2.12586 4.81567,-4.13195 l 2.00459,-1.287 0.24978,-4.61246 c 0.13547,-2.53823 0.2692,-5.27751 0.29846,-8.73805 0.0466,-5.67255 -0.0169,-6.31312 -0.64985,-6.50061 -2.82652,-0.83669 -20.46339,-3.82704 -29.7894,-5.05064 -13.77767,-1.80776 -29.87802,-2.83744 -42.50487,-2.82378 z m -166.48234,6.86048 c 15.93429,-0.0449 31.85107,2.97349 44.08822,8.85871 4.98491,2.39777 8.61804,4.97853 10.88235,8.6555 2.2643,3.67695 2.96782,8.08954 2.96348,13.74634 -0.009,10.58683 -3.15069,21.79551 -9.44505,34.34682 -3.71597,7.40817 -7.26178,12.66676 -11.42425,16.73523 -8.53425,8.34152 -19.79963,12.71519 -35.03052,13.91568 -16.37668,1.28971 -30.73991,-0.95881 -41.02314,-6.82872 -6.88721,-3.93261 -13.52812,-11.56164 -16.93421,-19.24361 h 0.002 c -3.71861,-8.38335 -5.1415,-17.00934 -5.148,-30.29954 -0.003,-4.43923 0.01,-6.92117 0.14605,-8.78462 0.13626,-1.86262 0.45425,-3.166 0.90175,-4.55741 1.82508,-5.67583 7.02787,-11.35488 13.52832,-15.66838 5.33188,-3.53887 15.51862,-6.96631 25.10284,-8.8439 6.90148,-1.3517 14.14746,-2.01162 21.39003,-2.0321 z m 156.55255,0.64138 c 15.20007,-0.0357 30.37154,2.6982 42.44348,8.4036 6.80473,3.21546 13.57292,9.1753 16.48122,15.01641 1.7448,3.50651 2.17547,7.55918 2.18663,16.29918 a 2.9070246,2.841376 0 0 0 0,0.002 c 0.0216,18.87798 -4.12628,32.30326 -13.49233,41.93968 -6.23627,6.416 -14.07525,10.32844 -24.40855,12.34504 -3.82998,0.74803 -6.67512,0.9425 -14.83649,1.03722 -10.96317,0.12686 -11.88751,0.0597 -18.0815,-1.06897 -9.94808,-1.81382 -18.00312,-5.31565 -24.60964,-11.27819 -6.60652,-5.96253 -11.70197,-14.23828 -16.30553,-25.42672 -3.77388,-9.17809 -5.82859,-18.18073 -5.8804,-26.23532 -0.0353,-5.63599 0.68332,-10.08139 2.96348,-13.7781 2.28019,-3.69669 5.94022,-6.30086 10.92892,-8.65761 12.18124,-5.75483 27.41052,-8.56269 42.61071,-8.59834 z"
-           id="path1195"
-           inkscape:connector-curvature="0" />
-        <path
-           style="opacity:0.5;fill:url(#linearGradient2668);fill-opacity:1;stroke-width:12.78325939"
-           d="m 177.53201,191.71607 c -7.24258,0.0205 -14.48683,0.6804 -21.38829,2.0321 -9.58424,1.87759 -19.77273,5.30504 -25.1046,8.8439 -6.50045,4.31352 -11.70178,9.99255 -13.52686,15.66838 -0.44749,1.39141 -0.76683,2.6948 -0.90308,4.55741 -0.13633,1.86346 -0.14789,4.34539 -0.1451,8.78462 0.007,13.2902 1.4292,21.91619 5.14781,30.29954 h -0.002 c 3.40609,7.68197 10.04625,15.31101 16.93346,19.24361 10.28322,5.86991 24.64788,8.11843 41.02455,6.82872 15.2309,-1.2005 26.49568,-5.57416 35.02993,-13.91568 4.16247,-4.06847 7.70801,-9.32705 11.42398,-16.73523 6.29436,-12.55131 9.43636,-23.75999 9.44454,-34.34682 0.004,-5.65679 -0.69835,-10.06938 -2.96265,-13.74634 -2.2643,-3.67697 -5.89765,-6.25772 -10.88256,-8.6555 -12.23716,-5.88521 -28.15469,-8.90362 -44.08898,-8.85871 z"
-           id="path1197"
-           inkscape:connector-curvature="0" />
-        <path
-           style="opacity:0.5;fill:url(#linearGradient2670);fill-opacity:1;stroke-width:12.78325939"
-           d="m 334.08548,192.35746 c -15.20019,0.0357 -30.4286,2.84351 -42.60983,8.59834 -4.9887,2.35675 -8.65002,4.96091 -10.93021,8.65761 -2.28016,3.69671 -2.99801,8.14211 -2.96265,13.7781 0.0518,8.05459 2.10595,17.05723 5.87983,26.23532 4.60356,11.18844 9.69891,19.46419 16.30543,25.42672 6.60652,5.96254 14.66274,9.46437 24.61082,11.27819 6.19399,1.12869 7.11813,1.19583 18.0813,1.06897 8.16137,-0.0947 11.00495,-0.2892 14.83493,-1.03722 10.33329,-2.0166 18.17316,-5.92904 24.40942,-12.34504 9.36606,-9.63642 13.51373,-23.0617 13.4922,-41.93969 a 2.9070246,2.841376 0 0 0 0,-0.002 c -0.0112,-8.74 -0.44252,-12.79268 -2.18732,-16.29918 -2.9083,-5.84112 -9.67613,-11.80095 -16.48086,-15.01641 -12.07194,-5.70541 -27.24299,-8.43929 -42.44306,-8.4036 z"
-           id="path1199"
-           inkscape:connector-curvature="0" />
-        <path
-           style="opacity:0.5;fill:#ffffff;stroke-width:12.78325939"
-           d="m 206.95237,275.67414 c -6.41044,3.41127 -14.17254,5.36014 -23.87717,6.02156 -16.03837,1.09202 -29.89753,-1.34792 -39.41908,-6.85147 l -0.002,0.002 c -6.09907,-3.52638 -12.59349,-10.90254 -15.7604,-17.90118 a 3.7245728,3.6455441 45 0 0 -0.003,-0.0129 c -3.60542,-7.97407 -5.05339,-16.01772 -5.20107,-29.18983 -0.0508,-4.47959 -0.0582,-6.94433 0.0456,-8.60559 0.0994,-1.59023 0.31481,-2.49282 0.70417,-3.74087 0.14912,-0.47811 0.34312,-0.96799 0.56426,-1.46335 -1.41765,1.86285 -2.46858,3.72031 -3.02255,5.44313 -0.39847,1.23895 -0.622,2.13345 -0.73718,3.70787 -0.12033,1.64473 -0.13796,4.08447 -0.13518,8.51599 0.006,13.03081 1.35228,20.97239 4.83485,28.82361 a 3.645544,3.645544 0 0 1 0.005,0.0142 c 3.05906,6.89079 9.40508,14.11854 15.40203,17.54281 l 0.002,-0.002 c 9.36214,5.34414 23.04888,7.61165 38.92868,6.36107 11.69965,-0.92217 20.57672,-3.69846 27.67149,-8.66532 z"
-           id="path1201"
-           inkscape:connector-curvature="0" />
-        <path
-           style="opacity:0.5;fill:#ffffff;stroke-width:12.78325939"
-           d="m 374.53886,274.24538 c -4.01013,2.27662 -8.67937,3.88151 -14.34264,4.94016 -3.581,0.66995 -5.94679,0.81581 -14.1163,0.84091 -11.03447,0.0335 -11.15179,0.0304 -17.36049,-1.15212 -9.44444,-1.80008 -16.6439,-5.03337 -22.62915,-10.4446 -6.00368,-5.42787 -10.88249,-13.13968 -15.46649,-24.09249 l 0.002,-0.002 c -3.70073,-8.84811 -5.68355,-17.41535 -5.79364,-24.7715 -0.0624,-4.21199 0.34623,-7.25767 1.34074,-9.67755 -0.66688,0.68136 -1.23909,1.38942 -1.70539,2.1455 -1.64067,2.65993 -2.30877,6.10048 -2.27597,11.32951 0.0469,7.29296 1.93976,15.77024 5.5343,24.51216 h -0.003 c 4.45251,10.82134 9.22632,18.42814 15.13326,23.75927 5.8888,5.31478 13.00008,8.45989 22.34937,10.16481 6.14615,1.11998 6.26194,1.12156 17.20331,0.99495 8.10059,-0.094 10.44834,-0.25792 14.0047,-0.95251 7.53712,-1.47091 13.31565,-3.89576 18.12596,-7.59492 z"
-           id="path1203"
-           inkscape:connector-curvature="0" />
-      </g>
-      <g
-         style="display:inline;stroke-width:18.15267181;enable-background:new"
-         transform="matrix(0.02754893,-5.1258878e-4,-5.1258878e-4,0.02754893,320.56163,241.90196)"
-         id="g1267">
-        <path
-           style="opacity:0.4;fill:url(#linearGradient1269);fill-opacity:1;stroke-width:18.15267181;filter:url(#filter4293)"
-           d="m 402.59658,214.13101 c -0.0574,-0.0429 -0.12197,-0.0718 -0.19498,-0.0934 -2.608,-0.772 -18.88194,-3.53248 -27.48694,-4.66148 -12.7125,-1.668 -27.56759,-2.61728 -39.21823,-2.60466 -3.88355,0.004 -7.41157,0.11464 -10.38432,0.34188 -15.226,1.16301 -35.22173,4.54881 -50.53073,8.5568 -9.541,2.49701 -9.83346,2.54427 -17.21247,2.80925 -9.047,0.32501 -12.61808,-0.1225 -23.79208,-2.9795 -11.15,-2.851 -19.85037,-4.54175 -33.41438,-6.49175 -13.59899,-1.956 -20.24215,-2.37935 -33.30315,-2.12135 -14.096,0.279 -26.42535,1.40271 -41.75835,3.8047 -6.09748,0.95461 -17.31892,2.98787 -18.53471,3.3571 0,0 -0.004,0.001 -0.004,0.001 l -0.001,0.001 c -0.66715,0.2042 -0.68688,0.62249 -0.44211,10.07264 l 0.25676,7.86067 0.99682,0.85129 c 0.54901,0.47 1.60167,1.17003 2.33967,1.55703 3.112,1.633 4.38453,6.83059 6.99154,19.57959 2.877,14.065 4.54005,19.64214 7.94305,26.65214 0.97371,2.00625 2.06271,3.91685 3.25136,5.73933 -10.43519,8.24593 -17.08742,15.02236 -16.24859,17.11085 4.11614,10.24817 19.75965,9.2767 29.11263,-1.13276 0.48346,-0.53807 0.97532,-1.07149 1.4623,-1.60784 0.92355,0.60807 1.86788,1.19489 2.84082,1.75063 4.746,2.711 11.15353,4.4665 19.53154,5.3535 3.77499,0.4 16.78511,0.16903 20.95813,-0.36797 8.39399,-1.087 16.7474,-3.29702 22.51241,-5.95901 12.49999,-5.773 21.83047,-17.88534 27.98948,-36.32934 1.3928,-4.17249 3.52041,-12.30539 4.87018,-18.34797 4.37032,-0.80291 8.85058,-1.5658 13.41737,-2.2875 4.64306,0.73318 9.19585,1.50748 13.6357,2.32457 1.3273,5.90044 3.29591,13.52088 4.58458,17.48569 5.14401,15.82601 12.74839,27.36097 22.26939,33.78098 6.64399,4.48 14.60963,7.20464 26.39263,9.02364 6.98499,1.079 20.84272,1.17485 27.12172,0.19085 7.59978,-1.19163 12.79632,-2.9978 18.22165,-6.5755 0.47688,0.52535 0.95858,1.04789 1.43208,1.57487 9.35298,10.40946 24.99512,11.38232 29.11125,1.13414 0.83753,-2.08522 -5.78935,-8.84395 -16.19641,-17.07241 2.36335,-3.62482 4.39857,-7.65257 5.95901,-11.8933 1.81099,-4.923 2.87227,-8.99523 4.89627,-18.78322 1.921,-9.29001 3.27735,-16.53868 4.23035,-18.38368 0.58199,-1.124 1.55617,-1.96056 4.44316,-3.81156 l 1.84949,-1.18769 0.0206,-0.38033 c 6.2e-4,-1e-5 0.0728,-0.001 0.0728,-0.001 l -0.0124,-1.12452 0.14966,-2.75021 c 0.125,-2.342 0.24761,-4.86951 0.27461,-8.06251 0.0376,-4.57975 -0.002,-5.6035 -0.40367,-5.90408 z m -23.12753,18.764 c 0.54643,0.79932 1.03354,1.60512 1.43345,2.40832 1.60991,3.23541 2.0067,6.97465 2.017,15.03894 a 2.6822779,2.6217047 0 0 0 10e-4,10e-4 c 0.0153,13.37672 -2.24912,23.77872 -7.20984,31.91638 -19.50486,-14.56321 -48.1054,-31.835 -68.2169,-36.4584 -7.39806,-1.70073 -15.75321,-3.42569 -24.6928,-5.14891 36.38891,-4.36254 73.57759,-6.64953 96.66772,-7.7577 z m -18.42762,-13.42149 c -23.84291,3.24193 -54.61551,7.61074 -85.08884,12.51254 0.33209,-0.82495 0.71624,-1.61669 1.18081,-2.36987 2.10391,-3.41091 5.48061,-5.81382 10.08363,-7.98837 11.23948,-5.30991 25.29205,-7.90192 39.31709,-7.93481 12.13543,-0.0285 24.24704,1.86174 34.50731,5.78051 z m -2.85318,72.17811 c 1.26685,1.29064 2.51662,2.59584 3.75802,3.90906 -4.04053,2.23793 -8.65704,3.82947 -13.99681,4.87156 -3.53387,0.69019 -6.15883,0.86823 -13.68923,0.95563 -10.11559,0.11706 -10.96872,0.057 -16.68384,-0.98446 -9.17898,-1.6736 -16.61026,-4.90474 -22.70601,-10.4063 -6.09576,-5.50156 -10.79816,-13.13912 -15.04581,-23.46256 -2.60008,-6.3234 -4.31271,-12.55404 -5.03495,-18.40015 11.92242,2.38085 22.81982,5.09305 31.90541,8.19295 19.96497,6.81183 36.6362,20.18829 51.49322,35.32427 z m -94.49693,-59.28112 c 0.45556,0.39231 0.84537,0.86757 1.18768,1.43209 -3.48304,0.57783 -6.90453,1.16019 -10.32528,1.7465 -3.38557,-0.58017 -6.77164,-1.15541 -10.21819,-1.72728 1.64638,-2.767 4.42919,-3.30217 10.27173,-3.30217 4.62351,0 7.33375,0.3436 9.08406,1.85086 z m -32.68942,-5.4757 c 0.67995,0.73491 1.28188,1.51896 1.80419,2.36713 0.5611,0.91117 1.00993,1.8762 1.37853,2.89437 -31.29677,-5.04729 -62.94396,-9.53344 -87.1841,-12.82284 4.60548,-1.77215 10.06484,-3.32197 15.3465,-4.35667 6.36791,-1.2472 13.05485,-1.8553 19.73749,-1.8742 14.70239,-0.0414 29.38807,2.7435 40.67914,8.17373 3.44964,1.6593 6.19843,3.41376 8.23825,5.61848 z m 4.16994,21.06385 c -0.94086,7.99703 -3.71526,16.44186 -8.34673,25.67728 -3.42867,6.83543 -6.70019,11.68869 -10.54085,15.44262 -7.87446,7.69663 -18.26943,11.73164 -32.3228,12.83932 -14.74994,1.1616 -27.71844,-0.79761 -37.15454,-5.9288 15.9027,-16.88703 33.80578,-32.21705 55.66178,-39.67408 9.29091,-3.16995 20.46328,-5.93724 32.70314,-8.35634 z m -8.8781,-7.30459 c -8.91398,1.71891 -17.24609,3.44012 -24.62552,5.13656 -20.26091,4.65775 -49.13548,22.15247 -68.64803,36.78245 -0.97111,-1.54323 -1.83004,-3.12512 -2.53326,-4.71091 l -0.001,-10e-4 c -3.43058,-7.7347 -4.74336,-15.69469 -4.74936,-27.95653 -0.003,-4.09603 0.0102,-6.38568 0.13593,-8.10508 0.12572,-1.71861 0.41917,-2.92041 0.83207,-4.20426 0.50976,-1.58532 1.30783,-3.17106 2.33554,-4.72189 23.02249,1.09543 60.53797,3.38201 97.254,7.78103 z"
-           id="path1249"
-           inkscape:connector-curvature="0" />
-        <path
-           transform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)"
-           inkscape:connector-curvature="0"
-           id="path1251"
-           d="m 402.59658,214.13101 c -0.0574,-0.0429 -0.12197,-0.0718 -0.19498,-0.0934 -2.608,-0.772 -18.88194,-3.53248 -27.48694,-4.66148 -12.7125,-1.668 -27.56759,-2.61728 -39.21823,-2.60466 -3.88355,0.004 -7.41157,0.11464 -10.38432,0.34188 -15.226,1.16301 -35.22173,4.54881 -50.53073,8.5568 -9.541,2.49701 -9.83346,2.54427 -17.21247,2.80925 -9.047,0.32501 -12.61808,-0.1225 -23.79208,-2.9795 -11.15,-2.851 -19.85037,-4.54175 -33.41438,-6.49175 -13.59899,-1.956 -20.24215,-2.37935 -33.30315,-2.12135 -14.096,0.279 -26.42535,1.40271 -41.75835,3.8047 -6.09748,0.95461 -17.31892,2.98787 -18.53471,3.3571 0,0 -0.004,0.001 -0.004,0.001 l -0.001,0.001 c -0.66715,0.2042 -0.68688,0.62249 -0.44211,10.07264 l 0.25676,7.86067 0.99682,0.85129 c 0.54901,0.47 1.60167,1.17003 2.33967,1.55703 3.112,1.633 4.38453,6.83059 6.99154,19.57959 2.877,14.065 4.54005,19.64214 7.94305,26.65214 0.97371,2.00625 2.06271,3.91685 3.25136,5.73933 -10.43519,8.24593 -17.08742,15.02236 -16.24859,17.11085 4.11614,10.24817 19.75965,9.2767 29.11263,-1.13276 0.48346,-0.53807 0.97532,-1.07149 1.4623,-1.60784 0.92355,0.60807 1.86788,1.19489 2.84082,1.75063 4.746,2.711 11.15353,4.4665 19.53154,5.3535 3.77499,0.4 16.78511,0.16903 20.95813,-0.36797 8.39399,-1.087 16.7474,-3.29702 22.51241,-5.95901 12.49999,-5.773 21.83047,-17.88534 27.98948,-36.32934 1.3928,-4.17249 3.52041,-12.30539 4.87018,-18.34797 4.37032,-0.80291 8.85058,-1.5658 13.41737,-2.2875 4.64306,0.73318 9.19585,1.50748 13.6357,2.32457 1.3273,5.90044 3.29591,13.52088 4.58458,17.48569 5.14401,15.82601 12.74839,27.36097 22.26939,33.78098 6.64399,4.48 14.60963,7.20464 26.39263,9.02364 6.98499,1.079 20.84272,1.17485 27.12172,0.19085 7.59978,-1.19163 12.79632,-2.9978 18.22165,-6.5755 0.47688,0.52535 0.95858,1.04789 1.43208,1.57487 9.35298,10.40946 24.99512,11.38232 29.11125,1.13414 0.83753,-2.08522 -5.78935,-8.84395 -16.19641,-17.07241 2.36335,-3.62482 4.39857,-7.65257 5.95901,-11.8933 1.81099,-4.923 2.87227,-8.99523 4.89627,-18.78322 1.921,-9.29001 3.27735,-16.53868 4.23035,-18.38368 0.58199,-1.124 1.55617,-1.96056 4.44316,-3.81156 l 1.84949,-1.18769 0.0206,-0.38033 c 6.2e-4,-1e-5 0.0728,-0.001 0.0728,-0.001 l -0.0124,-1.12452 0.14966,-2.75021 c 0.125,-2.342 0.24761,-4.86951 0.27461,-8.06251 0.0376,-4.57975 -0.002,-5.6035 -0.40367,-5.90408 z m -23.12753,18.764 c 0.54643,0.79932 1.03354,1.60512 1.43345,2.40832 1.60991,3.23541 2.0067,6.97465 2.017,15.03894 a 2.6822779,2.6217047 0 0 0 10e-4,10e-4 c 0.0153,13.37672 -2.24912,23.77872 -7.20984,31.91638 -19.50486,-14.56321 -48.1054,-31.835 -68.2169,-36.4584 -7.39806,-1.70073 -15.75321,-3.42569 -24.6928,-5.14891 36.38891,-4.36254 73.57759,-6.64953 96.66772,-7.7577 z m -18.42762,-13.42149 c -23.84291,3.24193 -54.61551,7.61074 -85.08884,12.51254 0.33209,-0.82495 0.71624,-1.61669 1.18081,-2.36987 2.10391,-3.41091 5.48061,-5.81382 10.08363,-7.98837 11.23948,-5.30991 25.29205,-7.90192 39.31709,-7.93481 12.13543,-0.0285 24.24704,1.86174 34.50731,5.78051 z m -2.85318,72.17811 c 1.26685,1.29064 2.51662,2.59584 3.75802,3.90906 -4.04053,2.23793 -8.65704,3.82947 -13.99681,4.87156 -3.53387,0.69019 -6.15883,0.86823 -13.68923,0.95563 -10.11559,0.11706 -10.96872,0.057 -16.68384,-0.98446 -9.17898,-1.6736 -16.61026,-4.90474 -22.70601,-10.4063 -6.09576,-5.50156 -10.79816,-13.13912 -15.04581,-23.46256 -2.60008,-6.3234 -4.31271,-12.55404 -5.03495,-18.40015 11.92242,2.38085 22.81982,5.09305 31.90541,8.19295 19.96497,6.81183 36.6362,20.18829 51.49322,35.32427 z m -94.49693,-59.28112 c 0.45556,0.39231 0.84537,0.86757 1.18768,1.43209 -3.48304,0.57783 -6.90453,1.16019 -10.32528,1.7465 -3.38557,-0.58017 -6.77164,-1.15541 -10.21819,-1.72728 1.64638,-2.767 4.42919,-3.30217 10.27173,-3.30217 4.62351,0 7.33375,0.3436 9.08406,1.85086 z m -32.68942,-5.4757 c 0.67995,0.73491 1.28188,1.51896 1.80419,2.36713 0.5611,0.91117 1.00993,1.8762 1.37853,2.89437 -31.29677,-5.04729 -62.94396,-9.53344 -87.1841,-12.82284 4.60548,-1.77215 10.06484,-3.32197 15.3465,-4.35667 6.36791,-1.2472 13.05485,-1.8553 19.73749,-1.8742 14.70239,-0.0414 29.38807,2.7435 40.67914,8.17373 3.44964,1.6593 6.19843,3.41376 8.23825,5.61848 z m 4.16994,21.06385 c -0.94086,7.99703 -3.71526,16.44186 -8.34673,25.67728 -3.42867,6.83543 -6.70019,11.68869 -10.54085,15.44262 -7.87446,7.69663 -18.26943,11.73164 -32.3228,12.83932 -14.74994,1.1616 -27.71844,-0.79761 -37.15454,-5.9288 15.9027,-16.88703 33.80578,-32.21705 55.66178,-39.67408 9.29091,-3.16995 20.46328,-5.93724 32.70314,-8.35634 z m -8.8781,-7.30459 c -8.91398,1.71891 -17.24609,3.44012 -24.62552,5.13656 -20.26091,4.65775 -49.13548,22.15247 -68.64803,36.78245 -0.97111,-1.54323 -1.83004,-3.12512 -2.53326,-4.71091 l -0.001,-10e-4 c -3.43058,-7.7347 -4.74336,-15.69469 -4.74936,-27.95653 -0.003,-4.09603 0.0102,-6.38568 0.13593,-8.10508 0.12572,-1.71861 0.41917,-2.92041 0.83207,-4.20426 0.50976,-1.58532 1.30783,-3.17106 2.33554,-4.72189 23.02249,1.09543 60.53797,3.38201 97.254,7.78103 z"
-           style="opacity:0.1;fill:#000000;stroke-width:16.74926186;filter:url(#filter4279)" />
-        <path
-           sodipodi:nodetypes="csssscc"
-           inkscape:connector-curvature="0"
-           id="path1253"
-           d="m 416.31018,192.73042 c 0,0 -147.26638,18.25561 -217.55148,34.41335 -36.82764,8.46625 -99.935182,56.07178 -97.34615,62.51784 4.46103,11.10685 21.41493,10.05312 31.55159,-1.22854 18.80646,-20.93077 40.02902,-40.79638 66.6602,-49.88264 65.50893,-22.35094 216.88742,-26.38224 216.88742,-26.38224 z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#636363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1161.77099609;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#636363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1161.77099609;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 95.898652,192.74234 c 0,0 147.266378,18.25561 217.551488,34.41335 36.82763,8.46625 99.93517,56.07178 97.34614,62.51784 -4.46103,11.10686 -21.41493,10.05312 -31.55159,-1.22854 -18.80646,-20.93076 -40.02902,-40.79638 -66.6602,-49.88264 C 247.07556,216.21141 95.697067,212.18011 95.697067,212.18011 Z"
-           id="path1255"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssscc" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path1257"
-           d="m 344.0153,184.8556 c -4.20895,0.004 -8.03305,0.12415 -11.25489,0.37044 -16.50178,1.26045 -38.17139,4.92977 -54.76312,9.2736 -10.34044,2.70622 -10.65787,2.75884 -18.65515,3.04603 -9.80505,0.35223 -13.67631,-0.1338 -25.78657,-3.23019 -12.08426,-3.08988 -21.51329,-4.92278 -36.21381,-7.03617 -14.73846,-2.11989 -21.93779,-2.57843 -36.09316,-2.29881 -15.2771,0.30237 -28.63893,1.52021 -45.25668,4.12347 -6.61111,1.03502 -18.783218,3.2399 -20.092436,3.63874 -0.725055,0.22109 -0.746037,0.66677 -0.480509,10.91833 l 0.277298,8.52003 1.081666,0.92291 c 0.595,0.50938 1.736068,1.26764 2.535904,1.68707 3.372757,1.76983 4.750497,7.40345 7.575937,21.22069 3.11806,15.24349 4.9208,21.28817 8.60893,28.88553 4.91499,10.12693 12.38768,18.12678 22.12878,23.69096 5.14367,2.93815 12.08989,4.84077 21.16988,5.80209 4.09131,0.43351 18.19036,0.18404 22.71302,-0.39796 9.09733,-1.17808 18.14991,-3.57324 24.39795,-6.45828 13.54737,-6.25672 23.66047,-19.38475 30.33553,-39.37416 2.03536,-6.0974 5.53221,-20.02767 6.435,-25.63628 1.68313,-10.45749 3.34139,-11.93015 13.45423,-11.93015 10.0218,0 11.74958,1.48754 13.44788,11.58088 0.9559,5.6758 4.30703,19.17482 6.22967,25.09015 5.57502,17.15205 13.81673,29.65383 24.13549,36.61177 7.20069,4.85538 15.83371,7.80809 28.604,9.7795 7.57027,1.16941 22.58844,1.2739 29.39355,0.20745 10.76203,-1.68746 17.07464,-4.4983 25.30819,-11.26548 6.84955,-5.63246 12.8199,-14.45938 16.44735,-24.31753 1.96274,-5.3355 3.11316,-9.74892 5.30675,-20.35705 2.08196,-10.0684 3.55209,-17.9235 4.58494,-19.92309 0.63077,-1.21818 1.68677,-2.12586 4.81567,-4.13195 l 2.00459,-1.287 0.24978,-4.61246 c 0.13547,-2.53823 0.2692,-5.27751 0.29846,-8.73805 0.0466,-5.67255 -0.0169,-6.31312 -0.64985,-6.50061 -2.82652,-0.83669 -20.46339,-3.82704 -29.7894,-5.05064 -13.77767,-1.80776 -29.87802,-2.83744 -42.50487,-2.82378 z m -166.48234,6.86048 c 15.93429,-0.0449 31.85107,2.97349 44.08822,8.85871 4.98491,2.39777 8.61804,4.97853 10.88235,8.6555 2.2643,3.67695 2.96782,8.08954 2.96348,13.74634 -0.009,10.58683 -3.15069,21.79551 -9.44505,34.34682 -3.71597,7.40817 -7.26178,12.66676 -11.42425,16.73523 -8.53425,8.34152 -19.79963,12.71519 -35.03052,13.91568 -16.37668,1.28971 -30.73991,-0.95881 -41.02314,-6.82872 -6.88721,-3.93261 -13.52812,-11.56164 -16.93421,-19.24361 h 0.002 c -3.71861,-8.38335 -5.1415,-17.00934 -5.148,-30.29954 -0.003,-4.43923 0.01,-6.92117 0.14605,-8.78462 0.13626,-1.86262 0.45425,-3.166 0.90175,-4.55741 1.82508,-5.67583 7.02787,-11.35488 13.52832,-15.66838 5.33188,-3.53887 15.51862,-6.96631 25.10284,-8.8439 6.90148,-1.3517 14.14746,-2.01162 21.39003,-2.0321 z m 156.55255,0.64138 c 15.20007,-0.0357 30.37154,2.6982 42.44348,8.4036 6.80473,3.21546 13.57292,9.1753 16.48122,15.01641 1.7448,3.50651 2.17547,7.55918 2.18663,16.29918 a 2.9070246,2.841376 0 0 0 0,0.002 c 0.0216,18.87798 -4.12628,32.30326 -13.49233,41.93968 -6.23627,6.416 -14.07525,10.32844 -24.40855,12.34504 -3.82998,0.74803 -6.67512,0.9425 -14.83649,1.03722 -10.96317,0.12686 -11.88751,0.0597 -18.0815,-1.06897 -9.94808,-1.81382 -18.00312,-5.31565 -24.60964,-11.27819 -6.60652,-5.96253 -11.70197,-14.23828 -16.30553,-25.42672 -3.77388,-9.17809 -5.82859,-18.18073 -5.8804,-26.23532 -0.0353,-5.63599 0.68332,-10.08139 2.96348,-13.7781 2.28019,-3.69669 5.94022,-6.30086 10.92892,-8.65761 12.18124,-5.75483 27.41052,-8.56269 42.61071,-8.59834 z"
-           style="fill:#1a5fb4;fill-opacity:1;stroke:#1a5fb4;stroke-width:18.15267181;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path1259"
-           d="m 177.53201,191.71607 c -7.24258,0.0205 -14.48683,0.6804 -21.38829,2.0321 -9.58424,1.87759 -19.77273,5.30504 -25.1046,8.8439 -6.50045,4.31352 -11.70178,9.99255 -13.52686,15.66838 -0.44749,1.39141 -0.76683,2.6948 -0.90308,4.55741 -0.13633,1.86346 -0.14789,4.34539 -0.1451,8.78462 0.007,13.2902 1.4292,21.91619 5.14781,30.29954 h -0.002 c 3.40609,7.68197 10.04625,15.31101 16.93346,19.24361 10.28322,5.86991 24.64788,8.11843 41.02455,6.82872 15.2309,-1.2005 26.49568,-5.57416 35.02993,-13.91568 4.16247,-4.06847 7.70801,-9.32705 11.42398,-16.73523 6.29436,-12.55131 9.43636,-23.75999 9.44454,-34.34682 0.004,-5.65679 -0.69835,-10.06938 -2.96265,-13.74634 -2.2643,-3.67697 -5.89765,-6.25772 -10.88256,-8.6555 -12.23716,-5.88521 -28.15469,-8.90362 -44.08898,-8.85871 z"
-           style="opacity:0.5;fill:url(#linearGradient1271);fill-opacity:1;stroke-width:17.94653702" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path1261"
-           d="m 334.08548,192.35746 c -15.20019,0.0357 -30.4286,2.84351 -42.60983,8.59834 -4.9887,2.35675 -8.65002,4.96091 -10.93021,8.65761 -2.28016,3.69671 -2.99801,8.14211 -2.96265,13.7781 0.0518,8.05459 2.10595,17.05723 5.87983,26.23532 4.60356,11.18844 9.69891,19.46419 16.30543,25.42672 6.60652,5.96254 14.66274,9.46437 24.61082,11.27819 6.19399,1.12869 7.11813,1.19583 18.0813,1.06897 8.16137,-0.0947 11.00495,-0.2892 14.83493,-1.03722 10.33329,-2.0166 18.17316,-5.92904 24.40942,-12.34504 9.36606,-9.63642 13.51373,-23.0617 13.4922,-41.93969 a 2.9070246,2.841376 0 0 0 0,-0.002 c -0.0112,-8.74 -0.44252,-12.79268 -2.18732,-16.29918 -2.9083,-5.84112 -9.67613,-11.80095 -16.48086,-15.01641 -12.07194,-5.70541 -27.24299,-8.43929 -42.44306,-8.4036 z"
-           style="opacity:0.5;fill:url(#linearGradient1273);fill-opacity:1;stroke-width:17.94653702" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path1263"
-           d="m 206.95237,275.67414 c -6.41044,3.41127 -14.17254,5.36014 -23.87717,6.02156 -16.03837,1.09202 -29.89753,-1.34792 -39.41908,-6.85147 l -0.002,0.002 c -6.09907,-3.52638 -12.59349,-10.90254 -15.7604,-17.90118 a 3.7245728,3.6455441 45 0 0 -0.003,-0.0129 c -3.60542,-7.97407 -5.05339,-16.01772 -5.20107,-29.18983 -0.0508,-4.47959 -0.0582,-6.94433 0.0456,-8.60559 0.0994,-1.59023 0.31481,-2.49282 0.70417,-3.74087 0.14912,-0.47811 0.34312,-0.96799 0.56426,-1.46335 -1.41765,1.86285 -2.46858,3.72031 -3.02255,5.44313 -0.39847,1.23895 -0.622,2.13345 -0.73718,3.70787 -0.12033,1.64473 -0.13796,4.08447 -0.13518,8.51599 0.006,13.03081 1.35228,20.97239 4.83485,28.82361 a 3.645544,3.645544 0 0 1 0.005,0.0142 c 3.05906,6.89079 9.40508,14.11854 15.40203,17.54281 l 0.002,-0.002 c 9.36214,5.34414 23.04888,7.61165 38.92868,6.36107 11.69965,-0.92217 20.57672,-3.69846 27.67149,-8.66532 z"
-           style="opacity:0.5;fill:#ffffff;stroke-width:17.94653702" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path1265"
-           d="m 374.53886,274.24538 c -4.01013,2.27662 -8.67937,3.88151 -14.34264,4.94016 -3.581,0.66995 -5.94679,0.81581 -14.1163,0.84091 -11.03447,0.0335 -11.15179,0.0304 -17.36049,-1.15212 -9.44444,-1.80008 -16.6439,-5.03337 -22.62915,-10.4446 -6.00368,-5.42787 -10.88249,-13.13968 -15.46649,-24.09249 l 0.002,-0.002 c -3.70073,-8.84811 -5.68355,-17.41535 -5.79364,-24.7715 -0.0624,-4.21199 0.34623,-7.25767 1.34074,-9.67755 -0.66688,0.68136 -1.23909,1.38942 -1.70539,2.1455 -1.64067,2.65993 -2.30877,6.10048 -2.27597,11.32951 0.0469,7.29296 1.93976,15.77024 5.5343,24.51216 h -0.003 c 4.45251,10.82134 9.22632,18.42814 15.13326,23.75927 5.8888,5.31478 13.00008,8.45989 22.34937,10.16481 6.14615,1.11998 6.26194,1.12156 17.20331,0.99495 8.10059,-0.094 10.44834,-0.25792 14.0047,-0.95251 7.53712,-1.47091 13.31565,-3.89576 18.12596,-7.59492 z"
-           style="opacity:0.5;fill:#ffffff;stroke-width:17.94653702" />
-      </g>
-      <path
-         style="display:inline;overflow:visible;fill:#ffffff;stroke-width:0.1979219;enable-background:new"
-         inkscape:connector-curvature="0"
-         id="path6353-7-3-6"
-         overflow="visible"
-         d="m 333,201.49992 a 8.3022303,8.3022303 0 0 0 2.83622,-1.42385 c 0.28521,-0.2205 0.56169,-0.46651 0.73567,-0.78219 0.087,-0.15795 0.14667,-0.33212 0.16309,-0.51163 0.0163,-0.17951 -0.0123,-0.36437 -0.0926,-0.52568 a 0.94765012,0.94765012 0 0 0 -0.30182,-0.34736 1.1390406,1.1390406 0 0 0 -0.42435,-0.18168 c -0.30341,-0.0633 -0.62227,-0.0127 -0.91222,0.097 -0.34875,0.13243 -0.66779,0.3533 -0.89204,0.65137 -0.22444,0.29827 -0.34953,0.67531 -0.32063,1.04741 0.019,0.24107 0.10153,0.47599 0.2288,0.68164 0.12726,0.20583 0.29866,0.38298 0.49401,0.52568 0.3909,0.28541 0.86987,0.42969 1.34982,0.49124 1.09254,0.13973 2.23356,-0.14151 3.13608,-0.77288 l -0.005,-1.02683 c -0.70738,0.78042 -1.71342,1.28314 -2.7622,1.38052 -0.45264,0.042 -0.9243,0.008 -1.33321,-0.1912 -0.20445,-0.0994 -0.39049,-0.23948 -0.5328,-0.41683 -0.1425,-0.17713 -0.24029,-0.39187 -0.26819,-0.61751 -0.0408,-0.32914 0.0709,-0.66897 0.2767,-0.92904 0.20583,-0.26007 0.50016,-0.44316 0.81682,-0.54231 0.17477,-0.0544 0.35983,-0.0849 0.54152,-0.0615 0.18149,0.0234 0.35962,0.1043 0.47798,0.24404 0.0958,0.1132 0.14844,0.25986 0.15755,0.4079 0.009,0.14806 -0.0231,0.29709 -0.0822,0.43326 -0.11776,0.27215 -0.33509,0.48768 -0.55655,0.68481 a 9.2672972,9.2672972 0 0 1 -2.73053,1.6857 z" />
-      <path
-         style="display:inline;overflow:visible;fill:#ffffff;stroke-width:0.13194552;enable-background:new"
-         inkscape:connector-curvature="0"
-         id="path6353-7-3-6-2"
-         overflow="visible"
-         d="m 329,244.99992 a 5.5347187,5.5347187 0 0 0 1.89078,-0.94922 c 0.19014,-0.147 0.37446,-0.311 0.49044,-0.52145 0.058,-0.1053 0.0978,-0.22141 0.10872,-0.34108 0.0109,-0.11967 -0.008,-0.24291 -0.0617,-0.35045 a 0.63175516,0.63175516 0 0 0 -0.20121,-0.23157 0.75934648,0.75934648 0 0 0 -0.28289,-0.12111 c -0.20227,-0.0422 -0.41484,-0.008 -0.60814,0.0647 -0.23249,0.0883 -0.44518,0.23553 -0.59468,0.43424 -0.14962,0.19884 -0.23302,0.4502 -0.21375,0.69826 0.0127,0.16071 0.0677,0.31732 0.15253,0.45442 0.0848,0.13722 0.1991,0.25531 0.32933,0.35045 0.2606,0.19027 0.57991,0.28645 0.89987,0.32748 0.72834,0.0932 1.48901,-0.0943 2.09068,-0.51524 l -0.003,-0.68454 c -0.47158,0.52027 -1.14226,0.85541 -1.84144,0.92033 -0.30175,0.028 -0.61618,0.005 -0.88879,-0.12747 -0.13629,-0.0663 -0.26032,-0.15965 -0.35519,-0.27788 -0.095,-0.11808 -0.16019,-0.26124 -0.17879,-0.41166 -0.0272,-0.21943 0.0473,-0.44597 0.18446,-0.61935 0.13722,-0.17338 0.33344,-0.29544 0.54454,-0.36154 0.11651,-0.0363 0.23988,-0.0566 0.36101,-0.041 0.12099,0.0156 0.23974,0.0695 0.31864,0.16269 0.0639,0.0755 0.099,0.17323 0.10504,0.27192 0.006,0.0987 -0.0154,0.19806 -0.0548,0.28884 -0.0785,0.18143 -0.22339,0.32511 -0.37103,0.45653 A 6.1780849,6.1780849 0 0 1 329.00031,245 Z" />
-      <g
-         id="g4295"
-         transform="matrix(0.47940943,0,0,0.47940943,21.25969,114.78782)"
-         style="display:inline;stroke-width:1.0429498;enable-background:new">
-        <path
-           inkscape:connector-curvature="0"
-           id="path4283"
-           d="m 402.59658,214.13101 c -0.0574,-0.0429 -0.12197,-0.0718 -0.19498,-0.0934 -2.608,-0.772 -18.88194,-3.53248 -27.48694,-4.66148 -12.7125,-1.668 -27.56759,-2.61728 -39.21823,-2.60466 -3.88355,0.004 -7.41157,0.11464 -10.38432,0.34188 -15.226,1.16301 -35.22173,4.54881 -50.53073,8.5568 -9.541,2.49701 -9.83346,2.54427 -17.21247,2.80925 -9.047,0.32501 -12.61808,-0.1225 -23.79208,-2.9795 -11.15,-2.851 -19.85037,-4.54175 -33.41438,-6.49175 -13.59899,-1.956 -20.24215,-2.37935 -33.30315,-2.12135 -14.096,0.279 -26.42535,1.40271 -41.75835,3.8047 -6.09748,0.95461 -17.31892,2.98787 -18.53471,3.3571 0,0 -0.004,0.001 -0.004,0.001 l -0.001,0.001 c -0.66715,0.2042 -0.68688,0.62249 -0.44211,10.07264 l 0.25676,7.86067 0.99682,0.85129 c 0.54901,0.47 1.60167,1.17003 2.33967,1.55703 3.112,1.633 4.38453,6.83059 6.99154,19.57959 2.877,14.065 4.54005,19.64214 7.94305,26.65214 0.97371,2.00625 2.06271,3.91685 3.25136,5.73933 -10.43519,8.24593 -17.08742,15.02236 -16.24859,17.11085 4.11614,10.24817 19.75965,9.2767 29.11263,-1.13276 0.48346,-0.53807 0.97532,-1.07149 1.4623,-1.60784 0.92355,0.60807 1.86788,1.19489 2.84082,1.75063 4.746,2.711 11.15353,4.4665 19.53154,5.3535 3.77499,0.4 16.78511,0.16903 20.95813,-0.36797 8.39399,-1.087 16.7474,-3.29702 22.51241,-5.95901 12.49999,-5.773 21.83047,-17.88534 27.98948,-36.32934 1.3928,-4.17249 3.52041,-12.30539 4.87018,-18.34797 4.37032,-0.80291 8.85058,-1.5658 13.41737,-2.2875 4.64306,0.73318 9.19585,1.50748 13.6357,2.32457 1.3273,5.90044 3.29591,13.52088 4.58458,17.48569 5.14401,15.82601 12.74839,27.36097 22.26939,33.78098 6.64399,4.48 14.60963,7.20464 26.39263,9.02364 6.98499,1.079 20.84272,1.17485 27.12172,0.19085 7.59978,-1.19163 12.79632,-2.9978 18.22165,-6.5755 0.47688,0.52535 0.95858,1.04789 1.43208,1.57487 9.35298,10.40946 24.99512,11.38232 29.11125,1.13414 0.83753,-2.08522 -5.78935,-8.84395 -16.19641,-17.07241 2.36335,-3.62482 4.39857,-7.65257 5.95901,-11.8933 1.81099,-4.923 2.87227,-8.99523 4.89627,-18.78322 1.921,-9.29001 3.27735,-16.53868 4.23035,-18.38368 0.58199,-1.124 1.55617,-1.96056 4.44316,-3.81156 l 1.84949,-1.18769 0.0206,-0.38033 c 6.2e-4,-1e-5 0.0728,-0.001 0.0728,-0.001 l -0.0124,-1.12452 0.14966,-2.75021 c 0.125,-2.342 0.24761,-4.86951 0.27461,-8.06251 0.0376,-4.57975 -0.002,-5.6035 -0.40367,-5.90408 z m -23.12753,18.764 c 0.54643,0.79932 1.03354,1.60512 1.43345,2.40832 1.60991,3.23541 2.0067,6.97465 2.017,15.03894 a 2.6822779,2.6217047 0 0 0 10e-4,10e-4 c 0.0153,13.37672 -2.24912,23.77872 -7.20984,31.91638 -19.50486,-14.56321 -48.1054,-31.835 -68.2169,-36.4584 -7.39806,-1.70073 -15.75321,-3.42569 -24.6928,-5.14891 36.38891,-4.36254 73.57759,-6.64953 96.66772,-7.7577 z m -18.42762,-13.42149 c -23.84291,3.24193 -54.61551,7.61074 -85.08884,12.51254 0.33209,-0.82495 0.71624,-1.61669 1.18081,-2.36987 2.10391,-3.41091 5.48061,-5.81382 10.08363,-7.98837 11.23948,-5.30991 25.29205,-7.90192 39.31709,-7.93481 12.13543,-0.0285 24.24704,1.86174 34.50731,5.78051 z m -2.85318,72.17811 c 1.26685,1.29064 2.51662,2.59584 3.75802,3.90906 -4.04053,2.23793 -8.65704,3.82947 -13.99681,4.87156 -3.53387,0.69019 -6.15883,0.86823 -13.68923,0.95563 -10.11559,0.11706 -10.96872,0.057 -16.68384,-0.98446 -9.17898,-1.6736 -16.61026,-4.90474 -22.70601,-10.4063 -6.09576,-5.50156 -10.79816,-13.13912 -15.04581,-23.46256 -2.60008,-6.3234 -4.31271,-12.55404 -5.03495,-18.40015 11.92242,2.38085 22.81982,5.09305 31.90541,8.19295 19.96497,6.81183 36.6362,20.18829 51.49322,35.32427 z m -94.49693,-59.28112 c 0.45556,0.39231 0.84537,0.86757 1.18768,1.43209 -3.48304,0.57783 -6.90453,1.16019 -10.32528,1.7465 -3.38557,-0.58017 -6.77164,-1.15541 -10.21819,-1.72728 1.64638,-2.767 4.42919,-3.30217 10.27173,-3.30217 4.62351,0 7.33375,0.3436 9.08406,1.85086 z m -32.68942,-5.4757 c 0.67995,0.73491 1.28188,1.51896 1.80419,2.36713 0.5611,0.91117 1.00993,1.8762 1.37853,2.89437 -31.29677,-5.04729 -62.94396,-9.53344 -87.1841,-12.82284 4.60548,-1.77215 10.06484,-3.32197 15.3465,-4.35667 6.36791,-1.2472 13.05485,-1.8553 19.73749,-1.8742 14.70239,-0.0414 29.38807,2.7435 40.67914,8.17373 3.44964,1.6593 6.19843,3.41376 8.23825,5.61848 z m 4.16994,21.06385 c -0.94086,7.99703 -3.71526,16.44186 -8.34673,25.67728 -3.42867,6.83543 -6.70019,11.68869 -10.54085,15.44262 -7.87446,7.69663 -18.26943,11.73164 -32.3228,12.83932 -14.74994,1.1616 -27.71844,-0.79761 -37.15454,-5.9288 15.9027,-16.88703 33.80578,-32.21705 55.66178,-39.67408 9.29091,-3.16995 20.46328,-5.93724 32.70314,-8.35634 z m -8.8781,-7.30459 c -8.91398,1.71891 -17.24609,3.44012 -24.62552,5.13656 -20.26091,4.65775 -49.13548,22.15247 -68.64803,36.78245 -0.97111,-1.54323 -1.83004,-3.12512 -2.53326,-4.71091 l -0.001,-10e-4 c -3.43058,-7.7347 -4.74336,-15.69469 -4.74936,-27.95653 -0.003,-4.09603 0.0102,-6.38568 0.13593,-8.10508 0.12572,-1.71861 0.41917,-2.92041 0.83207,-4.20426 0.50976,-1.58532 1.30783,-3.17106 2.33554,-4.72189 23.02249,1.09543 60.53797,3.38201 97.254,7.78103 z"
-           style="opacity:0.4;fill:url(#linearGradient2648);fill-opacity:1;stroke-width:1.0429498;filter:url(#filter4293)" />
-        <path
-           style="opacity:0.1;fill:#000000;stroke-width:0.96231776;filter:url(#filter4279)"
-           d="m 402.59658,214.13101 c -0.0574,-0.0429 -0.12197,-0.0718 -0.19498,-0.0934 -2.608,-0.772 -18.88194,-3.53248 -27.48694,-4.66148 -12.7125,-1.668 -27.56759,-2.61728 -39.21823,-2.60466 -3.88355,0.004 -7.41157,0.11464 -10.38432,0.34188 -15.226,1.16301 -35.22173,4.54881 -50.53073,8.5568 -9.541,2.49701 -9.83346,2.54427 -17.21247,2.80925 -9.047,0.32501 -12.61808,-0.1225 -23.79208,-2.9795 -11.15,-2.851 -19.85037,-4.54175 -33.41438,-6.49175 -13.59899,-1.956 -20.24215,-2.37935 -33.30315,-2.12135 -14.096,0.279 -26.42535,1.40271 -41.75835,3.8047 -6.09748,0.95461 -17.31892,2.98787 -18.53471,3.3571 0,0 -0.004,0.001 -0.004,0.001 l -0.001,0.001 c -0.66715,0.2042 -0.68688,0.62249 -0.44211,10.07264 l 0.25676,7.86067 0.99682,0.85129 c 0.54901,0.47 1.60167,1.17003 2.33967,1.55703 3.112,1.633 4.38453,6.83059 6.99154,19.57959 2.877,14.065 4.54005,19.64214 7.94305,26.65214 0.97371,2.00625 2.06271,3.91685 3.25136,5.73933 -10.43519,8.24593 -17.08742,15.02236 -16.24859,17.11085 4.11614,10.24817 19.75965,9.2767 29.11263,-1.13276 0.48346,-0.53807 0.97532,-1.07149 1.4623,-1.60784 0.92355,0.60807 1.86788,1.19489 2.84082,1.75063 4.746,2.711 11.15353,4.4665 19.53154,5.3535 3.77499,0.4 16.78511,0.16903 20.95813,-0.36797 8.39399,-1.087 16.7474,-3.29702 22.51241,-5.95901 12.49999,-5.773 21.83047,-17.88534 27.98948,-36.32934 1.3928,-4.17249 3.52041,-12.30539 4.87018,-18.34797 4.37032,-0.80291 8.85058,-1.5658 13.41737,-2.2875 4.64306,0.73318 9.19585,1.50748 13.6357,2.32457 1.3273,5.90044 3.29591,13.52088 4.58458,17.48569 5.14401,15.82601 12.74839,27.36097 22.26939,33.78098 6.64399,4.48 14.60963,7.20464 26.39263,9.02364 6.98499,1.079 20.84272,1.17485 27.12172,0.19085 7.59978,-1.19163 12.79632,-2.9978 18.22165,-6.5755 0.47688,0.52535 0.95858,1.04789 1.43208,1.57487 9.35298,10.40946 24.99512,11.38232 29.11125,1.13414 0.83753,-2.08522 -5.78935,-8.84395 -16.19641,-17.07241 2.36335,-3.62482 4.39857,-7.65257 5.95901,-11.8933 1.81099,-4.923 2.87227,-8.99523 4.89627,-18.78322 1.921,-9.29001 3.27735,-16.53868 4.23035,-18.38368 0.58199,-1.124 1.55617,-1.96056 4.44316,-3.81156 l 1.84949,-1.18769 0.0206,-0.38033 c 6.2e-4,-1e-5 0.0728,-0.001 0.0728,-0.001 l -0.0124,-1.12452 0.14966,-2.75021 c 0.125,-2.342 0.24761,-4.86951 0.27461,-8.06251 0.0376,-4.57975 -0.002,-5.6035 -0.40367,-5.90408 z m -23.12753,18.764 c 0.54643,0.79932 1.03354,1.60512 1.43345,2.40832 1.60991,3.23541 2.0067,6.97465 2.017,15.03894 a 2.6822779,2.6217047 0 0 0 10e-4,10e-4 c 0.0153,13.37672 -2.24912,23.77872 -7.20984,31.91638 -19.50486,-14.56321 -48.1054,-31.835 -68.2169,-36.4584 -7.39806,-1.70073 -15.75321,-3.42569 -24.6928,-5.14891 36.38891,-4.36254 73.57759,-6.64953 96.66772,-7.7577 z m -18.42762,-13.42149 c -23.84291,3.24193 -54.61551,7.61074 -85.08884,12.51254 0.33209,-0.82495 0.71624,-1.61669 1.18081,-2.36987 2.10391,-3.41091 5.48061,-5.81382 10.08363,-7.98837 11.23948,-5.30991 25.29205,-7.90192 39.31709,-7.93481 12.13543,-0.0285 24.24704,1.86174 34.50731,5.78051 z m -2.85318,72.17811 c 1.26685,1.29064 2.51662,2.59584 3.75802,3.90906 -4.04053,2.23793 -8.65704,3.82947 -13.99681,4.87156 -3.53387,0.69019 -6.15883,0.86823 -13.68923,0.95563 -10.11559,0.11706 -10.96872,0.057 -16.68384,-0.98446 -9.17898,-1.6736 -16.61026,-4.90474 -22.70601,-10.4063 -6.09576,-5.50156 -10.79816,-13.13912 -15.04581,-23.46256 -2.60008,-6.3234 -4.31271,-12.55404 -5.03495,-18.40015 11.92242,2.38085 22.81982,5.09305 31.90541,8.19295 19.96497,6.81183 36.6362,20.18829 51.49322,35.32427 z m -94.49693,-59.28112 c 0.45556,0.39231 0.84537,0.86757 1.18768,1.43209 -3.48304,0.57783 -6.90453,1.16019 -10.32528,1.7465 -3.38557,-0.58017 -6.77164,-1.15541 -10.21819,-1.72728 1.64638,-2.767 4.42919,-3.30217 10.27173,-3.30217 4.62351,0 7.33375,0.3436 9.08406,1.85086 z m -32.68942,-5.4757 c 0.67995,0.73491 1.28188,1.51896 1.80419,2.36713 0.5611,0.91117 1.00993,1.8762 1.37853,2.89437 -31.29677,-5.04729 -62.94396,-9.53344 -87.1841,-12.82284 4.60548,-1.77215 10.06484,-3.32197 15.3465,-4.35667 6.36791,-1.2472 13.05485,-1.8553 19.73749,-1.8742 14.70239,-0.0414 29.38807,2.7435 40.67914,8.17373 3.44964,1.6593 6.19843,3.41376 8.23825,5.61848 z m 4.16994,21.06385 c -0.94086,7.99703 -3.71526,16.44186 -8.34673,25.67728 -3.42867,6.83543 -6.70019,11.68869 -10.54085,15.44262 -7.87446,7.69663 -18.26943,11.73164 -32.3228,12.83932 -14.74994,1.1616 -27.71844,-0.79761 -37.15454,-5.9288 15.9027,-16.88703 33.80578,-32.21705 55.66178,-39.67408 9.29091,-3.16995 20.46328,-5.93724 32.70314,-8.35634 z m -8.8781,-7.30459 c -8.91398,1.71891 -17.24609,3.44012 -24.62552,5.13656 -20.26091,4.65775 -49.13548,22.15247 -68.64803,36.78245 -0.97111,-1.54323 -1.83004,-3.12512 -2.53326,-4.71091 l -0.001,-10e-4 c -3.43058,-7.7347 -4.74336,-15.69469 -4.74936,-27.95653 -0.003,-4.09603 0.0102,-6.38568 0.13593,-8.10508 0.12572,-1.71861 0.41917,-2.92041 0.83207,-4.20426 0.50976,-1.58532 1.30783,-3.17106 2.33554,-4.72189 23.02249,1.09543 60.53797,3.38201 97.254,7.78103 z"
-           id="path4272"
-           inkscape:connector-curvature="0"
-           transform="matrix(1.0837895,0,0,1.0837895,-21.332268,-37.717605)" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#636363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:66.74878693;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 416.31018,192.73042 c 0,0 -147.26638,18.25561 -217.55148,34.41335 -36.82764,8.46625 -99.935182,56.07178 -97.34615,62.51784 4.46103,11.10685 21.41493,10.05312 31.55159,-1.22854 18.80646,-20.93077 40.02902,-40.79638 66.6602,-49.88264 65.50893,-22.35094 216.88742,-26.38224 216.88742,-26.38224 z"
-           id="path4282"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssscc" />
-        <path
-           sodipodi:nodetypes="csssscc"
-           inkscape:connector-curvature="0"
-           id="path4280"
-           d="m 95.898652,192.74234 c 0,0 147.266378,18.25561 217.551488,34.41335 36.82763,8.46625 99.93517,56.07178 97.34614,62.51784 -4.46103,11.10686 -21.41493,10.05312 -31.55159,-1.22854 -18.80646,-20.93076 -40.02902,-40.79638 -66.6602,-49.88264 C 247.07556,216.21141 95.697067,212.18011 95.697067,212.18011 Z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#636363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:66.74878693;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           style="fill:#1a5fb4;fill-opacity:1;stroke-width:1.0429498"
-           d="m 344.0153,184.8556 c -4.20895,0.004 -8.03305,0.12415 -11.25489,0.37044 -16.50178,1.26045 -38.17139,4.92977 -54.76312,9.2736 -10.34044,2.70622 -10.65787,2.75884 -18.65515,3.04603 -9.80505,0.35223 -13.67631,-0.1338 -25.78657,-3.23019 -12.08426,-3.08988 -21.51329,-4.92278 -36.21381,-7.03617 -14.73846,-2.11989 -21.93779,-2.57843 -36.09316,-2.29881 -15.2771,0.30237 -28.63893,1.52021 -45.25668,4.12347 -6.61111,1.03502 -18.783218,3.2399 -20.092436,3.63874 -0.725055,0.22109 -0.746037,0.66677 -0.480509,10.91833 l 0.277298,8.52003 1.081666,0.92291 c 0.595,0.50938 1.736068,1.26764 2.535904,1.68707 3.372757,1.76983 4.750497,7.40345 7.575937,21.22069 3.11806,15.24349 4.9208,21.28817 8.60893,28.88553 4.91499,10.12693 12.38768,18.12678 22.12878,23.69096 5.14367,2.93815 12.08989,4.84077 21.16988,5.80209 4.09131,0.43351 18.19036,0.18404 22.71302,-0.39796 9.09733,-1.17808 18.14991,-3.57324 24.39795,-6.45828 13.54737,-6.25672 23.66047,-19.38475 30.33553,-39.37416 2.03536,-6.0974 5.53221,-20.02767 6.435,-25.63628 1.68313,-10.45749 3.34139,-11.93015 13.45423,-11.93015 10.0218,0 11.74958,1.48754 13.44788,11.58088 0.9559,5.6758 4.30703,19.17482 6.22967,25.09015 5.57502,17.15205 13.81673,29.65383 24.13549,36.61177 7.20069,4.85538 15.83371,7.80809 28.604,9.7795 7.57027,1.16941 22.58844,1.2739 29.39355,0.20745 10.76203,-1.68746 17.07464,-4.4983 25.30819,-11.26548 6.84955,-5.63246 12.8199,-14.45938 16.44735,-24.31753 1.96274,-5.3355 3.11316,-9.74892 5.30675,-20.35705 2.08196,-10.0684 3.55209,-17.9235 4.58494,-19.92309 0.63077,-1.21818 1.68677,-2.12586 4.81567,-4.13195 l 2.00459,-1.287 0.24978,-4.61246 c 0.13547,-2.53823 0.2692,-5.27751 0.29846,-8.73805 0.0466,-5.67255 -0.0169,-6.31312 -0.64985,-6.50061 -2.82652,-0.83669 -20.46339,-3.82704 -29.7894,-5.05064 -13.77767,-1.80776 -29.87802,-2.83744 -42.50487,-2.82378 z m -166.48234,6.86048 c 15.93429,-0.0449 31.85107,2.97349 44.08822,8.85871 4.98491,2.39777 8.61804,4.97853 10.88235,8.6555 2.2643,3.67695 2.96782,8.08954 2.96348,13.74634 -0.009,10.58683 -3.15069,21.79551 -9.44505,34.34682 -3.71597,7.40817 -7.26178,12.66676 -11.42425,16.73523 -8.53425,8.34152 -19.79963,12.71519 -35.03052,13.91568 -16.37668,1.28971 -30.73991,-0.95881 -41.02314,-6.82872 -6.88721,-3.93261 -13.52812,-11.56164 -16.93421,-19.24361 h 0.002 c -3.71861,-8.38335 -5.1415,-17.00934 -5.148,-30.29954 -0.003,-4.43923 0.01,-6.92117 0.14605,-8.78462 0.13626,-1.86262 0.45425,-3.166 0.90175,-4.55741 1.82508,-5.67583 7.02787,-11.35488 13.52832,-15.66838 5.33188,-3.53887 15.51862,-6.96631 25.10284,-8.8439 6.90148,-1.3517 14.14746,-2.01162 21.39003,-2.0321 z m 156.55255,0.64138 c 15.20007,-0.0357 30.37154,2.6982 42.44348,8.4036 6.80473,3.21546 13.57292,9.1753 16.48122,15.01641 1.7448,3.50651 2.17547,7.55918 2.18663,16.29918 a 2.9070246,2.841376 0 0 0 0,0.002 c 0.0216,18.87798 -4.12628,32.30326 -13.49233,41.93968 -6.23627,6.416 -14.07525,10.32844 -24.40855,12.34504 -3.82998,0.74803 -6.67512,0.9425 -14.83649,1.03722 -10.96317,0.12686 -11.88751,0.0597 -18.0815,-1.06897 -9.94808,-1.81382 -18.00312,-5.31565 -24.60964,-11.27819 -6.60652,-5.96253 -11.70197,-14.23828 -16.30553,-25.42672 -3.77388,-9.17809 -5.82859,-18.18073 -5.8804,-26.23532 -0.0353,-5.63599 0.68332,-10.08139 2.96348,-13.7781 2.28019,-3.69669 5.94022,-6.30086 10.92892,-8.65761 12.18124,-5.75483 27.41052,-8.56269 42.61071,-8.59834 z"
-           id="path3011"
-           inkscape:connector-curvature="0" />
-        <path
-           style="opacity:0.5;fill:url(#linearGradient2650);fill-opacity:1;stroke-width:1.03110635"
-           d="m 177.53201,191.71607 c -7.24258,0.0205 -14.48683,0.6804 -21.38829,2.0321 -9.58424,1.87759 -19.77273,5.30504 -25.1046,8.8439 -6.50045,4.31352 -11.70178,9.99255 -13.52686,15.66838 -0.44749,1.39141 -0.76683,2.6948 -0.90308,4.55741 -0.13633,1.86346 -0.14789,4.34539 -0.1451,8.78462 0.007,13.2902 1.4292,21.91619 5.14781,30.29954 h -0.002 c 3.40609,7.68197 10.04625,15.31101 16.93346,19.24361 10.28322,5.86991 24.64788,8.11843 41.02455,6.82872 15.2309,-1.2005 26.49568,-5.57416 35.02993,-13.91568 4.16247,-4.06847 7.70801,-9.32705 11.42398,-16.73523 6.29436,-12.55131 9.43636,-23.75999 9.44454,-34.34682 0.004,-5.65679 -0.69835,-10.06938 -2.96265,-13.74634 -2.2643,-3.67697 -5.89765,-6.25772 -10.88256,-8.6555 -12.23716,-5.88521 -28.15469,-8.90362 -44.08898,-8.85871 z"
-           id="path4259"
-           inkscape:connector-curvature="0" />
-        <path
-           style="opacity:0.5;fill:url(#linearGradient2652);fill-opacity:1;stroke-width:1.03110635"
-           d="m 334.08548,192.35746 c -15.20019,0.0357 -30.4286,2.84351 -42.60983,8.59834 -4.9887,2.35675 -8.65002,4.96091 -10.93021,8.65761 -2.28016,3.69671 -2.99801,8.14211 -2.96265,13.7781 0.0518,8.05459 2.10595,17.05723 5.87983,26.23532 4.60356,11.18844 9.69891,19.46419 16.30543,25.42672 6.60652,5.96254 14.66274,9.46437 24.61082,11.27819 6.19399,1.12869 7.11813,1.19583 18.0813,1.06897 8.16137,-0.0947 11.00495,-0.2892 14.83493,-1.03722 10.33329,-2.0166 18.17316,-5.92904 24.40942,-12.34504 9.36606,-9.63642 13.51373,-23.0617 13.4922,-41.93969 a 2.9070246,2.841376 0 0 0 0,-0.002 c -0.0112,-8.74 -0.44252,-12.79268 -2.18732,-16.29918 -2.9083,-5.84112 -9.67613,-11.80095 -16.48086,-15.01641 -12.07194,-5.70541 -27.24299,-8.43929 -42.44306,-8.4036 z"
-           id="path4291"
-           inkscape:connector-curvature="0" />
-        <path
-           style="opacity:0.5;fill:#ffffff;stroke-width:1.03110635"
-           d="m 206.95237,275.67414 c -6.41044,3.41127 -14.17254,5.36014 -23.87717,6.02156 -16.03837,1.09202 -29.89753,-1.34792 -39.41908,-6.85147 l -0.002,0.002 c -6.09907,-3.52638 -12.59349,-10.90254 -15.7604,-17.90118 a 3.7245728,3.6455441 45 0 0 -0.003,-0.0129 c -3.60542,-7.97407 -5.05339,-16.01772 -5.20107,-29.18983 -0.0508,-4.47959 -0.0582,-6.94433 0.0456,-8.60559 0.0994,-1.59023 0.31481,-2.49282 0.70417,-3.74087 0.14912,-0.47811 0.34312,-0.96799 0.56426,-1.46335 -1.41765,1.86285 -2.46858,3.72031 -3.02255,5.44313 -0.39847,1.23895 -0.622,2.13345 -0.73718,3.70787 -0.12033,1.64473 -0.13796,4.08447 -0.13518,8.51599 0.006,13.03081 1.35228,20.97239 4.83485,28.82361 a 3.645544,3.645544 0 0 1 0.005,0.0142 c 3.05906,6.89079 9.40508,14.11854 15.40203,17.54281 l 0.002,-0.002 c 9.36214,5.34414 23.04888,7.61165 38.92868,6.36107 11.69965,-0.92217 20.57672,-3.69846 27.67149,-8.66532 z"
-           id="path4237"
-           inkscape:connector-curvature="0" />
-        <path
-           style="opacity:0.5;fill:#ffffff;stroke-width:1.03110635"
-           d="m 374.53886,274.24538 c -4.01013,2.27662 -8.67937,3.88151 -14.34264,4.94016 -3.581,0.66995 -5.94679,0.81581 -14.1163,0.84091 -11.03447,0.0335 -11.15179,0.0304 -17.36049,-1.15212 -9.44444,-1.80008 -16.6439,-5.03337 -22.62915,-10.4446 -6.00368,-5.42787 -10.88249,-13.13968 -15.46649,-24.09249 l 0.002,-0.002 c -3.70073,-8.84811 -5.68355,-17.41535 -5.79364,-24.7715 -0.0624,-4.21199 0.34623,-7.25767 1.34074,-9.67755 -0.66688,0.68136 -1.23909,1.38942 -1.70539,2.1455 -1.64067,2.65993 -2.30877,6.10048 -2.27597,11.32951 0.0469,7.29296 1.93976,15.77024 5.5343,24.51216 h -0.003 c 4.45251,10.82134 9.22632,18.42814 15.13326,23.75927 5.8888,5.31478 13.00008,8.45989 22.34937,10.16481 6.14615,1.11998 6.26194,1.12156 17.20331,0.99495 8.10059,-0.094 10.44834,-0.25792 14.0047,-0.95251 7.53712,-1.47091 13.31565,-3.89576 18.12596,-7.59492 z"
-           id="path4246"
-           inkscape:connector-curvature="0" />
-      </g>
-      <g
-         style="display:inline;enable-background:new"
-         id="g6950"
-         transform="translate(88,-8)">
-        <rect
-           x="72"
-           y="116"
-           width="72"
-           height="64"
-           rx="0"
-           ry="0"
-           id="rect6351-3"
-           style="fill:#f66151;stroke-width:2.12132049" />
-        <path
-           d="m 75.842365,168.727 a 94.310016,94.310016 0 0 0 32.218345,-16.17436 c 3.23982,-2.50463 6.38071,-5.29928 8.35698,-8.88534 0.98926,-1.79415 1.666,-3.77267 1.85261,-5.81189 0.18436,-2.03922 -0.1394,-4.13915 -1.05221,-5.97152 a 10.764926,10.764926 0 0 0 -3.42868,-3.94579 12.939045,12.939045 0 0 0 -4.82039,-2.06395 c -3.44666,-0.71947 -7.06869,-0.1439 -10.36248,1.10167 -3.96153,1.50412 -7.58581,4.01324 -10.13315,7.3992 -2.54959,3.38821 -3.97052,7.67125 -3.64227,11.89808 0.21584,2.73844 1.15339,5.40719 2.59905,7.74319 1.44567,2.33824 3.39271,4.35049 5.61179,5.97152 4.44043,3.24207 9.88135,4.88109 15.33351,5.58031 12.41069,1.58731 25.37222,-1.60754 35.62453,-8.77966 l -0.054,-11.66425 c -8.03547,8.8651 -19.46365,14.57582 -31.37746,15.68199 -5.1419,0.47664 -10.49963,0.0877 -15.14465,-2.17188 -2.32251,-1.12865 -4.43593,-2.72046 -6.05246,-4.73494 -1.61879,-2.01224 -2.72946,-4.45167 -3.04647,-7.01474 -0.46315,-3.73895 0.8049,-7.5993 3.14314,-10.55359 2.33825,-2.95428 5.68149,-5.03397 9.2788,-6.16038 1.98526,-0.61828 4.08744,-0.96452 6.15139,-0.69922 2.0617,0.2653 4.08518,1.18486 5.42968,2.77217 1.08818,1.28603 1.68623,2.95203 1.78965,4.63377 0.10567,1.68174 -0.26305,3.37472 -0.93305,4.92156 -1.33774,3.09143 -3.80639,5.53985 -6.32226,7.77917 A 105.27279,105.27279 0 0 1 75.844613,168.727 Z"
-           overflow="visible"
-           id="path6353-6"
-           inkscape:connector-curvature="0"
-           style="overflow:visible;fill:#ffffff;stroke-width:2.24831367" />
-      </g>
+         transform="matrix(0.01530612,0,0,0.01530612,329.66837,242.08674)" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/file-roller.svg
+++ b/icons/src/fullcolor/default/apps/file-roller.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="file-roller.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="-196.5"
-     inkscape:cy="58.5"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="373.70593"
+     inkscape:cy="180.66578"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,8 +61,6 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:bbox-nodes="true"
-     inkscape:snap-bbox-edge-midpoints="true"
      inkscape:document-rotation="0"
      inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
@@ -94,201 +92,197 @@
   </sodipodi:namedview>
   <defs
      id="defs3">
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter946"
-       x="-0.2775"
-       width="1.555"
-       y="-0.032647057"
-       height="1.0652941">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.85"
-         id="feGaussianBlur948" />
-    </filter>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient878"
+       id="linearGradient880"
+       x1="137.58333"
+       y1="154.12498"
+       x2="137.58333"
+       y2="169.99998"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93723849,0,0,0.93723849,25.03542,4.6047425)" />
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient927">
+       id="linearGradient878">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         style="stop-color:#060000;stop-opacity:1;"
          offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983-0">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985-2"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971-3">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-5">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-1-2">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-8-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient876"
-       id="linearGradient3257"
-       x1="330.0751"
-       y1="133.5"
-       x2="341.92554"
-       y2="162.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient876"
-       id="linearGradient920"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.0386186,0.03904659,0,315.4715,253.54546)"
-       x1="441.37933"
-       y1="240.28154"
-       x2="52.9655"
-       y2="401.42957" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient876"
-       id="linearGradient916"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05921519,0.05978336,0,313.2699,214.63635)"
-       x1="441.37936"
-       y1="240.30258"
-       x2="52.965523"
-       y2="386.30795" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="169.65668"
-       x2="4.4137931"
-       y1="386.29544"
-       x1="494.34482"
-       id="linearGradient4226"
-       xlink:href="#linearGradient876"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.957,268)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient876"
-       id="linearGradient3194"
-       x1="335.23154"
-       y1="61.500046"
-       x2="352.27026"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4380"
-       x="-0.057817147"
-       width="1.1156343"
-       y="-0.045429151"
-       height="1.0908583">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="8.4801079"
-         id="feGaussianBlur4382" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4346"
-       x="-0.014454287"
-       width="1.0289086"
-       y="-0.011357288"
-       height="1.0227146">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.120027"
-         id="feGaussianBlur4348" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient2908"
-       gradientUnits="userSpaceOnUse"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient876">
-      <stop
-         style="stop-color:#aea795;stop-opacity:1"
-         offset="0"
-         id="stop872" />
-      <stop
-         style="stop-color:#c8c4b7;stop-opacity:1"
-         offset="1"
          id="stop874" />
+      <stop
+         style="stop-color:#060000;stop-opacity:0.89400923"
+         offset="1"
+         id="stop876" />
     </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient870"
+       id="radialGradient872"
+       cx="135.46667"
+       cy="161.53331"
+       fx="135.46667"
+       fy="161.53331"
+       r="119.0625"
+       gradientTransform="matrix(0.93723849,0,0,0.24993031,25.03542,115.62791)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient870">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop866" />
+      <stop
+         style="stop-color:#e9dfb9;stop-opacity:1"
+         offset="1"
+         id="stop868" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient892"
+       id="linearGradient894"
+       x1="137.58331"
+       y1="-62.833351"
+       x2="137.58331"
+       y2="344.62497"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93723849,0,0,0.93723849,25.03544,4.6047425)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient892">
+      <stop
+         style="stop-color:#f5e1a3;stop-opacity:1"
+         offset="0"
+         id="stop888" />
+      <stop
+         style="stop-color:#955e15;stop-opacity:1"
+         offset="1"
+         id="stop890" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient892"
+       id="linearGradient456"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.19246862,0,0,0.19246862,317.92693,52.909909)"
+       x1="137.58331"
+       y1="-62.833351"
+       x2="137.58331"
+       y2="344.62497" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient870"
+       id="radialGradient458"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.19246862,0,0,0.05132497,317.92692,75.709309)"
+       cx="135.46667"
+       cy="161.53331"
+       fx="135.46667"
+       fy="161.53331"
+       r="119.0625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient878"
+       id="linearGradient460"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.19246862,0,0,0.19246862,317.92692,52.909909)"
+       x1="137.58333"
+       y1="154.12498"
+       x2="137.58333"
+       y2="169.99998" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient892"
+       id="linearGradient472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12552301,0,0,0.12552301,318.99582,127.72386)"
+       x1="137.58331"
+       y1="-62.833351"
+       x2="137.58331"
+       y2="344.62497" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient870"
+       id="radialGradient474"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12552301,0,0,0.03347281,318.99582,142.59303)"
+       cx="135.46667"
+       cy="161.53331"
+       fx="135.46667"
+       fy="161.53331"
+       r="119.0625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient878"
+       id="linearGradient476"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12552301,0,0,0.12552301,318.99582,127.72386)"
+       x1="137.58333"
+       y1="154.12498"
+       x2="137.58333"
+       y2="169.99998" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient892"
+       id="linearGradient488"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09623431,0,0,0.09623431,318.96346,184.45495)"
+       x1="137.58331"
+       y1="-62.833351"
+       x2="137.58331"
+       y2="344.62497" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient870"
+       id="radialGradient490"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09623431,0,0,0.02566249,318.96346,195.85465)"
+       cx="135.46667"
+       cy="161.53331"
+       fx="135.46667"
+       fy="161.53331"
+       r="119.0625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient878"
+       id="linearGradient492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09623431,0,0,0.09623431,318.96346,184.45495)"
+       x1="137.58333"
+       y1="154.12498"
+       x2="137.58333"
+       y2="169.99998" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient892"
+       id="linearGradient504"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06276151,0,0,0.06276151,319.49791,233.86192)"
+       x1="137.58331"
+       y1="-62.833351"
+       x2="137.58331"
+       y2="344.62497" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient870"
+       id="radialGradient506"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06276151,0,0,0.01673641,319.49791,241.29651)"
+       cx="135.46667"
+       cy="161.53331"
+       fx="135.46667"
+       fy="161.53331"
+       r="119.0625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient878"
+       id="linearGradient508"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06276151,0,0,0.06276151,319.49791,233.86192)"
+       x1="137.58333"
+       y1="154.12498"
+       x2="137.58333"
+       y2="169.99998" />
   </defs>
   <metadata
      id="metadata4">
@@ -388,7 +382,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">file-roller</tspan></text>
+           id="tspan924">file-roller</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -423,321 +417,184 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
-      <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path4350"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 464,514.75001 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4380);enable-background:accumulate"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.02028775;marker:none;enable-background:accumulate"
-         d="M 101.8116,42 C 65.71279,42 61.8286,45.690158 62.00552,81.689842 V 156 230.31016 C 61.8286,266.30985 65.71279,270 101.8116,270 h 100.38732 c 36.09881,0 39.80608,-3.68973 39.80608,-39.68984 V 156 81.689842 C 242.005,45.689729 238.29773,42 202.19892,42 Z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 201.07298,44 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 156 229.00647 C 240.16759,264.37459 236.36971,268 201.07298,268 H 102.91622 C 67.6195,268 63.9946,264.375 63.9946,229.00647 V 156 82.99353 C 63.9946,47.624997 67.6195,44 102.91622,44 Z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188,44 C 67.62515,44 63.82701,47.626029 64,82.994141 v 2 C 63.82701,49.626029 67.62515,46 102.92188,46 h 98.15624 C 236.37485,46 240,49.625608 240,84.994141 v -2 C 240,47.625608 236.37485,44 201.07812,44 Z"
-         id="path931"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 152,44 v 224 h 49.07227 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 156 82.994141 C 240.16713,47.626029 236.369,44 201.07227,44 Z"
-         id="rect4158-3"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86523,189 c -1.12014,0 -2.01524,0.0241 -2.79101,0.1543 -0.77577,0.13022 -1.48014,0.38763 -2.00977,0.91601 -0.52962,0.52838 -0.79079,1.23687 -0.91992,2.01367 -0.12912,0.77681 -0.15002,1.67169 -0.14453,2.79493 V 201 v 6.125 c -0.005,1.12104 0.0156,2.01529 0.14453,2.79102 0.12912,0.77681 0.39029,1.48529 0.91992,2.01367 0.52964,0.52838 1.234,0.78579 2.00977,0.91601 0.77577,0.13022 1.67087,0.1543 2.79101,0.1543 h 8.26954 c 1.12013,0 2.01264,-0.024 2.78711,-0.1543 0.77446,-0.13033 1.48001,-0.38927 2.00781,-0.91797 0.5278,-0.52869 0.78594,-1.23438 0.91601,-2.00976 C 341.97577,209.14258 342,208.24735 342,207.125 V 201 194.875 c 0,-1.12235 -0.0242,-2.01758 -0.1543,-2.79297 -0.13007,-0.77538 -0.38821,-1.48107 -0.91601,-2.00976 -0.5278,-0.5287 -1.23334,-0.78764 -2.00781,-0.91797 C 338.1474,189.02397 337.25491,189 336.13477,189 Z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 330.19336,134 c -1.42096,0 -2.54883,0.0308 -3.50586,0.19141 -0.95703,0.16064 -1.79146,0.4726 -2.41211,1.09179 -0.62065,0.61919 -0.93647,1.45612 -1.0957,2.41407 -0.15924,0.95795 -0.18666,2.08705 -0.17969,3.51171 V 149 v 7.79688 c -0.007,1.42131 0.0207,2.5495 0.17969,3.50585 0.15923,0.95796 0.47505,1.79488 1.0957,2.41407 0.62065,0.61919 1.45508,0.93115 2.41211,1.09179 0.95703,0.16065 2.0849,0.19141 3.50586,0.19141 h 11.61523 c 1.42097,0 2.54669,-0.0307 3.50196,-0.19141 0.95527,-0.16075 1.78779,-0.47425 2.40625,-1.09375 0.61845,-0.6195 0.93134,-1.45363 1.09179,-2.41015 C 348.96905,159.34816 349,158.22066 349,156.79688 V 149 141.20312 c 0,-1.42378 -0.031,-2.55128 -0.19141,-3.50781 -0.16045,-0.95653 -0.47334,-1.79065 -1.09179,-2.41015 -0.61846,-0.61951 -1.45098,-0.933 -2.40625,-1.09375 C 344.35528,134.03065 343.22956,134 341.80859,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.23093,61.500047 c -2.22316,0 -3.97368,0.05118 -5.41406,0.292969 -1.44039,0.241784 -2.61905,0.695299 -3.48243,1.55664 -0.86337,0.861342 -1.31906,2.039471 -1.55859,3.480469 -0.23953,1.440999 -0.28629,3.195341 -0.27539,5.423828 V 85 97.752143 c -0.0108,2.225063 0.0361,3.978517 0.27539,5.417967 0.23953,1.441 0.69522,2.61913 1.55859,3.48047 0.86338,0.86134 2.04204,1.31486 3.48243,1.55664 1.44039,0.24179 3.1909,0.29297 5.41406,0.29297 h 17.53883 c 2.22317,0 3.97276,-0.0511 5.41017,-0.29297 1.4374,-0.24189 2.61246,-0.69694 3.47265,-1.55859 0.8602,-0.86165 1.31319,-2.03894 1.55468,-3.47852 0.24149,-1.43957 0.29297,-3.190353 0.29297,-5.417967 V 85 72.248094 c 0,-2.227614 -0.0515,-3.978392 -0.29297,-5.417969 -0.24149,-1.439576 -0.69449,-2.616863 -1.55469,-3.478516 -0.86019,-0.861652 -2.03525,-1.316704 -3.47265,-1.558593 -1.4374,-0.24189 -3.187,-0.292969 -5.41016,-0.292969 z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 327.636,188.49999 c -4.65703,0 -5.15812,0.47378 -5.1353,5.09575 v 6.40425 6.40426 c -0.0229,4.62196 0.47827,5.09574 5.1353,5.09574 h 8.72869 c 4.65703,0 5.1353,-0.47372 5.1353,-5.09574 v -6.40426 -6.40425 c 0,-4.62202 -0.47828,-5.09575 -5.13531,-5.09575 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.8545,236.50001 c -3.04166,0 -3.36894,0.30899 -3.35403,3.32331 v 4.17669 4.17668 c -0.0149,3.01433 0.31237,3.32332 3.35403,3.32332 h 6.29146 c 3.04167,0 3.35404,-0.30895 3.35404,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.31238,-3.32331 -3.35404,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3257);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="opacity:0.1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-         d="m 344,61.5 v 45 h 8.77148 c 8.22949,0 9.72852,-0.90592 9.72852,-9.748047 V 84 71.248047 C 362.5,62.405917 360.99903,61.5 352.76953,61.5 Z"
-         id="rect2978"
-         inkscape:connector-curvature="0" />
-      <path
-         style="opacity:0.1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-         d="m 336,134 v 28 h 5.51367 C 347.39624,162 348,161.42369 348,155.79688 V 148 140.20312 C 348,134.57631 347.39624,134 341.51367,134 Z"
-         id="rect3005"
-         inkscape:connector-curvature="0" />
-      <path
-         style="opacity:0.1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-         d="m 332,188.5 v 23 h 4.36523 c 4.65703,0 5.13477,-0.47368 5.13477,-5.0957 V 200 193.5957 c 0,-4.62202 -0.47774,-5.0957 -5.13477,-5.0957 z"
-         id="rect3042"
-         inkscape:connector-curvature="0" />
-      <path
-         style="opacity:0.1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-         d="m 328,236.5 v 15 h 3.14648 c 3.04166,0 3.35352,-0.30985 3.35352,-3.32422 V 244 239.82422 c 0,-3.01436 -0.31187,-3.32422 -3.35352,-3.32422 z"
-         id="rect3082"
-         inkscape:connector-curvature="0" />
+      <rect
+         rx="10.684518"
+         y="52.717285"
+         x="40.410049"
+         height="206.5654"
+         width="223.1799"
+         id="rect1383"
+         style="display:inline;fill:url(#linearGradient894);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:19.5244;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.90967;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke;enable-background:new"
+         id="rect932"
+         width="222.09033"
+         height="205.55659"
+         x="40.954819"
+         y="53.22168"
+         rx="10.632354" />
+      <rect
+         rx="2.1941421"
+         y="62.790161"
+         x="321.0842"
+         height="42.419678"
+         width="45.831585"
+         id="rect446"
+         style="display:inline;fill:url(#linearGradient456);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.00948;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.392164;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke;enable-background:new"
+         id="rect452"
+         width="45.607834"
+         height="42.212513"
+         x="321.19608"
+         y="62.893745"
+         rx="2.1834297" />
+      <rect
+         rx="1.4309622"
+         y="134.1675"
+         x="321.05493"
+         height="27.665009"
+         width="29.890165"
+         id="rect462"
+         style="display:inline;fill:url(#linearGradient472);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.61488;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.255759;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke;enable-background:new"
+         id="rect468"
+         width="29.74424"
+         height="27.529902"
+         x="321.12787"
+         y="134.23505"
+         rx="1.4239759" />
+      <rect
+         rx="1.0970711"
+         y="189.39508"
+         x="320.54211"
+         height="21.209839"
+         width="22.915792"
+         id="rect478"
+         style="display:inline;fill:url(#linearGradient488);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.00474;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.196082;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke;enable-background:new"
+         id="rect484"
+         width="22.803917"
+         height="21.106256"
+         x="320.59805"
+         y="189.44687"
+         rx="1.0917149" />
+      <rect
+         rx="0.71548116"
+         y="237.08374"
+         x="320.52747"
+         height="13.832505"
+         width="14.945084"
+         id="rect494"
+         style="display:inline;fill:url(#linearGradient504);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.30744;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.12788;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke;enable-background:new"
+         id="rect500"
+         width="14.872122"
+         height="13.764952"
+         x="320.56393"
+         y="237.11752"
+         rx="0.71198803" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
-      <path
-         inkscape:connector-curvature="0"
-         id="rect4185"
-         d="m 152,43.999993 v 8 h 8 v -8 z m 0,8 h -8 v 8 h 8 z m 0,8 v 8 h 8 v -8 z m 0,8 h -8 v 8 h 8 z m 0,8 v 8 h 8 v -8 z m 0,8 h -8 v 8 h 8 z m 0,8 v 7.999998 h 8 v -7.999998 z m 0,7.999998 h -8 v 7.999999 h 8 z m 0,7.999999 v 8 h 8 v -8 z m 0,8 h -8 v 8 h 8 z m 0,8 v 8 h 8 v -8 z m 0,8 h -8 v 8 h 8 z m 0,8 V 148 h 8 v -8.00001 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter946);enable-background:accumulate"
-         d="m 144,45.999991 v 8 h 8 v -8 z m 8,8 v 8 h 8 v -8 z m 0,8 h -8 v 8 h 8 z m 0,8 v 8 h 8 v -8 z m 0,8 h -8 v 8 h 8 z m 0,8 v 8 h 8 v -8 z m 0,8 h -8 v 7.999999 h 8 z m 0,7.999999 v 8 h 8 v -8 z m 0,8 h -8 v 8 h 8 z m 0,8 v 8 h 8 v -8 z m 0,8 h -8 v 8 h 8 z m 0,8 V 142 h 8 v -8.00001 z M 152,142 h -8 v 8 30 c 0,1.108 0.892,2 2,2 h 12 c 1.108,0 2,-0.892 2,-2 v -30 h -8 z m -4,28 h 8 v 8 h -8 z"
-         id="path941"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccsssscccccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#faf8f6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 144,148 v 30 c 0,1.108 0.892,2 2,2 h 12 c 1.108,0 2,-0.892 2,-2 v -30 z m 4,20 h 8 v 8 h -8 z"
-         id="path4783"
-         sodipodi:nodetypes="cssssccccccc" />
-      <path
-         sodipodi:nodetypes="cssssccccccc"
-         id="path968-3"
-         d="M 342,83.000001 V 89.5 c 0,0.277 0.223,0.5 0.5,0.5 h 3 c 0.277,0 0.5,-0.223 0.5,-0.5 V 83.000001 Z M 343,87 h 2 v 2 h -2 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="cssssccccccc"
-         id="path968"
-         d="M 342,82.000001 V 88.5 c 0,0.277 0.223,0.5 0.5,0.5 h 3 c 0.277,0 0.5,-0.223 0.5,-0.5 V 82.000001 Z M 343,86 h 2 v 2 h -2 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#faf8f6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccc"
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f1f0e9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 343.99999,62.000004 h 2 v 2 h -2 z m 0,2 v 2 h -2 v -2 z m 0,2 h 2 v 1.999999 h -2 z m 0,1.999999 v 2 h -2 v -2 z m 0,2 h 2 v 2 h -2 z m 0,2 v 1.999999 h -2 v -1.999999 z m 0,1.999999 h 2 v 2 h -2 z m 0,2 v 2 h -2 v -2 z m 0,2 h 2 v 1.999999 h -2 z m 0,1.999999 v 2 h -2 v -2 z"
-         id="path970-3" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 334,147 v 6.5 c 0,0.277 0.223,0.5 0.5,0.5 h 3 c 0.277,0 0.5,-0.223 0.5,-0.5 V 147 Z m 1,4 h 2 v 2 h -2 z"
-         id="path998-6"
-         sodipodi:nodetypes="cssssccccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#faf8f6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 334,146 v 6.5 c 0,0.277 0.223,0.5 0.5,0.5 h 3 c 0.277,0 0.5,-0.223 0.5,-0.5 V 146 Z m 1,4 h 2 v 2 h -2 z"
-         id="path998"
-         sodipodi:nodetypes="cssssccccccc" />
-      <path
-         id="path1000"
-         d="m 335.99999,134 h 2 v 2 h -2 z m 0,2 v 2 h -2 v -2 z m 0,2 h 2 v 2 h -2 z m 0,2 v 2 h -2 v -2 z m 0,2 h 2 v 2 h -2 z m 0,2 v 2 h -2 v -2 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f1f0e9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccccccccccccccccccc" />
-      <path
-         sodipodi:nodetypes="cssssccccccc"
-         id="path1004-5"
-         d="m 327,243.5 v 2.75 c 10e-6,0.1385 0.1115,0.25 0.25,0.25 h 1.5 c 0.1385,0 0.25,-0.1115 0.25,-0.25 v -2.75 z m 0.5,1.5 h 1 v 1 h -1 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15.00000095;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="cssssccccccc"
-         id="path1004"
-         d="m 327,243 v 2.75 c 10e-6,0.1385 0.1115,0.25 0.25,0.25 h 1.5 c 0.1385,0 0.25,-0.1115 0.25,-0.25 V 243 Z m 0.5,1.5 h 1 v 1 h -1 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#faf8f6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15.00000095;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="cccccccccccccccccccccccccccccc"
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f1f0e9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15.00000095;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 328.00001,237 h 1 v 1 h -1 z m 0,1 v 1 h -1 v -1 z m 0,1 h 1 v 1 h -1 z m 0,1 v 1 h -1 v -1 z m 0,1 h 1 v 1 h -1 z m 0,1 v 1 h -1 v -1 z"
-         id="path1008" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15.00000095;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331,199.5 v 2.75 c 10e-6,0.1385 0.1115,0.25 0.25,0.25 h 1.5 c 0.1385,0 0.25,-0.1115 0.25,-0.25 v -2.75 z m 0.5,1.5 h 1 v 1 h -1 z"
-         id="path1033-7"
-         sodipodi:nodetypes="cssssccccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#faf8f6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15.00000095;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331,199 v 2.75 c 10e-6,0.1385 0.1115,0.25 0.25,0.25 h 1.5 c 0.1385,0 0.25,-0.1115 0.25,-0.25 V 199 Z m 0.5,1.5 h 1 v 1 h -1 z"
-         id="path1033"
-         sodipodi:nodetypes="cssssccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f1f0e9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15.00000095;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 332,189 h 1 v 1 h -1 z m 0,1 v 1 h -1 v -1 z m 0,1 h 1 v 1 h -1 z m 0,1 v 1 h -1 v -1 z m 0,1 h 1 v 1 h -1 z m 0,1 v 1 h -1 v -1 z m 0,1 h 1 v 1 h -1 z m 0,1 v 1 h -1 v -1 z m 0,1 h 1 v 1 h -1 z m 0,1 v 1 h -1 v -1 z"
-         id="path1035-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f1f0e9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 152,43.999993 v 8 h -8 v -8 z m 0,8 h 8 v 8 h -8 z m 0,8 v 8 h -8 v -8 z m 0,8 h 8 v 8 h -8 z m 0,8 v 8 h -8 v -8 z m 0,8 h 8 v 8 h -8 z m 0,8 v 7.999998 h -8 v -7.999998 z m 0,7.999998 h 8 v 7.999999 h -8 z m 0,7.999999 v 8 h -8 v -8 z m 0,8 h 8 v 8 h -8 z m 0,8 v 8 h -8 v -8 z m 0,8 h 8 v 8 h -8 z m 0,8 V 148 h -8 v -8.00001 z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
-      <path
-         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccc"
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 343.99999,62.000004 h -2 v 2 h 2 z m 0,2 v 2 h 2 v -2 z m 0,2 h -2 v 1.999999 h 2 z m 0,1.999999 v 2 h 2 v -2 z m 0,2 h -2 v 2 h 2 z m 0,2 v 1.999999 h 2 v -1.999999 z m 0,1.999999 h -2 v 2 h 2 z m 0,2 v 2 h 2 v -2 z m 0,2 h -2 v 1.999999 h 2 z m 0,1.999999 v 2 h 2 v -2 z"
-         id="path970-3-3" />
-      <path
-         id="path1000-6"
-         d="m 335.99999,134 h -2 v 2 h 2 z m 0,2 v 2 h 2 v -2 z m 0,2 h -2 v 2 h 2 z m 0,2 v 2 h 2 v -2 z m 0,2 h -2 v 2 h 2 z m 0,2 v 2 h 2 v -2 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccccccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15.00000095;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 332,189 h -1 v 1 h 1 z m 0,1 v 1 h 1 v -1 z m 0,1 h -1 v 1 h 1 z m 0,1 v 1 h 1 v -1 z m 0,1 h -1 v 1 h 1 z m 0,1 v 1 h 1 v -1 z m 0,1 h -1 v 1 h 1 z m 0,1 v 1 h 1 v -1 z m 0,1 h -1 v 1 h 1 z m 0,1 v 1 h 1 v -1 z"
-         id="path1035-6-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccc" />
-      <path
-         sodipodi:nodetypes="cccccccccccccccccccccccccccccc"
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15.00000095;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 328.00001,237 h -1 v 1 h 1 z m 0,1 v 1 h 1 v -1 z m 0,1 h -1 v 1 h 1 z m 0,1 v 1 h 1 v -1 z m 0,1 h -1 v 1 h 1 z m 0,1 v 1 h 1 v -1 z"
-         id="path1008-7" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         transform="matrix(0.66664182,0,0,0.63636364,106.67522,94.545454)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2908);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-1-2)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-5)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971-3)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:1.85638201;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983-0)"
-         transform="matrix(1.0833332,0,0,1.0714286,-27.33329,-17.42857)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 336.50849,211.51179 c 4.23214,0 5.02499,-0.46371 5.00275,-4.98757 v -6.5241 -6.52423 c 0.0222,-4.52386 -0.77061,-4.98757 -5.00275,-4.98757 h -9.01743 c -4.23108,0 -5.00275,0.46366 -5.00275,4.98757 v 6.52423 6.5241 c 0,4.52391 0.77167,4.98757 5.00275,4.98757 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.08651,251.51179 c 2.89732,0 3.44011,-0.30259 3.42488,-3.25454 v -4.25716 -4.25724 c 0.0152,-2.95195 -0.52756,-3.25453 -3.42488,-3.25453 h -6.17331 c -2.8966,0 -3.42488,0.30255 -3.42488,3.25453 v 4.25724 4.25716 c 0,2.95199 0.52828,3.25454 3.42488,3.25454 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92728,268 c -35.296735,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 C 63.832405,262.37397 67.630545,266 102.92728,266 h 98.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 C 240.0054,264.37439 236.38025,268 201.08352,268 Z"
-         id="path931-8"
-         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;enable-background:new;fill:url(#radialGradient872);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:10.5683;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="rect860"
+         width="223.1799"
+         x="40.410049"
+         y="126.24268"
+         height="59.514648"
+         ry="0" />
+      <rect
+         ry="0"
+         height="4.9595551"
+         y="153.5202"
+         x="40.410049"
+         width="223.1799"
+         id="rect862"
+         style="display:inline;enable-background:new;opacity:0.68;fill:url(#linearGradient880);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.0508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <rect
+         style="display:inline;enable-background:new;fill:url(#radialGradient458);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.17028;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="rect448"
+         width="45.831585"
+         x="321.0842"
+         y="77.88913"
+         height="12.221758"
+         ry="0" />
+      <rect
+         ry="0"
+         height="1.0184801"
+         y="83.490761"
+         x="321.0842"
+         width="45.831585"
+         id="rect450"
+         style="display:inline;enable-background:new;opacity:0.68;fill:url(#linearGradient460);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.626504;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <rect
+         style="display:inline;enable-background:new;fill:url(#radialGradient474);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.4154;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="rect464"
+         width="29.890165"
+         x="321.05493"
+         y="144.01465"
+         height="7.9707117"
+         ry="0" />
+      <rect
+         ry="0"
+         height="0.66422611"
+         y="147.66789"
+         x="321.05493"
+         width="29.890165"
+         id="rect466"
+         style="display:inline;enable-background:new;opacity:0.68;fill:url(#linearGradient476);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.408589;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <rect
+         style="display:inline;enable-background:new;fill:url(#radialGradient490);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.08514;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="rect480"
+         width="22.915792"
+         x="320.54211"
+         y="196.94456"
+         height="6.1108789"
+         ry="0" />
+      <rect
+         ry="0"
+         height="0.50924003"
+         y="199.74538"
+         x="320.54211"
+         width="22.915792"
+         id="rect482"
+         style="display:inline;enable-background:new;opacity:0.68;fill:url(#linearGradient492);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.313252;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <rect
+         style="display:inline;enable-background:new;fill:url(#radialGradient506);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.707699;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="rect496"
+         width="14.945084"
+         x="320.52747"
+         y="242.00732"
+         height="3.9853561"
+         ry="0" />
+      <rect
+         ry="0"
+         height="0.33211309"
+         y="243.83394"
+         x="320.52747"
+         width="14.945084"
+         id="rect498"
+         style="display:inline;enable-background:new;opacity:0.68;fill:url(#linearGradient508);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.204295;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/gallery-app.svg
+++ b/icons/src/fullcolor/default/apps/gallery-app.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="gallery-app.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.8284271"
-     inkscape:cx="137.17872"
-     inkscape:cy="183.31743"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="2"
+     inkscape:cx="223"
+     inkscape:cy="214"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -92,219 +92,216 @@
   </sodipodi:namedview>
   <defs
      id="defs3">
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4346"
-       x="-0.014454287"
-       width="1.0289086"
-       y="-0.011357288"
-       height="1.0227146">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.120027"
-         id="feGaussianBlur4348" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4380"
-       x="-0.057817147"
-       width="1.1156343"
-       y="-0.045429151"
-       height="1.0908583">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="8.4801079"
-         id="feGaussianBlur4382" />
-    </filter>
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="e"
+       x2="1"
+       gradientTransform="matrix(0,-43.619541,43.619541,0,1342.0107,238.91632)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#006783"
          offset="0"
-         id="stop923" />
+         id="stop42" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#13bee3"
          offset="1"
-         id="stop925" />
-    </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="66.000679"
-       x2="344"
-       y2="102.00067"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,344,84)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="331.99966"
-       y1="191.00034"
-       x2="331.99966"
-       y2="209.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,331.99966,200)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="238.00043"
-       x2="328"
-       y2="250"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,328,244)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004-8"
-       x1="344"
-       y1="65.144272"
-       x2="344"
-       y2="102.85715"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.04758,0.95458104,0,263.81519,444.36752)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1129">
-      <stop
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0"
-         id="stop1123" />
-      <stop
-         id="stop1125"
-         offset="1"
-         style="stop-color:#000000;stop-opacity:1" />
+         id="stop44" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4463"
-       inkscape:collect="always">
+       id="d"
+       x2="1"
+       gradientTransform="matrix(8.0477837e-7,-62.373844,62.373844,8.0477837e-7,5689.3279,248.80654)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         id="stop4465"
+         stop-color="#a7a7a7"
          offset="0"
-         style="stop-color:#000000;stop-opacity:0" />
+         id="stop37" />
       <stop
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.42311791"
-         id="stop4471" />
-      <stop
-         id="stop4467"
+         stop-color="#3b3b3b"
          offset="1"
-         style="stop-color:#000000;stop-opacity:0;" />
+         id="stop39" />
     </linearGradient>
     <linearGradient
-       gradientTransform="translate(4.2e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4463"
-       id="linearGradient1121-8"
-       gradientUnits="userSpaceOnUse"
-       x1="128"
-       y1="100"
-       x2="264"
-       y2="180" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1117-7"
-       x="-0.0105"
-       width="1.021"
-       y="-0.014"
-       height="1.028">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.7"
-         id="feGaussianBlur1119-2" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1001-5"
-       x="-0.060000002"
-       width="1.12"
-       y="-0.060000002"
-       height="1.12">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.2"
-         id="feGaussianBlur1003-2" />
-    </filter>
+       id="c"
+       x2="1"
+       gradientTransform="matrix(0.19153826,-97.684501,97.684501,0.19153826,7244.4615,282.85017)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#333"
+         offset="0"
+         id="stop32" />
+      <stop
+         stop-color="#828282"
+         offset="1"
+         id="stop34" />
+    </linearGradient>
+    <linearGradient
+       id="b"
+       x2="1"
+       gradientTransform="matrix(211.10343,0,0,211.10343,39.854129,8254.535)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#173964"
+         offset="0"
+         id="stop27" />
+      <stop
+         stop-color="#2767b9"
+         offset="1"
+         id="stop29" />
+    </linearGradient>
+    <linearGradient
+       id="a"
+       x2="1"
+       gradientTransform="matrix(0,-182.1641,182.1641,0,2918.0283,247.13612)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#71a9fa"
+         offset="0"
+         id="stop22" />
+      <stop
+         stop-color="#199acb"
+         offset="1"
+         id="stop24" />
+    </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1129"
-       id="linearGradient1091-3"
-       x1="128"
-       y1="100"
-       x2="185.54404"
-       y2="133.84943"
+       xlink:href="#e"
+       id="linearGradient554"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(4.2e-4,2)" />
-    <filter
+       gradientTransform="matrix(0,-8.9575842,8.9575842,0,588.3772,101.02746)"
+       x2="1" />
+    <linearGradient
        inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1101-7"
-       x="-0.14"
-       width="1.28"
-       y="-0.18334825"
-       height="1.3666965">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="7"
-         id="feGaussianBlur1103-1" />
-    </filter>
+       xlink:href="#d"
+       id="linearGradient556"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6526698e-7,-12.808914,12.808914,1.6526698e-7,1481.1298,103.05848)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient558"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03933375,-20.06021,20.06021,0.03933375,1800.4876,110.04959)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient560"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(43.351597,0,0,43.351597,320.97004,1747.092)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient562"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-37.408699,37.408699,0,912.02366,102.71545)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#e"
+       id="linearGradient582"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-5.8419024,5.8419024,0,495.37642,159.10487)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d"
+       id="linearGradient584"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0778281e-7,-8.3536391,8.3536391,1.0778281e-7,1077.6064,160.42945)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient586"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02565244,-13.082745,13.082745,0.02565244,1285.8832,164.98886)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient588"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(28.272779,0,0,28.272779,320.98046,1232.6252)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient590"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-24.396976,24.396976,0,706.45019,160.20572)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#e"
+       id="linearGradient610"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-4.2840617,4.2840617,0,448.87604,208.14357)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d"
+       id="linearGradient612"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(7.9040727e-8,-6.126002,6.126002,7.9040727e-8,875.84469,209.11493)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient614"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01881179,-9.594013,9.594013,0.01881179,1028.581,212.4585)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(20.733371,0,0,20.733371,320.98567,995.39181)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-17.891116,17.891116,0,603.66347,208.95086)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#e"
+       id="linearGradient638"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-2.7262211,2.7262211,0,402.37567,249.18228)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d"
+       id="linearGradient640"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.0298645e-8,-3.8983649,3.8983649,5.0298645e-8,674.083,249.8004)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient642"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01197114,-6.105281,6.105281,0.01197114,771.27883,251.92814)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient644"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(13.193963,0,0,13.193963,320.99089,750.15843)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient646"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-11.385256,11.385256,0,500.87676,249.69601)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -404,7 +401,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">gallery-app</tspan></text>
+           id="tspan924">gallery-app</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -439,403 +436,284 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 343.99961,196.86562 c 0,-1.12014 -0.0241,-2.01524 -0.1543,-2.79101 -0.13022,-0.77577 -0.38763,-1.48014 -0.91601,-2.00977 -0.52838,-0.52962 -1.23687,-0.79079 -2.01367,-0.91992 -0.77681,-0.12912 -1.67169,-0.15002 -2.79493,-0.14453 h -6.12109 -6.125 c -1.12104,-0.005 -2.01529,0.0156 -2.79102,0.14453 -0.77681,0.12912 -1.48529,0.39029 -2.01367,0.91992 -0.52838,0.52964 -0.78579,1.234 -0.91601,2.00977 -0.13022,0.77577 -0.1543,1.67087 -0.1543,2.79101 v 8.26954 c 0,1.12013 0.024,2.01264 0.1543,2.78711 0.13033,0.77446 0.38927,1.48001 0.91797,2.00781 0.52869,0.5278 1.23438,0.78594 2.00976,0.91601 0.77539,0.13007 1.67062,0.1543 2.79297,0.1543 h 6.125 6.125 c 1.12235,0 2.01758,-0.0242 2.79297,-0.1543 0.77538,-0.13007 1.48107,-0.38821 2.00976,-0.91601 0.5287,-0.5278 0.78764,-1.23334 0.91797,-2.00781 0.13033,-0.77448 0.1543,-1.66697 0.1543,-2.78711 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.49972,241.59598 c 0,-0.71904 -0.0139,-1.30185 -0.10352,-1.83593 -0.0897,-0.53409 -0.27628,-1.0683 -0.68359,-1.47657 -0.4073,-0.40826 -0.94323,-0.59657 -1.47851,-0.68554 -0.53529,-0.089 -1.12048,-0.10119 -1.8418,-0.0977 h -2.89258 -3.89844 c -0.71816,-0.003 -1.30235,0.009 -1.83594,0.0977 -0.53528,0.089 -1.07121,0.27727 -1.47851,0.68554 -0.40731,0.40827 -0.59394,0.94248 -0.68359,1.47657 -0.0897,0.53408 -0.10352,1.11689 -0.10352,1.83593 v 5.8086 c 0,0.71904 0.0137,1.30058 0.10352,1.83398 0.0898,0.53341 0.27792,1.06768 0.68554,1.47461 0.40762,0.40693 0.94271,0.59404 1.47656,0.68359 0.53386,0.0896 1.11551,0.10352 1.83594,0.10352 h 3.89844 2.89844 c 0.72043,0 1.30208,-0.014 1.83594,-0.10352 0.53385,-0.0895 1.06894,-0.27666 1.47656,-0.68359 0.40762,-0.40693 0.59578,-0.9412 0.68554,-1.47461 0.0898,-0.5334 0.10352,-1.11494 0.10352,-1.83398 z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 350.99951,143.19385 c 0,-1.42096 -0.0308,-2.54883 -0.19141,-3.50586 -0.16064,-0.95703 -0.4726,-1.79146 -1.09179,-2.41211 -0.61919,-0.62065 -1.45612,-0.93647 -2.41407,-1.0957 -0.95795,-0.15924 -2.08705,-0.18666 -3.51171,-0.17969 h -7.79102 -7.79688 c -1.42131,-0.007 -2.5495,0.0207 -3.50585,0.17969 -0.95796,0.15923 -1.79488,0.47505 -2.41407,1.0957 -0.61919,0.62065 -0.93115,1.45508 -1.09179,2.41211 -0.16065,0.95703 -0.19141,2.0849 -0.19141,3.50586 v 11.61523 c 0,1.42097 0.0307,2.54669 0.19141,3.50196 0.16075,0.95527 0.47425,1.78779 1.09375,2.40625 0.6195,0.61845 1.45363,0.93134 2.41015,1.09179 0.95653,0.16046 2.08403,0.19141 3.50781,0.19141 h 7.79688 7.79688 c 1.42378,0 2.55128,-0.031 3.50781,-0.19141 0.95653,-0.16045 1.79065,-0.47334 2.41015,-1.09179 0.61951,-0.61846 0.933,-1.45098 1.09375,-2.40625 0.16076,-0.95527 0.19141,-2.08099 0.19141,-3.50196 z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 367.49969,76.231427 c 0,-2.22316 -0.0512,-3.97368 -0.29297,-5.41406 -0.24178,-1.44039 -0.69529,-2.61905 -1.55664,-3.48243 -0.86134,-0.86337 -2.03947,-1.31906 -3.48046,-1.55859 -1.441,-0.23953 -3.19535,-0.28629 -5.42383,-0.27539 H 343.99974 331.2476 c -2.22507,-0.0108 -3.97852,0.0361 -5.41797,0.27539 -1.441,0.23953 -2.61913,0.69522 -3.48047,1.55859 -0.86134,0.86338 -1.31486,2.04204 -1.55664,3.48243 -0.24179,1.44039 -0.29297,3.1909 -0.29297,5.41406 v 17.53883 c 0,2.22317 0.0511,3.97276 0.29297,5.41017 0.24189,1.437403 0.69694,2.612463 1.55859,3.472653 0.86165,0.8602 2.03894,1.31319 3.47852,1.55468 1.43957,0.24149 3.19035,0.29297 5.41797,0.29297 h 12.75214 12.75191 c 2.22761,0 3.97839,-0.0515 5.41797,-0.29297 1.43957,-0.24149 2.61686,-0.69449 3.47851,-1.55469 0.86165,-0.86019 1.31671,-2.03525 1.55859,-3.472653 0.24189,-1.4374 0.29297,-3.187 0.29297,-5.41016 z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0,0.5,-0.5,0,300.9973,13.002698)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path4350"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 464,514.75001 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4380);enable-background:accumulate"
-         transform="matrix(0,0.5,-0.5,0,300.9973,13.002698)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.02028775;marker:none;enable-background:accumulate"
-         d="m 266.0025,105.8091 c 0,-36.098811 -3.69016,-39.983003 -39.68984,-39.806081 H 152.0025 77.69234 C 41.69265,65.826097 38.0025,69.710289 38.0025,105.8091 v 100.38732 c 0,36.09881 3.68973,39.80608 39.68984,39.80608 h 74.31016 74.31016 c 36.00011,0 39.68984,-3.70727 39.68984,-39.80608 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a3dbf0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 366.50065,75.231076 c 0,-8.23154 -0.90635,-9.77365 -9.74838,-9.7304 H 344.0007 331.24889 c -8.84203,-0.0433 -9.74838,1.49886 -9.74838,9.7304 v 17.53897 c 0,8.229494 0.90625,9.730394 9.74838,9.730394 h 12.75181 12.75157 c 8.84213,0 9.74838,-1.5009 9.74838,-9.730404 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a3dbf0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 263.9973,205.07568 c 0,35.29673 -3.62542,39.09461 -38.99353,38.92162 H 151.9973 78.99083 C 43.62271,244.17029 39.9973,240.37241 39.9973,205.07568 v -98.15676 c 0,-35.296716 3.625,-38.921616 38.99353,-38.921616 h 73.00647 73.00647 c 35.36853,0 38.99353,3.6249 38.99353,38.921616 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 343.49998,195.636 c 0,-4.65703 -0.47377,-5.15811 -5.09574,-5.13529 h -6.40426 -6.40425 c -4.62197,-0.0229 -5.09574,0.47826 -5.09574,5.13529 v 8.7287 c 0,4.65703 0.47371,5.13529 5.09574,5.13529 h 6.40425 6.40426 c 4.62202,0 5.09574,-0.47827 5.09574,-5.1353 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a3dbf0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a3dbf0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.50001,240.8545 c 0,-3.04166 -0.30899,-3.36894 -3.32331,-3.35403 h -4.17669 -4.17669 c -3.01432,-0.0149 -3.32331,0.31237 -3.32331,3.35403 v 6.29146 c 0,3.04167 0.30895,3.35404 3.32331,3.35404 h 4.17669 4.17669 c 3.01435,0 3.32331,-0.31238 3.32331,-3.35404 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a3dbf0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 350.50001,142.07508 c 0,-5.56175 -0.58409,-6.6037 -6.28227,-6.57447 h -8.21765 -8.21781 c -5.69818,-0.0293 -6.28227,1.01272 -6.28227,6.57447 v 11.85044 c 0,5.56037 0.58403,6.57447 6.28227,6.57447 h 8.21781 8.21765 c 5.69824,0 6.28227,-1.0141 6.28227,-6.57447 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer6"
-       inkscape:label="Pictograms"
-       style="display:inline">
-      <path
-         style="display:inline;opacity:1;fill:#8fbf3a;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 321.52539 94 C 321.64039 101.08643 322.89491 102.5 331.24805 102.5 L 344 102.5 L 356.75195 102.5 C 365.1051 102.5 366.36156 101.08646 366.47656 94 L 321.52539 94 z "
-         id="path1082-8" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 353.12109 65.5 L 333.75391 102.5 L 344 102.5 L 356.75195 102.5 C 365.59408 102.5 366.5 100.99904 366.5 92.769531 L 366.5 75.230469 C 366.5 66.998929 365.59398 65.45675 356.75195 65.5 L 353.12109 65.5 z "
-         id="path4390-1-6" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b6e2f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 344.86914 65.5 L 330 94 L 339 94 L 353.86914 65.5 L 344.86914 65.5 z "
-         id="rect4248-2-0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffda64;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 353.86914 65.5 L 339 94 L 352.5 94 L 365.76562 68.574219 C 364.73403 66.076814 362.31355 65.472796 356.75195 65.5 L 353.86914 65.5 z "
-         id="path4266-7-6" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1181-5"
-         d="m 355.50042,72.5 a 4.5,4.5 0 0 0 -4.5,4.5 4.5,4.5 0 0 0 4.5,4.5 4.5,4.5 0 0 0 4.5,-4.5 4.5,4.5 0 0 0 -4.5,-4.5 z M 338.93206,77.820312 330.00042,95 h 17.86328 4.63672 l -6.75,-12.9375 -2.31055,4.427734 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b6e2f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 365.76562 68.574219 L 352.5 94 L 361.5 94 L 366.5 84.416016 L 366.5 75.230469 C 366.5 72.176529 366.3741 70.047281 365.76562 68.574219 z "
-         id="path1051-0-3" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path4244-2-6-1"
-         d="M 330.00042,94 338.93199,76.819702 347.86356,94 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f2f2f2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="m 339.00042,94 6.75,-12.9375 6.75,12.9375 z"
-         id="path4246-6-0-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <circle
-         style="opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="path1076-6-5"
-         cx="355.50043"
-         cy="76"
-         r="4.5" />
-      <path
-         style="display:inline;opacity:1;fill:#8fbf3a;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 321.52148 155 C 321.62048 159.57637 322.49219 160.5 327.7832 160.5 L 336 160.5 L 344.2168 160.5 C 349.50781 160.5 350.37952 159.57637 350.47852 155 L 321.52148 155 z "
-         id="path1094-8" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 343.16797 135.5 L 330.08203 160.5 L 336 160.5 L 344.2168 160.5 C 349.91504 160.5 350.5 159.48615 350.5 153.92578 L 350.5 142.07422 C 350.5 136.51247 349.91498 135.47077 344.2168 135.5 L 343.16797 135.5 z "
-         id="path1023-4" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b6e2f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 337.17383 135.5 L 327 155 L 333 155 L 343.17383 135.5 L 337.17383 135.5 z "
-         id="path1026-5" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffda64;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 343.17383 135.5 L 333 155 L 342 155 L 350.34961 138.99805 C 349.96838 136.12769 348.63347 135.47734 344.2168 135.5 L 343.17383 135.5 z "
-         id="path1028-2" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b6e2f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 350.34961 138.99805 L 342 155 L 348 155 L 350.5 150.20703 L 350.5 142.07422 C 350.5 140.8234 350.46022 139.83088 350.34961 138.99805 z "
-         id="path1030-5" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f2f2f2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="M 327.00042,155 332.95481,143.54646 338.90919,155 Z"
-         id="path1032-3"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path1034-1"
-         d="m 333.00042,155 4.5,-8.625 4.5,8.625 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="m 344.00042,141 a 3,3 0 0 0 -3,3 3,3 0 0 0 3,3 3,3 0 0 0 3,-3 3,3 0 0 0 -3,-3 z M 332.9555,144.54688 327.00042,156 h 11.9082 3.0918 l -4.5,-8.625 -1.54102,2.95312 z"
-         id="path1195-7" />
-      <circle
-         r="3"
-         cy="143"
-         cx="344.00043"
-         id="circle1036-7"
-         style="opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         id="path1188-0"
-         d="m 344.00042,140 a 3,3 0 0 0 -3,3 3,3 0 0 0 3,3 3,3 0 0 0 3,-3 3,3 0 0 0 -3,-3 z M 332.9555,143.54688 327.00042,155 h 11.9082 3.0918 l -4.5,-8.625 -1.54102,2.95312 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f2f2f2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;opacity:1;fill:#8fbf3a;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 320.55469 205 C 320.66389 206.86817 320.96706 208.11118 321.64844 208.93945 C 322.39425 209.40915 323.61046 209.5 325.5957 209.5 L 332 209.5 L 338.4043 209.5 C 340.39079 209.5 341.60783 209.40993 342.35352 208.93945 C 343.03447 208.11118 343.33615 206.86763 343.44531 205 L 320.55469 205 z "
-         id="path1099-4" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 337.06055 190.5 L 327.11523 209.5 L 332 209.5 L 338.4043 209.5 C 343.02632 209.5 343.5 209.02226 343.5 204.36523 L 343.5 195.63672 C 343.5 190.97969 343.02627 190.47718 338.4043 190.5 L 337.06055 190.5 z "
-         id="path1040-2" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b6e2f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 332.56445 190.5 L 325 205 L 329.5 205 L 337.06445 190.5 L 332.56445 190.5 z "
-         id="path1042-0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffda64;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 337.06445 190.5 L 329.5 205 L 336.25 205 L 343.08008 191.91016 C 342.52273 190.67557 341.25321 190.48593 338.4043 190.5 L 337.06445 190.5 z "
-         id="path1044-5" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="m 337.75043,194.75001 a 2.2500001,2.2500001 0 0 0 -2.25,2.25 2.2500001,2.2500001 0 0 0 2.25,2.25 2.2500001,2.2500001 0 0 0 2.25,-2.25 2.2500001,2.2500001 0 0 0 -2.25,-2.25 z m -8.28516,2.66016 -4.46484,8.58984 h 8.93164 2.31836 l -3.375,-6.46875 -1.15625,2.21484 z"
-         id="path1197-1"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b6e2f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 343.08008 191.91016 L 336.25 205 L 340.75 205 L 343.5 199.72852 L 343.5 195.63672 C 343.5 193.85021 343.42695 192.67852 343.08008 191.91016 z "
-         id="path1046-0" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path1048-7"
-         d="m 325.00042,205 4.46579,-8.59014 L 333.932,205 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f2f2f2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="m 329.50042,205 3.375,-6.46875 3.375,6.46875 z"
-         id="path1052-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <circle
-         style="opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="circle1054-9"
-         cx="337.75043"
-         cy="196"
-         r="2.25" />
-      <path
-         style="display:inline;opacity:1;fill:#8fbf3a;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 320.5 247 L 320.5 247.14648 C 320.5 250.18815 320.80986 250.5 323.82422 250.5 L 328 250.5 L 332.17578 250.5 C 335.19013 250.5 335.5 250.18814 335.5 247.14648 L 335.5 247 L 320.5 247 z "
-         id="path1134-0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 331.76758 237.5 L 324.96289 250.5 L 328 250.5 L 332.17578 250.5 C 335.19013 250.5 335.5 250.18814 335.5 247.14648 L 335.5 240.85547 C 335.5 237.81381 335.1901 237.48509 332.17578 237.5 L 331.76758 237.5 z "
-         id="path1058-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b6e2f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 328.95703 237.5 L 324 247 L 326.8125 247 L 331.76953 237.5 L 328.95703 237.5 z "
-         id="path1060-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffda64;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 331.76953 237.5 L 326.8125 247 L 331.03125 247 L 335.32812 238.76367 C 335.03765 237.66629 334.25744 237.4897 332.17578 237.5 L 331.76953 237.5 z "
-         id="path1062-4" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b6e2f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 335.32812 238.76367 L 331.03125 247 L 333.84375 247 L 335.5 243.82617 L 335.5 240.85547 C 335.5 239.91435 335.45827 239.25534 335.32812 238.76367 z "
-         id="path1064-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f2f2f2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="m 324.00042,247 2.79111,-5.36884 2.79112,5.36884 z"
-         id="path1067-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path1069-3"
-         d="m 326.81292,247 2.10937,-4.04297 2.10938,4.04297 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate" />
-      <circle
-         r="1.40625"
-         cy="241.375"
-         cx="331.96918"
-         id="circle1071-8"
-         style="opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         style="display:inline;opacity:1;fill:#8fbf3a;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 40.068359 212 C 40.668648 240.84911 46.098353 244.15893 78.990234 243.99805 L 151.99805 243.99805 L 225.00391 243.99805 C 257.89578 244.15893 263.32549 240.84911 263.92578 212 L 56.5 212 L 40.068359 212 z "
-         id="path1031-0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 195.06445 67.998047 L 102.93945 243.99805 L 151.99805 243.99805 L 225.00391 243.99805 C 260.37202 244.17104 263.99805 240.3729 263.99805 205.07617 L 263.99805 106.91797 C 263.99805 71.621249 260.37244 67.998047 225.00391 67.998047 L 195.06445 67.998047 z "
-         id="path4390-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b6e2f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 147.13086 67.998047 L 72 212 L 120 212 L 195.13086 67.998047 L 151.99805 67.998047 L 147.13086 67.998047 z "
-         id="rect4248-4" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffda64;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 195.13086 67.998047 L 120 212 L 192 212 L 261.13672 79.486328 C 257.05663 69.461977 247.3969 67.998047 225.00391 67.998047 L 195.13086 67.998047 z "
-         id="path4266-2" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b6e2f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 261.13672 79.486328 L 192 212 L 240 212 L 263.99805 166.00391 L 263.99805 106.91797 C 263.99805 93.968781 263.50091 85.294898 261.13672 79.486328 z "
-         id="path1051-6" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient1091-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;filter:url(#filter1101-7);enable-background:accumulate"
-         d="M 119.63519,122.37109 72.00042,214 h 95.26953 24.73047 l -36,-69 -12.32227,23.61914 z"
-         id="path1078-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1115-2"
-         d="m 208.00042,92 a 24,24 0 0 0 -24,24 24,24 0 0 0 24,24 24,24 0 0 0 24,-24 24,24 0 0 0 -24,-24 z M 119.63519,120.37109 72.00042,212 h 95.26953 24.73047 l -36,-69 -12.32227,23.61914 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient1121-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;filter:url(#filter1117-7);enable-background:accumulate" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path4244-2-5"
-         d="M 72.00042,212 119.63547,120.37174 167.27052,212 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f2f2f2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="m 120.00042,212 36,-69 36,69 z"
-         id="path4246-6-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <circle
-         r="24"
-         cy="118"
-         cx="208.00043"
-         id="circle967-5"
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter1001-5);enable-background:new" />
-      <circle
-         style="display:inline;opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="path1076-1"
-         cx="208.00043"
-         cy="116"
-         r="24" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;marker:none;enable-background:accumulate"
-         d="m 333.00042,155 4.5,-8.625 4.5,8.625 z"
-         id="path4246-6-0-8-3"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer2"
-       inkscape:label="Highlights"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.990234,67.998047 c -35.36853,0 -38.992187,3.623202 -38.992187,38.919923 v 98.1582 c 0,0.0882 0.0019,0.16224 0.002,0.25 V 108.91602 C 40,73.6193 43.625611,69.994141 78.994141,69.994141 H 152 225.00586 c 35.28016,0 38.97394,3.621035 38.99219,38.671879 v -1.74805 c 0,-35.296721 -3.62561,-38.919923 -38.99414,-38.919923 h -73.00586 z"
-         id="rect4158-78"
-         inkscape:connector-curvature="0" />
+         d="m 229.66111,47.01289 c 17.29268,0 31.326,14.03332 31.326,31.326 v 155.32222 c 0,17.29268 -14.03332,31.326 -31.326,31.326 H 74.33889 c -17.292677,0 -31.326,-14.03332 -31.326,-31.326 V 78.33889 c 0,-17.29268 14.033323,-31.326 31.326,-31.326 z"
+         fill="url(#a)"
+         id="path47"
+         style="display:inline;enable-background:new;fill:url(#a);stroke-width:5.02986" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 39.998047,203.07617 v 2 c 0,35.29673 3.624067,39.09487 38.992187,38.92188 h 73.007816 73.00586 c 35.36811,0.17299 38.99414,-3.62515 38.99414,-38.92188 v -2 c 0,35.29673 -3.62603,39.09487 -38.99414,38.92188 H 151.99805 78.990234 c -35.36812,0.17299 -38.992187,-3.62515 -38.992187,-38.92188 z"
-         id="rect4158-6"
-         inkscape:connector-curvature="0" />
+         d="m 260.98711,189.55926 v 44.10185 c 0,17.29268 -14.03332,31.326 -31.326,31.326 H 74.33889 c -17.292677,0 -31.326,-14.03332 -31.326,-31.326 V 218.0132 l 36.58221,-10.58283 15.38132,9.84847 35.48067,-11.1663 40.73185,-16.55328 z"
+         fill="url(#b)"
+         id="path49"
+         style="display:inline;enable-background:new;fill:url(#b);stroke-width:5.02986" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983)"
-         transform="rotate(90,328,244)" />
+         d="m 266.25841,192.33574 c 0,-5.04495 -2.00189,-9.87865 -5.56806,-13.43979 -3.56114,-3.57121 -8.39987,-5.57309 -13.4398,-5.57309 H 131.08079 c -5.03992,0 -9.87865,2.00188 -13.4398,5.57309 -3.56617,3.56114 -5.57309,8.39484 -5.57309,13.43979 V 252 c 0,5.03993 2.00692,9.87866 5.57309,13.4398 3.56115,3.56617 8.39988,5.57309 13.4398,5.57309 h 116.16976 c 5.03993,0 9.87866,-2.00692 13.4398,-5.57309 3.56617,-3.56114 5.56806,-8.39987 5.56806,-13.4398 z"
+         id="path53"
+         style="display:inline;enable-background:new;stroke-width:5.02986" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.51173,240.91355 c 0,-2.89732 -0.30259,-3.44011 -3.25454,-3.42488 h -4.25716 -4.25724 c -2.95195,-0.0152 -3.25453,0.52756 -3.25453,3.42488 v 6.17331 c 0,2.8966 0.30255,3.42488 3.25453,3.42488 h 4.25724 4.25716 c 2.95199,0 3.25454,-0.52828 3.25454,-3.42488 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 195.73971,156 c 5.42219,0.005 10.31122,3.26438 12.40364,8.25401 l 2.96259,7.07199 h 36.14461 c 5.03993,0 9.87866,2.00189 13.4398,5.56806 3.56617,3.56617 5.56806,8.39987 5.56806,13.4398 v 59.66425 c 0,5.03993 -2.00189,9.87866 -5.56806,13.44483 -3.56114,3.56618 -8.39987,5.56806 -13.4398,5.56806 H 131.08079 c -5.03992,0 -9.87865,-2.00188 -13.4398,-5.56806 -3.56617,-3.56617 -5.57309,-8.4049 -5.57309,-13.44483 v -59.66425 c 0,-5.03993 2.00692,-9.87363 5.57309,-13.4398 3.56115,-3.56617 8.39988,-5.56806 13.4398,-5.56806 h 7.03175 l 3.57121,-7.60013 c 2.21314,-4.70795 6.9563,-7.72084 12.16221,-7.72587 z"
+         fill="url(#c)"
+         id="path55"
+         style="display:inline;enable-background:new;fill:url(#c);stroke-width:5.02986" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 343.51172,195.49156 c 0,-4.23214 -0.46371,-5.02499 -4.98757,-5.00275 h -6.5241 -6.52423 c -4.52386,-0.0222 -4.98757,0.77061 -4.98757,5.00275 v 9.01743 c 0,4.23108 0.46366,5.00275 4.98757,5.00275 h 6.52423 6.5241 c 4.52391,0 4.98757,-0.77167 4.98757,-5.00275 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 359.94826,61.618718 c 3.55118,0 6.43302,2.881843 6.43302,6.433019 v 31.896526 c 0,3.551177 -2.88184,6.433017 -6.43302,6.433017 h -31.89652 c -3.55118,0 -6.43302,-2.88184 -6.43302,-6.433017 V 68.051737 c 0,-3.551176 2.88184,-6.433018 6.43302,-6.433018 z"
+         fill="url(#a)"
+         id="path536"
+         style="display:inline;fill:url(#linearGradient562);stroke-width:1.03292;enable-background:new" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971)"
-         transform="rotate(90,331.99966,200)" />
+         d="m 366.38128,90.891633 v 9.05663 c 0,3.551177 -2.88184,6.433017 -6.43302,6.433017 h -31.89652 c -3.55118,0 -6.43302,-2.88184 -6.43302,-6.433017 v -3.21341 l 7.51242,-2.17326 3.15866,2.022454 7.28621,-2.293079 8.36458,-3.399335 z"
+         fill="url(#b)"
+         id="path538"
+         style="display:inline;fill:url(#linearGradient560);stroke-width:1.03292;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 350.50001,142.07508 c 0,-5.56175 -0.58409,-6.6037 -6.28227,-6.57447 h -8.21765 -8.21781 c -5.69818,-0.0293 -6.28227,1.01272 -6.28227,6.57447 v 11.85044 c 0,5.56037 0.58403,6.57447 6.28227,6.57447 h 8.21781 8.21765 c 5.69824,0 6.28227,-1.0141 6.28227,-6.57447 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 367.46378,91.461804 c 0,-1.036017 -0.4111,-2.028651 -1.14344,-2.759957 -0.73131,-0.733373 -1.72497,-1.144474 -2.75996,-1.144474 h -23.85629 c -1.03498,0 -2.02865,0.411101 -2.75996,1.144474 -0.73234,0.731306 -1.14447,1.72394 -1.14447,2.759957 v 12.252486 c 0,1.03498 0.41213,2.02865 1.14447,2.75995 0.73131,0.73234 1.72498,1.14448 2.75996,1.14448 h 23.85629 c 1.03499,0 2.02865,-0.41214 2.75996,-1.14448 0.73234,-0.7313 1.14344,-1.72497 1.14344,-2.75995 z"
+         id="path542"
+         style="display:inline;stroke-width:1.03292;enable-background:new" />
       <path
-         transform="matrix(0,0.66664182,-0.63636364,0,389.45455,-81.324786)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004-8);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-1)" />
+         d="m 352.98226,84 c 1.11349,0.001 2.11748,0.670363 2.54718,1.695019 l 0.60839,1.452285 h 7.42255 c 1.03499,0 2.02865,0.411102 2.75996,1.143441 0.73234,0.732337 1.14344,1.724973 1.14344,2.759958 v 12.252477 c 0,1.03499 -0.4111,2.02866 -1.14344,2.761 -0.73131,0.73234 -1.72497,1.14344 -2.75996,1.14344 h -23.85629 c -1.03498,0 -2.02865,-0.4111 -2.75996,-1.14344 -0.73234,-0.73234 -1.14447,-1.72601 -1.14447,-2.761 V 91.050703 c 0,-1.034986 0.41213,-2.027621 1.14447,-2.759958 0.73131,-0.732338 1.72498,-1.143441 2.75996,-1.143441 h 1.44402 l 0.73337,-1.560741 c 0.45449,-0.966811 1.42853,-1.58553 2.4976,-1.586562 z"
+         fill="url(#c)"
+         id="path544"
+         style="display:inline;fill:url(#linearGradient558);stroke-width:1.03292;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 366.50065,75.231076 c 0,-8.23154 -0.90635,-9.77365 -9.74838,-9.7304 H 344.0007 331.24889 c -8.84203,-0.0433 -9.74838,1.49886 -9.74838,9.7304 v 17.53897 c 0,8.229494 0.90625,9.730394 9.74838,9.730394 h 12.75181 12.75157 c 8.84213,0 9.74838,-1.5009 9.74838,-9.730404 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 346.40104,133.40352 c 2.31598,0 4.19544,1.87946 4.19544,4.19544 v 20.80208 c 0,2.31598 -1.87946,4.19544 -4.19544,4.19544 h -20.80208 c -2.31599,0 -4.19545,-1.87946 -4.19545,-4.19544 v -20.80209 c 0,-2.31597 1.87946,-4.19544 4.19545,-4.19544 z"
+         fill="url(#a)"
+         id="path564"
+         style="display:inline;fill:url(#linearGradient590);stroke-width:0.673643;enable-background:new" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994)"
-         transform="rotate(90,344,84)" />
+         d="m 350.59648,152.49455 v 5.90649 c 0,2.31598 -1.87946,4.19544 -4.19544,4.19544 h -20.80208 c -2.31599,0 -4.19545,-1.87946 -4.19545,-4.19544 v -2.0957 l 4.8994,-1.41734 2.06,1.31899 4.75188,-1.49548 5.45516,-2.21696 z"
+         fill="url(#b)"
+         id="path566"
+         style="display:inline;fill:url(#linearGradient588);stroke-width:0.673643;enable-background:new" />
+      <path
+         d="m 351.30246,152.86639 c 0,-0.67565 -0.26811,-1.32302 -0.74572,-1.79997 -0.47694,-0.47828 -1.12498,-0.74639 -1.79997,-0.74639 h -15.55845 c -0.67499,0 -1.32304,0.26811 -1.79998,0.74639 -0.47761,0.47695 -0.74639,1.12432 -0.74639,1.79997 v 7.99075 c 0,0.67499 0.26878,1.32303 0.74639,1.79997 0.47694,0.47761 1.12499,0.7464 1.79998,0.7464 h 15.55845 c 0.67499,0 1.32303,-0.26879 1.79997,-0.7464 0.47761,-0.47694 0.74572,-1.12498 0.74572,-1.79997 z"
+         id="path570"
+         style="display:inline;stroke-width:0.673643;enable-background:new" />
+      <path
+         d="m 341.85799,148.00001 c 0.72619,6.5e-4 1.38097,0.43718 1.66121,1.10543 l 0.39677,0.94714 h 4.8408 c 0.67499,0 1.32303,0.26811 1.79997,0.74573 0.47761,0.47761 0.74572,1.12498 0.74572,1.79997 v 7.99075 c 0,0.67499 -0.26811,1.32303 -0.74572,1.80065 -0.47694,0.47761 -1.12498,0.74572 -1.79997,0.74572 h -15.55845 c -0.67499,0 -1.32304,-0.26811 -1.79998,-0.74572 -0.47761,-0.47762 -0.74639,-1.12566 -0.74639,-1.80065 v -7.99075 c 0,-0.67499 0.26878,-1.32236 0.74639,-1.79997 0.47694,-0.47761 1.12499,-0.74573 1.79998,-0.74573 h 0.94175 l 0.47828,-1.01787 c 0.29641,-0.63053 0.93165,-1.03404 1.62887,-1.0347 z"
+         fill="url(#c)"
+         id="path572"
+         style="display:inline;fill:url(#linearGradient586);stroke-width:0.673643;enable-background:new" />
+      <path
+         d="m 339.62743,189.29592 c 1.69839,0 3.07666,1.37827 3.07666,3.07665 v 15.25486 c 0,1.69839 -1.37827,3.07666 -3.07666,3.07666 h -15.25486 c -1.69839,0 -3.07666,-1.37827 -3.07666,-3.07666 v -15.25486 c 0,-1.69838 1.37827,-3.07666 3.07666,-3.07666 z"
+         fill="url(#a)"
+         id="path592"
+         style="display:inline;fill:url(#linearGradient618);stroke-width:0.494005;enable-background:new" />
+      <path
+         d="m 342.70409,203.29601 v 4.33142 c 0,1.69839 -1.37827,3.07666 -3.07666,3.07666 h -15.25486 c -1.69839,0 -3.07666,-1.37827 -3.07666,-3.07666 v -1.53684 l 3.59289,-1.03939 1.51067,0.96726 3.48471,-1.09668 4.00045,-1.62577 z"
+         fill="url(#b)"
+         id="path594"
+         style="display:inline;fill:url(#linearGradient616);stroke-width:0.494005;enable-background:new" />
+      <path
+         d="m 343.22181,203.56869 c 0,-0.49548 -0.19662,-0.97022 -0.54686,-1.31998 -0.34976,-0.35074 -0.82499,-0.54735 -1.31998,-0.54735 h -11.40953 c -0.495,0 -0.97023,0.19661 -1.31999,0.54735 -0.35025,0.34976 -0.54735,0.8245 -0.54735,1.31998 v 5.85988 c 0,0.49499 0.1971,0.97022 0.54735,1.31998 0.34976,0.35025 0.82499,0.54736 1.31999,0.54736 h 11.40953 c 0.49499,0 0.97022,-0.19711 1.31998,-0.54736 0.35024,-0.34976 0.54686,-0.82499 0.54686,-1.31998 z"
+         id="path598"
+         style="display:inline;stroke-width:0.494005;enable-background:new" />
+      <path
+         d="m 336.29586,200.00001 c 0.53254,4.8e-4 1.01271,0.3206 1.21822,0.81065 l 0.29097,0.69457 h 3.54992 c 0.49499,0 0.97022,0.19661 1.31998,0.54687 0.35024,0.35024 0.54686,0.82498 0.54686,1.31997 v 5.85989 c 0,0.49499 -0.19662,0.97022 -0.54686,1.32047 -0.34976,0.35025 -0.82499,0.54687 -1.31998,0.54687 h -11.40953 c -0.495,0 -0.97023,-0.19662 -1.31999,-0.54687 -0.35025,-0.35025 -0.54735,-0.82548 -0.54735,-1.32047 v -5.85989 c 0,-0.49499 0.1971,-0.96973 0.54735,-1.31997 0.34976,-0.35025 0.82499,-0.54687 1.31999,-0.54687 h 0.69061 l 0.35074,-0.74644 c 0.21737,-0.46239 0.68321,-0.7583 1.19451,-0.75878 z"
+         fill="url(#c)"
+         id="path600"
+         style="display:inline;fill:url(#linearGradient614);stroke-width:0.494005;enable-background:new" />
+      <path
+         d="m 332.85382,237.18832 c 1.0808,0 1.95788,0.87708 1.95788,1.95786 v 9.70764 c 0,1.0808 -0.87708,1.95788 -1.95788,1.95788 h -9.70764 c -1.08079,0 -1.95787,-0.87709 -1.95787,-1.95788 v -9.70764 c 0,-1.08078 0.87707,-1.95787 1.95787,-1.95787 z"
+         fill="url(#a)"
+         id="path620"
+         style="display:inline;fill:url(#linearGradient646);stroke-width:0.314367;enable-background:new" />
+      <path
+         d="m 334.8117,246.09746 v 2.75636 c 0,1.0808 -0.87708,1.95788 -1.95788,1.95788 h -9.70764 c -1.08079,0 -1.95787,-0.87709 -1.95787,-1.95788 v -0.97799 l 2.28638,-0.66143 0.96134,0.61553 2.21754,-0.69788 2.54574,-1.03459 z"
+         fill="url(#b)"
+         id="path622"
+         style="display:inline;fill:url(#linearGradient644);stroke-width:0.314367;enable-background:new" />
+      <path
+         d="m 325.27865,239.49568 c 0.99094,0.001 1.79425,0.80898 1.79236,1.80227 -0.002,0.99378 -0.80802,1.79897 -1.79943,1.79755 -0.99094,-10e-4 -1.79424,-0.80896 -1.79237,-1.80227 0.002,-0.9933 0.80803,-1.79848 1.79944,-1.79755 z"
+         fill="#b6ebfc"
+         id="path624"
+         style="display:inline;stroke-width:0.471426;enable-background:new" />
+      <path
+         d="m 335.14116,246.27099 c 0,-0.31531 -0.12513,-0.61741 -0.34801,-0.83999 -0.22257,-0.2232 -0.52499,-0.34831 -0.83998,-0.34831 h -7.26061 c -0.315,0 -0.61742,0.12511 -0.84,0.34831 -0.22288,0.22258 -0.34831,0.52468 -0.34831,0.83999 V 250 c 0,0.31499 0.12543,0.61742 0.34831,0.83999 0.22258,0.22289 0.525,0.34832 0.84,0.34832 h 7.26061 c 0.31499,0 0.61741,-0.12543 0.83998,-0.34832 0.22288,-0.22257 0.34801,-0.525 0.34801,-0.83999 z"
+         id="path626"
+         style="display:inline;stroke-width:0.314367;enable-background:new" />
+      <path
+         d="m 330.73373,244.00001 c 0.33889,3.1e-4 0.64445,0.20402 0.77523,0.51587 l 0.18517,0.442 h 2.25904 c 0.31499,0 0.61741,0.12511 0.83998,0.34801 0.22288,0.22288 0.34801,0.52498 0.34801,0.83998 v 3.72901 c 0,0.31499 -0.12513,0.61742 -0.34801,0.84031 -0.22257,0.22288 -0.52499,0.348 -0.83998,0.348 h -7.26061 c -0.315,0 -0.61742,-0.12512 -0.84,-0.348 -0.22288,-0.22289 -0.34831,-0.52531 -0.34831,-0.84031 v -3.72901 c 0,-0.315 0.12543,-0.6171 0.34831,-0.83998 0.22258,-0.2229 0.525,-0.34801 0.84,-0.34801 h 0.43948 l 0.22319,-0.47501 c 0.13833,-0.29425 0.43477,-0.48255 0.76015,-0.48286 z"
+         fill="url(#c)"
+         id="path628"
+         style="display:inline;fill:url(#linearGradient642);stroke-width:0.314367;enable-background:new" />
+      <circle
+         cx="333.49701"
+         cy="245.95064"
+         r="0.48003769"
+         fill="#00f47c"
+         id="circle630"
+         style="display:inline;stroke-width:0.314367;enable-background:new" />
+      <circle
+         cx="329.59918"
+         cy="247.851"
+         r="2.4806662"
+         fill="#ebebeb"
+         id="circle632"
+         style="display:inline;stroke-width:0.314367;enable-background:new" />
+      <circle
+         cx="329.59918"
+         cy="247.851"
+         r="1.9490724"
+         fill="url(#d)"
+         id="circle634"
+         style="display:inline;fill:url(#linearGradient640);stroke-width:0.314367;enable-background:new" />
+      <circle
+         cx="329.59918"
+         cy="247.851"
+         r="1.7535366"
+         fill="url(#e)"
+         id="circle636"
+         style="display:inline;fill:url(#linearGradient638);stroke-width:0.314367;enable-background:new" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictogram"
+       style="display:inline">
+      <path
+         d="m 108.45839,83.93104 c 15.85502,0.0251 28.70804,12.9435 28.67786,28.83627 -0.0302,15.9003 -12.92842,28.78345 -28.791,28.76081 -15.85504,-0.0251 -28.70803,-12.9435 -28.67786,-28.83626 0.0302,-15.89276 12.92842,-28.77591 28.791,-28.76082 z"
+         fill="#b6ebfc"
+         id="path51"
+         style="display:inline;stroke-width:7.54284;enable-background:new" />
+      <circle
+         cx="239.95221"
+         cy="187.21034"
+         r="7.6806035"
+         fill="#00f47c"
+         id="circle57"
+         style="display:inline;stroke-width:5.02986;enable-background:new" />
+      <circle
+         cx="177.58694"
+         cy="217.61586"
+         r="39.690662"
+         fill="#ebebeb"
+         id="circle59"
+         style="display:inline;stroke-width:5.02986;enable-background:new" />
+      <circle
+         cx="177.58694"
+         cy="217.61586"
+         r="31.185162"
+         fill="url(#d)"
+         id="circle61"
+         style="display:inline;fill:url(#d);stroke-width:5.02986;enable-background:new" />
+      <circle
+         cx="177.58694"
+         cy="217.61586"
+         r="28.056587"
+         fill="url(#e)"
+         id="circle63"
+         style="display:inline;fill:url(#e);stroke-width:5.02986;enable-background:new" />
+      <path
+         d="m 335.05842,69.200124 c 3.25594,0.0052 5.8954,2.65804 5.8892,5.921735 -0.006,3.26524 -2.65494,5.910887 -5.91243,5.906238 -3.25595,-0.0052 -5.8954,-2.658041 -5.88921,-5.921732 0.006,-3.263692 2.65495,-5.90934 5.91244,-5.906241 z"
+         fill="#b6ebfc"
+         id="path540"
+         style="display:inline;stroke-width:1.54898;enable-background:new" />
+      <circle
+         cx="362.06161"
+         cy="90.409264"
+         r="1.5772668"
+         fill="#00f47c"
+         id="circle546"
+         style="display:inline;stroke-width:1.03292;enable-background:new" />
+      <circle
+         cx="349.25446"
+         cy="96.653259"
+         r="8.1507607"
+         fill="#ebebeb"
+         id="circle548"
+         style="display:inline;stroke-width:1.03292;enable-background:new" />
+      <circle
+         cx="349.25446"
+         cy="96.653259"
+         r="6.4040956"
+         fill="url(#d)"
+         id="circle550"
+         style="display:inline;fill:url(#linearGradient556);stroke-width:1.03292;enable-background:new" />
+      <circle
+         cx="349.25446"
+         cy="96.653259"
+         r="5.7616205"
+         fill="url(#e)"
+         id="circle552"
+         style="display:inline;fill:url(#linearGradient554);stroke-width:1.03292;enable-background:new" />
+      <path
+         d="m 330.16853,138.34791 c 2.12344,0.003 3.84483,1.7335 3.84078,3.86199 -0.004,2.12951 -1.73148,3.85494 -3.85593,3.8519 -2.12344,-0.003 -3.84482,-1.73351 -3.84079,-3.862 0.004,-2.1285 1.73149,-3.85392 3.85594,-3.85189 z"
+         fill="#b6ebfc"
+         id="path568"
+         style="display:inline;stroke-width:1.0102;enable-background:new" />
+      <circle
+         cx="347.7793"
+         cy="152.17995"
+         r="1.0286522"
+         fill="#00f47c"
+         id="circle574"
+         style="display:inline;stroke-width:0.673643;enable-background:new" />
+      <circle
+         cx="339.42682"
+         cy="156.25212"
+         r="5.3157134"
+         fill="#ebebeb"
+         id="circle576"
+         style="display:inline;stroke-width:0.673643;enable-background:new" />
+      <circle
+         cx="339.42682"
+         cy="156.25212"
+         r="4.1765838"
+         fill="url(#d)"
+         id="circle578"
+         style="display:inline;fill:url(#linearGradient584);stroke-width:0.673643;enable-background:new" />
+      <circle
+         cx="339.42682"
+         cy="156.25212"
+         r="3.7575784"
+         fill="url(#e)"
+         id="circle580"
+         style="display:inline;fill:url(#linearGradient582);stroke-width:0.673643;enable-background:new" />
+      <path
+         d="m 327.72359,192.9218 c 1.55719,0.002 2.81954,1.27124 2.81657,2.83213 -0.003,1.56164 -1.26975,2.82696 -2.82768,2.82473 -1.55719,-0.002 -2.81953,-1.27124 -2.81658,-2.83214 0.003,-1.5609 1.26976,-2.82621 2.82769,-2.82472 z"
+         fill="#b6ebfc"
+         id="path596"
+         style="display:inline;stroke-width:0.740813;enable-background:new" />
+      <circle
+         cx="340.63815"
+         cy="203.06529"
+         r="0.75434494"
+         fill="#00f47c"
+         id="circle602"
+         style="display:inline;stroke-width:0.494005;enable-background:new" />
+      <circle
+         cx="334.513"
+         cy="206.05156"
+         r="3.8981898"
+         fill="#ebebeb"
+         id="circle604"
+         style="display:inline;stroke-width:0.494005;enable-background:new" />
+      <circle
+         cx="334.513"
+         cy="206.05156"
+         r="3.0628281"
+         fill="url(#d)"
+         id="circle606"
+         style="display:inline;fill:url(#linearGradient612);stroke-width:0.494005;enable-background:new" />
+      <circle
+         cx="334.513"
+         cy="206.05156"
+         r="2.7555575"
+         fill="url(#e)"
+         id="circle608"
+         style="display:inline;fill:url(#linearGradient610);stroke-width:0.494005;enable-background:new" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/games-app.svg
+++ b/icons/src/fullcolor/default/apps/games-app.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="games-app.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -32,17 +32,17 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:zoom="2.8284271"
-     inkscape:cx="178.19091"
-     inkscape:cy="202.05576"
-     inkscape:current-layer="layer8"
+     inkscape:cx="250.66935"
+     inkscape:cy="167.23075"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -92,154 +92,581 @@
   </sodipodi:namedview>
   <defs
      id="defs3">
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4346"
-       x="-0.014454287"
-       width="1.0289086"
-       y="-0.011357288"
-       height="1.0227146">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.120027"
-         id="feGaussianBlur4348" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4380"
-       x="-0.057817147"
-       width="1.1156343"
-       y="-0.045429151"
-       height="1.0908583">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="8.4801079"
-         id="feGaussianBlur4382" />
-    </filter>
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="g"
+       x2="0"
+       y1="8"
+       y2="24"
+       gradientTransform="matrix(6.9649154,0,0,-6.9649154,40.561569,211.71929)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient1114" />
+    <linearGradient
+       id="linearGradient1114">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#2a2c2f"
          offset="0"
-         id="stop923" />
+         id="stop1110"
+         style="stop-color:#999a9c;stop-opacity:1;" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#424649"
          offset="1"
-         id="stop925" />
+         id="stop1112"
+         style="stop-color:#f4f5f5;stop-opacity:1;" />
     </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
+       id="h"
+       x2="0"
+       y1="20"
+       y2="18"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient1114"
+       gradientTransform="matrix(6.9649154,0,0,6.9649154,40.561569,44.561322)" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
+       id="i"
+       x2="0"
+       y1="536.79999"
+       y2="532.79999"
+       gradientTransform="matrix(6.9649154,0,0,6.9649154,-2630.971,-3547.942)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#a" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
+       id="a">
+      <stop
+         stop-color="#2a2c2f"
+         offset="0"
+         id="stop292" />
+      <stop
+         stop-color="#424649"
+         offset="1"
+         id="stop294" />
+    </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004-8"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
+       id="k"
+       x2="0"
+       y1="532.79999"
+       y2="526.79999"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient1114"
+       gradientTransform="matrix(6.9649154,0,0,6.9649154,-2637.9359,-3547.942)" />
+    <linearGradient
+       id="f"
+       x2="0"
+       y1="532.79999"
+       y2="530.79999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(6.9649154,0,0,6.9649154,-2637.9359,-3547.942)">
+      <stop
+         stop-color="#2980b9"
+         offset="0"
+         id="stop298" />
+      <stop
+         stop-color="#3498db"
+         offset="1"
+         id="stop300" />
+    </linearGradient>
+    <linearGradient
+       id="d"
+       x2="0"
+       y1="530.79999"
+       y2="528.79999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(6.9649154,0,0,6.9649154,-2637.9359,-3547.942)">
+      <stop
+         stop-color="#c0392b"
+         offset="0"
+         id="stop308" />
+      <stop
+         stop-color="#e74c3c"
+         offset="1"
+         id="stop310" />
+    </linearGradient>
+    <linearGradient
+       id="c"
+       x2="0"
+       y1="530.79999"
+       y2="528.79999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(6.9649154,0,0,6.9649154,-2637.9359,-3547.942)">
+      <stop
+         stop-color="#f33777"
+         offset="0"
+         id="stop313" />
+      <stop
+         stop-color="#fd2d65"
+         offset="1"
+         id="stop315" />
+    </linearGradient>
+    <linearGradient
+       id="e"
+       x2="0"
+       y1="528.79999"
+       y2="526.79999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(6.9649154,0,0,6.9649154,-2637.9359,-3547.942)">
+      <stop
+         stop-color="#27ae60"
+         offset="0"
+         id="stop303" />
+      <stop
+         stop-color="#2ecc71"
+         offset="1"
+         id="stop305" />
+    </linearGradient>
+    <linearGradient
+       id="j"
+       x2="0"
+       y1="533.79999"
+       y2="523.79999"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#a"
+       gradientTransform="matrix(6.9649154,0,0,6.9649154,-2637.9359,-3547.942)" />
+    <linearGradient
+       id="l"
+       x2="0"
+       y1="24"
+       y2="8"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#a"
+       gradientTransform="matrix(6.9649154,0,0,6.9649154,40.561569,44.561322)" />
     <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1507"
-       x="-0.060000002"
-       width="1.12"
-       y="-0.060000002"
-       height="1.12">
+       id="n"
+       x="-0.029076968"
+       y="-0.04724997"
+       width="1.0581539"
+       height="1.0944999"
+       color-interpolation-filters="sRGB">
       <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.2"
-         id="feGaussianBlur1509" />
+         stdDeviation="0.315"
+         id="feGaussianBlur326" />
     </filter>
+    <linearGradient
+       id="m"
+       x1="403.44"
+       x2="402.48999"
+       y1="544.98999"
+       y2="518.34003"
+       gradientTransform="matrix(7.4622104,0,0,7.4622104,-2837.2231,-3812.4625)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#d3d3d3"
+         offset="0"
+         id="stop321" />
+      <stop
+         stop-color="#fcf9f9"
+         offset="1"
+         id="stop323" />
+    </linearGradient>
     <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1496"
-       x="-0.051428564"
-       width="1.1028571"
-       y="-0.072000003"
-       height="1.144">
+       id="o"
+       x="-0.036000386"
+       y="-0.036000386"
+       width="1.0720008"
+       height="1.0720008"
+       color-interpolation-filters="sRGB">
       <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.2"
-         id="feGaussianBlur1498" />
+         stdDeviation="0.42822458"
+         id="feGaussianBlur318" />
     </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1114"
+       id="linearGradient1573"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4302951,0,0,-1.4302951,321.08735,95.402304)"
+       y1="8"
+       x2="0"
+       y2="24" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1114"
+       id="linearGradient1575"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4302951,0,0,1.4302951,321.08735,61.075222)"
+       y1="20"
+       x2="0"
+       y2="18" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1577"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4302951,0,0,1.4302951,-227.53094,-676.67098)"
+       y1="536.79999"
+       x2="0"
+       y2="532.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1114"
+       id="linearGradient1579"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4302951,0,0,1.4302951,-228.96123,-676.67098)"
+       y1="532.79999"
+       x2="0"
+       y2="526.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#f"
+       id="linearGradient1581"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4302951,0,0,1.4302951,-228.96123,-676.67098)"
+       y1="532.79999"
+       x2="0"
+       y2="530.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d"
+       id="linearGradient1583"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4302951,0,0,1.4302951,-228.96123,-676.67098)"
+       y1="530.79999"
+       x2="0"
+       y2="528.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient1585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4302951,0,0,1.4302951,-228.96123,-676.67098)"
+       y1="530.79999"
+       x2="0"
+       y2="528.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#e"
+       id="linearGradient1587"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4302951,0,0,1.4302951,-228.96123,-676.67098)"
+       y1="528.79999"
+       x2="0"
+       y2="526.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1589"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4302951,0,0,1.4302951,-228.96123,-676.67098)"
+       y1="533.79999"
+       x2="0"
+       y2="523.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1591"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4302951,0,0,1.4302951,321.08735,61.075222)"
+       y1="24"
+       x2="0"
+       y2="8" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#m"
+       id="linearGradient1593"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5324182,0,0,1.5324182,-269.88628,-730.99216)"
+       x1="403.44"
+       y1="544.98999"
+       x2="402.48999"
+       y2="518.34003" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1114"
+       id="linearGradient1623"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93280112,0,0,-0.93280112,321.05698,155.43629)"
+       y1="8"
+       x2="0"
+       y2="24" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1114"
+       id="linearGradient1625"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93280112,0,0,0.93280112,321.05698,133.04906)"
+       y1="20"
+       x2="0"
+       y2="18" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1627"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93280112,0,0,0.93280112,-36.737552,-348.08975)"
+       y1="536.79999"
+       x2="0"
+       y2="532.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1114"
+       id="linearGradient1629"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93280112,0,0,0.93280112,-37.67035,-348.08975)"
+       y1="532.79999"
+       x2="0"
+       y2="526.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#f"
+       id="linearGradient1631"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93280112,0,0,0.93280112,-37.67035,-348.08975)"
+       y1="532.79999"
+       x2="0"
+       y2="530.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d"
+       id="linearGradient1633"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93280112,0,0,0.93280112,-37.67035,-348.08975)"
+       y1="530.79999"
+       x2="0"
+       y2="528.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient1635"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93280112,0,0,0.93280112,-37.67035,-348.08975)"
+       y1="530.79999"
+       x2="0"
+       y2="528.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#e"
+       id="linearGradient1637"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93280112,0,0,0.93280112,-37.67035,-348.08975)"
+       y1="528.79999"
+       x2="0"
+       y2="526.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1639"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93280112,0,0,0.93280112,-37.67035,-348.08975)"
+       y1="533.79999"
+       x2="0"
+       y2="523.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1641"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93280112,0,0,0.93280112,321.05698,133.04906)"
+       y1="24"
+       x2="0"
+       y2="8" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#m"
+       id="linearGradient1643"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99940314,0,0,0.99940314,-64.360599,-383.51661)"
+       x1="403.44"
+       y1="544.98999"
+       x2="402.48999"
+       y2="518.34003" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1114"
+       id="linearGradient1673"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71514753,0,0,-0.71514753,320.55766,205.72119)"
+       y1="8"
+       x2="0"
+       y2="24" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1114"
+       id="linearGradient1675"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71514753,0,0,0.71514753,320.55766,188.55764)"
+       y1="20"
+       x2="0"
+       y2="18" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1677"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71514753,0,0,0.71514753,46.248517,-180.31545)"
+       y1="536.79999"
+       x2="0"
+       y2="532.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1114"
+       id="linearGradient1679"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71514753,0,0,0.71514753,45.533372,-180.31545)"
+       y1="532.79999"
+       x2="0"
+       y2="526.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#f"
+       id="linearGradient1681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71514753,0,0,0.71514753,45.533372,-180.31545)"
+       y1="532.79999"
+       x2="0"
+       y2="530.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d"
+       id="linearGradient1683"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71514753,0,0,0.71514753,45.533372,-180.31545)"
+       y1="530.79999"
+       x2="0"
+       y2="528.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient1685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71514753,0,0,0.71514753,45.533372,-180.31545)"
+       y1="530.79999"
+       x2="0"
+       y2="528.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#e"
+       id="linearGradient1687"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71514753,0,0,0.71514753,45.533372,-180.31545)"
+       y1="528.79999"
+       x2="0"
+       y2="526.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1689"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71514753,0,0,0.71514753,45.533372,-180.31545)"
+       y1="533.79999"
+       x2="0"
+       y2="523.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1691"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71514753,0,0,0.71514753,320.55766,188.55764)"
+       y1="24"
+       x2="0"
+       y2="8" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#m"
+       id="linearGradient1693"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.76620908,0,0,0.76620908,25.070848,-207.47604)"
+       x1="403.44"
+       y1="544.98999"
+       x2="402.48999"
+       y2="518.34003" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1114"
+       id="linearGradient1723"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46640056,0,0,-0.46640056,320.53761,247.73121)"
+       y1="8"
+       x2="0"
+       y2="24" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1114"
+       id="linearGradient1725"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46640056,0,0,0.46640056,320.53761,236.53759)"
+       y1="20"
+       x2="0"
+       y2="18" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1727"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46640056,0,0,0.46640056,141.64035,-4.0318151)"
+       y1="536.79999"
+       x2="0"
+       y2="532.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1114"
+       id="linearGradient1729"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46640056,0,0,0.46640056,141.17395,-4.0318151)"
+       y1="532.79999"
+       x2="0"
+       y2="526.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#f"
+       id="linearGradient1731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46640056,0,0,0.46640056,141.17395,-4.0318151)"
+       y1="532.79999"
+       x2="0"
+       y2="530.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d"
+       id="linearGradient1733"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46640056,0,0,0.46640056,141.17395,-4.0318151)"
+       y1="530.79999"
+       x2="0"
+       y2="528.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient1735"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46640056,0,0,0.46640056,141.17395,-4.0318151)"
+       y1="530.79999"
+       x2="0"
+       y2="528.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#e"
+       id="linearGradient1737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46640056,0,0,0.46640056,141.17395,-4.0318151)"
+       y1="528.79999"
+       x2="0"
+       y2="526.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1739"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46640056,0,0,0.46640056,141.17395,-4.0318151)"
+       y1="533.79999"
+       x2="0"
+       y2="523.79999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient1741"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46640056,0,0,0.46640056,320.53761,236.53759)"
+       y1="24"
+       x2="0"
+       y2="8" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#m"
+       id="linearGradient1743"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.49970157,0,0,0.49970157,127.82882,-21.745243)"
+       x1="403.44"
+       y1="544.98999"
+       x2="402.48999"
+       y2="518.34003" />
   </defs>
   <metadata
      id="metadata4">
@@ -315,7 +742,8 @@
        style="display:none"
        inkscape:label="Baseplate"
        id="layer7"
-       inkscape:groupmode="layer">
+       inkscape:groupmode="layer"
+       sodipodi:insensitive="true">
       <text
          y="-8.2548828"
          xml:space="preserve"
@@ -339,7 +767,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">games-app</tspan></text>
+           id="tspan924">games-app</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -374,299 +802,439 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86523,189 c -1.12014,0 -2.01524,0.0241 -2.79101,0.1543 -0.77577,0.13022 -1.48014,0.38763 -2.00977,0.91601 -0.52962,0.52838 -0.79079,1.23687 -0.91992,2.01367 -0.12912,0.77681 -0.15002,1.67169 -0.14453,2.79493 V 201 v 6.125 c -0.005,1.12104 0.0156,2.01529 0.14453,2.79102 0.12912,0.77681 0.39029,1.48529 0.91992,2.01367 0.52964,0.52838 1.234,0.78579 2.00977,0.91601 0.77577,0.13022 1.67087,0.1543 2.79101,0.1543 h 8.26954 c 1.12013,0 2.01264,-0.024 2.78711,-0.1543 0.77446,-0.13033 1.48001,-0.38927 2.00781,-0.91797 0.5278,-0.52869 0.78594,-1.23438 0.91601,-2.00976 C 341.97577,209.14258 342,208.24735 342,207.125 V 201 194.875 c 0,-1.12235 -0.0242,-2.01758 -0.1543,-2.79297 -0.13007,-0.77538 -0.38821,-1.48107 -0.91601,-2.00976 -0.5278,-0.5287 -1.23334,-0.78764 -2.00781,-0.91797 C 338.1474,189.02397 337.25491,189 336.13477,189 Z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 330.19336,134 c -1.42096,0 -2.54883,0.0308 -3.50586,0.19141 -0.95703,0.16064 -1.79146,0.4726 -2.41211,1.09179 -0.62065,0.61919 -0.93647,1.45612 -1.0957,2.41407 -0.15924,0.95795 -0.18666,2.08705 -0.17969,3.51171 V 149 v 7.79688 c -0.007,1.42131 0.0207,2.5495 0.17969,3.50585 0.15923,0.95796 0.47505,1.79488 1.0957,2.41407 0.62065,0.61919 1.45508,0.93115 2.41211,1.09179 0.95703,0.16065 2.0849,0.19141 3.50586,0.19141 h 11.61523 c 1.42097,0 2.54669,-0.0307 3.50196,-0.19141 0.95527,-0.16075 1.78779,-0.47425 2.40625,-1.09375 0.61845,-0.6195 0.93134,-1.45363 1.09179,-2.41015 C 348.96905,159.34816 349,158.22066 349,156.79688 V 149 141.20312 c 0,-1.42378 -0.031,-2.55128 -0.19141,-3.50781 -0.16045,-0.95653 -0.47334,-1.79065 -1.09179,-2.41015 -0.61846,-0.61951 -1.45098,-0.933 -2.40625,-1.09375 C 344.35528,134.03065 343.22956,134 341.80859,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.23093,61.500047 c -2.22316,0 -3.97368,0.05118 -5.41406,0.292969 -1.44039,0.241784 -2.61905,0.695299 -3.48243,1.55664 -0.86337,0.861342 -1.31906,2.039471 -1.55859,3.480469 -0.23953,1.440999 -0.28629,3.195341 -0.27539,5.423828 V 85 97.752143 c -0.0108,2.225063 0.0361,3.978517 0.27539,5.417967 0.23953,1.441 0.69522,2.61913 1.55859,3.48047 0.86338,0.86134 2.04204,1.31486 3.48243,1.55664 1.44039,0.24179 3.1909,0.29297 5.41406,0.29297 h 17.53883 c 2.22317,0 3.97276,-0.0511 5.41017,-0.29297 1.4374,-0.24189 2.61246,-0.69694 3.47265,-1.55859 0.8602,-0.86165 1.31319,-2.03894 1.55468,-3.47852 0.24149,-1.43957 0.29297,-3.190353 0.29297,-5.417967 V 85 72.248094 c 0,-2.227614 -0.0515,-3.978392 -0.29297,-5.417969 -0.24149,-1.439576 -0.69449,-2.616863 -1.55469,-3.478516 -0.86019,-0.861652 -2.03525,-1.316704 -3.47265,-1.558593 -1.4374,-0.24189 -3.187,-0.292969 -5.41016,-0.292969 z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path4350"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 464,514.75001 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4380);enable-background:accumulate"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.02028775;marker:none;enable-background:accumulate"
-         d="M 101.8116,42 C 65.712789,42 61.828597,45.690158 62.005519,81.689842 V 156 230.31016 C 61.828597,266.30985 65.712789,270 101.8116,270 h 100.38732 c 36.09881,0 39.80608,-3.68973 39.80608,-39.68984 V 156 81.689842 C 242.005,45.689729 238.29773,42 202.19892,42 Z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e3dfd5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e3dfd5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 201.07298,44 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 156 229.00647 C 240.16759,264.37459 236.36971,268 201.07298,268 H 102.91622 C 67.619504,268 63.994604,264.375 63.994604,229.00647 V 156 82.99353 C 63.994604,47.624997 67.619504,44 102.91622,44 Z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 327.63532,188.49999 c -4.65703,0 -5.15812,0.47378 -5.1353,5.09575 v 6.40425 6.40426 c -0.0229,4.62196 0.47827,5.09574 5.1353,5.09574 h 8.72869 c 4.65703,0 5.1353,-0.47372 5.1353,-5.09574 v -6.40426 -6.40425 c 0,-4.62202 -0.47828,-5.09575 -5.13531,-5.09575 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e3dfd5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e3dfd5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.8545,236.50001 c -3.04166,0 -3.36894,0.30899 -3.35403,3.32331 v 4.17669 4.17668 c -0.0149,3.01433 0.31237,3.32332 3.35403,3.32332 h 6.29146 c 3.04167,0 3.35404,-0.30895 3.35404,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.31238,-3.32331 -3.35404,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e3dfd5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+      <circle
+         transform="matrix(7.3194296,0,0,7.3194296,-2779.8809,-3735.3261)"
+         cx="400.57999"
+         cy="531.66998"
+         r="14.274"
+         filter="url(#o)"
+         opacity="0.25"
+         id="circle331"
+         style="display:inline;enable-background:new" />
+      <circle
+         cx="152.00026"
+         cy="155.99983"
+         r="104.47373"
+         fill="url(#m)"
+         id="circle333"
+         style="display:inline;enable-background:new;fill:url(#m);stroke-width:6.96492" />
+      <circle
+         cx="103.24585"
+         cy="142.06999"
+         fill="#e3dbdb"
+         id="ellipse341"
+         r="0"
+         style="display:inline;enable-background:new;stroke-width:0.696492;stroke-linecap:square" />
+      <circle
+         transform="matrix(1.5030972,0,0,1.5030972,-258.11066,-715.15166)"
+         cx="400.57999"
+         cy="531.66998"
+         r="14.274"
+         filter="url(#o)"
+         opacity="0.25"
+         id="circle1545"
+         style="display:inline;enable-background:new" />
+      <circle
+         cx="343.97208"
+         cy="83.959915"
+         r="21.454428"
+         fill="url(#m)"
+         id="circle1547"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1593);stroke-width:1.4303" />
+      <circle
+         cx="333.96002"
+         cy="81.099327"
+         fill="#e3dbdb"
+         id="circle1555"
+         r="0"
+         style="display:inline;enable-background:new;stroke-width:0.14303;stroke-linecap:square" />
+      <circle
+         transform="matrix(0.98028075,0,0,0.98028075,-56.680849,-373.18585)"
+         cx="400.57999"
+         cy="531.66998"
+         r="14.274"
+         filter="url(#o)"
+         opacity="0.25"
+         id="circle1595"
+         style="display:inline;enable-background:new" />
+      <circle
+         cx="335.98178"
+         cy="147.97386"
+         r="13.992018"
+         fill="url(#m)"
+         id="circle1597"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1643);stroke-width:0.932804" />
+      <circle
+         cx="329.45218"
+         cy="146.10826"
+         fill="#e3dbdb"
+         id="circle1605"
+         r="0"
+         style="display:inline;enable-background:new;stroke-width:0.0932804;stroke-linecap:square" />
+      <circle
+         transform="matrix(0.75154858,0,0,0.75154858,30.958657,-199.55579)"
+         cx="400.57999"
+         cy="531.66998"
+         r="14.274"
+         filter="url(#o)"
+         opacity="0.25"
+         id="circle1645"
+         style="display:inline;enable-background:new" />
+      <circle
+         cx="332"
+         cy="200"
+         r="10.727214"
+         fill="url(#m)"
+         id="circle1647"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1693);stroke-width:0.71515" />
+      <circle
+         cx="326.99399"
+         cy="198.5697"
+         fill="#e3dbdb"
+         id="circle1655"
+         r="0"
+         style="display:inline;enable-background:new;stroke-width:0.071515;stroke-linecap:square" />
+      <circle
+         transform="matrix(0.49014038,0,0,0.49014038,131.6687,-16.579863)"
+         cx="400.57999"
+         cy="531.66998"
+         r="14.274"
+         filter="url(#o)"
+         opacity="0.25"
+         id="circle1695"
+         style="display:inline;enable-background:new" />
+      <circle
+         cx="328"
+         cy="244"
+         r="6.9960089"
+         fill="url(#m)"
+         id="circle1697"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1743);stroke-width:0.466402" />
+      <circle
+         cx="324.73523"
+         cy="243.06718"
+         fill="#e3dbdb"
+         id="circle1705"
+         r="0"
+         style="display:inline;enable-background:new;stroke-width:0.0466402;stroke-linecap:square" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;filter:url(#filter1496);enable-background:new"
-         d="m 208.00001,174 a 12,12 0 0 0 -12,12 12,12 0 0 0 12,12 12,12 0 0 0 12,-12 12,12 0 0 0 -12,-12 z M 176,190 a 12,12 0 0 0 -12,12 12,12 0 0 0 12,12 12,12 0 0 0 12,-12 12,12 0 0 0 -12,-12 z"
-         id="circle1487"
-         inkscape:connector-curvature="0" />
+         d="m -55.519507,139.47202 c -3.3137,0 -6,2.6863 -6,6 l -0.94141,7.5254 c -0.0384,0.15529 -0.0581,0.31463 -0.0586,0.47461 0,1.1046 0.89543,2 2,2 0.59429,-5.5e-4 1.1576,-0.26536 1.5371,-0.72266 l 0.002,0.004 2.8789,-3.3105 c 0.1917,0.0185 0.38548,0.0293 0.58203,0.0293 1.1777,-0.001 2.3291,-0.34898 3.3105,-1 h 5.3789 c 0.98145,0.65102 2.1328,0.99881 3.3105,1 0.19655,0 0.39033,-0.0108 0.58203,-0.0293 l 2.8789,3.3105 0.002,-0.004 c 0.37951,0.45729 0.94282,0.72211 1.5371,0.72266 1.1046,0 2,-0.89543 2,-2 -4.8e-4,-0.15998 -0.0202,-0.31932 -0.0586,-0.47461 l -0.94149,-7.5254 c 0,-3.3137 -2.6863,-6 -6,-6 h -5 -2 -5 z"
+         filter="url(#n)"
+         opacity="0.25"
+         id="path335"
+         style="display:inline;enable-background:new;stroke-width:0.1;stroke-linecap:square"
+         transform="matrix(6.9649154,0,0,6.9649154,496.89939,-871.13018)" />
       <path
-         id="path1501"
-         d="m 104,170 c -2.216,0 -4,1.784 -4,4 v 12 H 88 c -2.216,0 -4,1.784 -4,4 v 8 c 0,2.216 1.784,4 4,4 h 12 v 12 c 0,2.216 1.784,4 4,4 h 8 c 2.216,0 4,-1.784 4,-4 v -12 h 12 c 2.216,0 4,-1.784 4,-4 v -8 c 0,-2.216 -1.784,-4 -4,-4 h -12 v -12 c 0,-2.216 -1.784,-4 -4,-4 z"
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;filter:url(#filter1507);enable-background:new"
-         inkscape:connector-curvature="0" />
+         d="m 68.42123,142.07014 -6.556841,52.41377 c -0.267453,1.08158 -0.404661,2.19137 -0.408144,3.30562 0,7.69344 6.236594,13.92983 13.929831,13.92983 4.13918,-0.004 8.062586,-1.84821 10.705772,-5.03327 l 0.01393,0.0279 38.034702,-43.74802 z m 167.15797,0 -55.71932,20.89474 38.0347,43.74803 0.0139,-0.0279 c 2.64326,3.18499 6.56631,5.02936 10.70577,5.0332 7.69345,0 13.92983,-6.2366 13.92983,-13.92984 -0.003,-1.11424 -0.14069,-2.22403 -0.40814,-3.30561 z"
+         fill="url(#l)"
+         id="path337"
+         style="display:inline;enable-background:new;fill:url(#l);stroke-width:0.696492;stroke-linecap:square" />
       <path
-         inkscape:connector-curvature="0"
-         style="display:inline;opacity:1;fill:#5d5d5d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         d="m 104,168 c -2.216,0 -4,1.784 -4,4 v 12 H 88 c -2.216,0 -4,1.784 -4,4 v 8 c 0,2.216 1.784,4 4,4 h 12 v 12 c 0,2.216 1.784,4 4,4 h 8 c 2.216,0 4,-1.784 4,-4 v -12 h 12 c 2.216,0 4,-1.784 4,-4 v -8 c 0,-2.216 -1.784,-4 -4,-4 h -12 v -12 c 0,-2.216 -1.784,-4 -4,-4 z"
-         id="rect1426" />
+         d="m 110.21072,100.28064 c -23.079637,0 -41.78949,18.70986 -41.78949,41.7895 0,23.07964 18.709853,41.78949 41.78949,41.78949 8.20258,-0.007 16.22199,-2.43062 23.05735,-6.96492 h 37.46359 c 6.83571,4.5343 14.85477,6.95663 23.05735,6.96492 23.07964,0 41.78949,-18.70985 41.78949,-41.78949 0,-23.07964 -18.70985,-41.7895 -41.78949,-41.7895 H 158.96443 145.0346 Z"
+         fill="url(#j)"
+         id="path339"
+         style="display:inline;enable-background:new;fill:url(#j);stroke-width:0.696492;stroke-linecap:square" />
       <path
-         style="display:inline;opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         d="m 208.00001,172 a 12,12 0 0 0 -12,12 12,12 0 0 0 12,12 12,12 0 0 0 12,-12 12,12 0 0 0 -12,-12 z M 176,188 a 12,12 0 0 0 -12,12 12,12 0 0 0 12,12 12,12 0 0 0 12,-12 12,12 0 0 0 -12,-12 z"
-         id="path1432"
-         inkscape:connector-curvature="0" />
+         d="m 200.75462,121.17539 a 6.9649154,6.9649154 0 0 0 -6.96491,6.96492 6.9649154,6.9649154 0 0 0 6.96491,6.96491 6.9649154,6.9649154 0 0 0 6.96492,-6.96491 6.9649154,6.9649154 0 0 0 -6.96492,-6.96492 z"
+         fill="url(#e)"
+         id="path343"
+         style="display:inline;enable-background:new;fill:url(#e);stroke-width:0.696492;stroke-linecap:square" />
       <path
-         inkscape:connector-curvature="0"
-         style="display:inline;opacity:0.5;fill:#aea795;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         d="m 130,240 c -1.108,0 -2,0.892 -2,2 v 4 c 0,1.108 0.892,2 2,2 h 12 c 1.108,0 2,-0.892 2,-2 v -4 c 0,-1.108 -0.892,-2 -2,-2 z m 32,0 c -1.108,0 -2,0.892 -2,2 v 4 c 0,1.108 0.892,2 2,2 h 12 c 1.108,0 2,-0.892 2,-2 v -4 c 0,-1.108 -0.892,-2 -2,-2 z"
-         id="rect1443" />
-      <rect
-         rx="8"
-         style="display:inline;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         id="rect1511"
-         width="136"
-         height="80"
-         x="84"
-         y="66"
-         ry="8" />
-      <rect
-         y="64"
-         x="84"
-         height="80"
-         width="136"
-         id="rect1481"
-         style="display:inline;opacity:1;fill:#5d5d5d;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         ry="8"
-         rx="8" />
+         d="m 186.82479,135.10522 a 6.9649154,6.9649154 0 0 0 -6.96491,6.96492 6.9649154,6.9649154 0 0 0 6.96491,6.96491 6.9649154,6.9649154 0 0 0 6.96492,-6.96491 6.9649154,6.9649154 0 0 0 -6.96492,-6.96492 z"
+         fill="url(#c)"
+         id="path345"
+         style="display:inline;enable-background:new;fill:url(#c);stroke-width:0.696492;stroke-linecap:square" />
       <path
-         inkscape:connector-curvature="0"
-         id="path1525"
-         d="m 343.5,151 a 1.5000001,1.5 0 0 0 -1.5,1.5 1.5000001,1.5 0 0 0 1.5,1.5 1.5000001,1.5 0 0 0 1.5,-1.5 1.5000001,1.5 0 0 0 -1.5,-1.5 z m -4,2 a 1.5000001,1.5 0 0 0 -1.5,1.5 1.5000001,1.5 0 0 0 1.5,1.5 1.5000001,1.5 0 0 0 1.5,-1.5 1.5000001,1.5 0 0 0 -1.5,-1.5 z"
-         style="display:inline;opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new" />
+         d="m 214.68445,135.10522 a 6.9649154,6.9649154 0 0 0 -6.96491,6.96492 6.9649154,6.9649154 0 0 0 6.96491,6.96491 6.9649154,6.9649154 0 0 0 6.96492,-6.96491 6.9649154,6.9649154 0 0 0 -6.96492,-6.96492 z"
+         fill="url(#d)"
+         id="path347"
+         style="display:inline;enable-background:new;fill:url(#d);stroke-width:0.696492;stroke-linecap:square" />
       <path
-         id="path1527"
-         d="m 329.5,150 c -0.277,0 -0.5,0.223 -0.5,0.5 v 1.5 h -1.5 c -0.277,0 -0.5,0.223 -0.5,0.5 v 1 c 0,0.277 0.223,0.5 0.5,0.5 h 1.5 v 1.5 c 0,0.277 0.223,0.5 0.5,0.5 h 1 c 0.277,0 0.5,-0.223 0.5,-0.5 V 154 h 1.5 c 0.277,0 0.5,-0.223 0.5,-0.5 v -1 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 H 331 v -1.5 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 z"
-         style="display:inline;opacity:1;fill:#5d5d5d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         inkscape:connector-curvature="0" />
-      <rect
-         style="display:inline;opacity:1;fill:#5d5d5d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         id="rect1529"
-         width="17.999998"
-         height="10"
-         x="327"
-         y="137"
-         rx="2"
-         ry="2" />
+         d="m 200.75462,149.03505 a 6.9649154,6.9649154 0 0 0 -6.96491,6.96492 6.9649154,6.9649154 0 0 0 6.96491,6.96491 6.9649154,6.9649154 0 0 0 6.96492,-6.96491 6.9649154,6.9649154 0 0 0 -6.96492,-6.96492 z"
+         fill="url(#f)"
+         id="path349"
+         style="display:inline;enable-background:new;fill:url(#f);stroke-width:0.696492;stroke-linecap:square" />
       <path
-         style="display:inline;opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         d="m 331.50001,244.75 c -0.41421,0 -0.75,0.33579 -0.75,0.75 0,0.41421 0.33579,0.75 0.75,0.75 0.41421,0 0.75,-0.33579 0.75,-0.75 0,-0.41421 -0.33579,-0.75 -0.75,-0.75 z m -2,1 c -0.41421,0 -0.75,0.33579 -0.75,0.75 0,0.41421 0.33579,0.75 0.75,0.75 0.41421,0 0.75,-0.33579 0.75,-0.75 0,-0.41421 -0.33579,-0.75 -0.75,-0.75 z"
-         id="path1531"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ssssssssss" />
+         d="m 96.280892,121.17539 v 13.92983 H 82.351061 v 13.92983 h 13.929831 v 13.92983 h 13.929828 v -13.92983 h 13.92983 v -13.92983 h -13.92983 v -13.92983 z"
+         fill="url(#k)"
+         id="path351"
+         style="display:inline;enable-background:new;fill:url(#k);stroke-width:0.696492;stroke-linecap:square" />
       <path
-         inkscape:connector-curvature="0"
-         style="display:inline;opacity:1;fill:#5d5d5d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         d="m 325.25001,244 c -0.1385,0 -0.25,0.1115 -0.25,0.25 V 245 h -0.75 c -0.1385,0 -0.25,0.1115 -0.25,0.25 v 0.5 c 0,0.1385 0.1115,0.25 0.25,0.25 h 0.75 v 0.75 c 0,0.1385 0.1115,0.25 0.25,0.25 h 0.5 c 0.1385,0 0.25,-0.1115 0.25,-0.25 V 246 h 0.75 c 0.1385,0 0.25,-0.1115 0.25,-0.25 v -0.5 c 0,-0.1385 -0.1115,-0.25 -0.25,-0.25 h -0.75 v -0.75 c 0,-0.1385 -0.1115,-0.25 -0.25,-0.25 z"
-         id="path1533" />
-      <rect
-         y="239"
-         x="324"
-         height="4"
-         width="8"
-         id="rect1535"
-         style="display:inline;opacity:1;fill:#5d5d5d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         rx="1"
-         ry="1" />
+         d="m 131.10547,162.96488 a 13.929831,13.929831 0 0 0 -13.92983,13.92983 13.929831,13.929831 0 0 0 13.92983,13.92983 13.929831,13.929831 0 0 0 13.92983,-13.92983 13.929831,13.929831 0 0 0 -13.92983,-13.92983 z m 41.78949,0 a 13.929831,13.929831 0 0 0 -13.92983,13.92983 13.929831,13.929831 0 0 0 13.92983,13.92983 13.929831,13.929831 0 0 0 13.92983,-13.92983 13.929831,13.929831 0 0 0 -13.92983,-13.92983 z"
+         fill="url(#i)"
+         stroke-width="0.232162"
+         id="path355"
+         style="display:inline;enable-background:new;fill:url(#i);stroke-linecap:square" />
       <path
-         inkscape:connector-curvature="0"
-         style="display:inline;opacity:1;fill:#5d5d5d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         d="m 334.75001,87 c -0.4155,0 -0.75,0.3345 -0.75,0.75 V 90 h -2.25 c -0.4155,0 -0.75,0.3345 -0.75,0.75 v 1.5 c 0,0.4155 0.3345,0.75 0.75,0.75 h 2.25 v 2.25 c 0,0.4155 0.3345,0.75 0.75,0.75 h 1.5 c 0.4155,0 0.75,-0.3345 0.75,-0.75 V 93 h 2.25 c 0.4155,0 0.75,-0.3345 0.75,-0.75 v -1.5 c 0,-0.4155 -0.3345,-0.75 -0.75,-0.75 h -2.25 v -2.25 c 0,-0.4155 -0.3345,-0.75 -0.75,-0.75 z"
-         id="path1543" />
-      <rect
-         y="67"
-         x="331"
-         height="15"
-         width="26"
-         id="rect1545"
-         style="display:inline;opacity:1;fill:#5d5d5d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         rx="2"
-         ry="2" />
-      <g
-         transform="translate(-2.0000023,-2)"
-         style="display:inline;enable-background:new"
-         id="g1570">
-        <path
-           sodipodi:nodetypes="sssss"
-           inkscape:connector-curvature="0"
-           id="path1541"
-           d="m 350.99999,93 c -1.10457,0 -2,0.89543 -2,2 0,1.104569 0.89543,2 2,2 1.10458,0 2,-0.895431 2,-2 0,-1.10457 -0.89542,-2 -2,-2 z"
-           style="display:inline;opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new" />
-        <path
-           style="display:inline;opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-           d="m 355.99999,90 c -1.10457,0 -2,0.89543 -2,2 0,1.104569 0.89543,2 2,2 1.10458,0 2,-0.895431 2,-2 0,-1.10457 -0.89542,-2 -2,-2 z"
-           id="path1559"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="sssss" />
-      </g>
-      <rect
-         style="display:inline;opacity:1;fill:#5d5d5d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         id="rect1581"
-         width="12"
-         height="7"
-         x="326"
-         y="192"
-         rx="2"
-         ry="2" />
+         d="m 131.10547,169.9298 a 6.9648458,6.9648458 0 0 0 -6.96492,6.96491 6.9648458,6.9648458 0 0 0 6.96492,6.96492 6.9648458,6.9648458 0 0 0 6.96491,-6.96492 6.9648458,6.9648458 0 0 0 -6.96491,-6.96491 z m 41.78949,0 a 6.9649154,6.9649154 0 0 0 -6.96491,6.96491 6.9649154,6.9649154 0 0 0 6.96491,6.96492 6.9649154,6.9649154 0 0 0 6.96492,-6.96492 6.9649154,6.9649154 0 0 0 -6.96492,-6.96491 z"
+         fill="url(#h)"
+         stroke-width="0.696492"
+         id="path357"
+         style="display:inline;enable-background:new;fill:url(#h);stroke-linecap:square" />
       <path
-         style="display:inline;opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         d="m 337.30001,202 a 0.90000003,0.9 0 0 0 -0.9,0.9 0.90000003,0.9 0 0 0 0.9,0.9 0.90000003,0.9 0 0 0 0.9,-0.9 0.90000003,0.9 0 0 0 -0.9,-0.9 z m -2.4,1.2 a 0.90000003,0.9 0 0 0 -0.9,0.9 0.90000003,0.9 0 0 0 0.9,0.9 0.90000003,0.9 0 0 0 0.9,-0.9 0.90000003,0.9 0 0 0 -0.9,-0.9 z"
-         id="path1602"
-         inkscape:connector-curvature="0" />
+         d="m 148.51776,149.03505 c -1.92329,0 -3.48246,-1.55916 -3.48246,-3.48246 0,-1.92329 1.55917,-3.48245 3.48246,-3.48245 1.92329,0 3.48245,1.55916 3.48245,3.48245 0,1.9233 -1.55916,3.48246 -3.48245,3.48246 z m 10.44737,-6.96491 -4.9244,-4.92441 9.00563,-9.00563 -9.00563,-9.00564 4.9244,-4.9244 13.92983,13.92983 -4.9244,4.9244 z m -17.41229,-6.96492 c -1.92329,0 -3.48239,-1.55917 -3.48246,-3.48246 7e-5,-1.92329 1.55917,-3.48245 3.48246,-3.48245 1.92329,0 3.48239,1.55916 3.48246,3.48245 -7e-5,1.92329 -1.55917,3.48246 -3.48246,3.48246 z m 6.96492,-13.92983 c -1.92329,0 -3.48246,-1.55917 -3.48246,-3.48246 0,-1.92329 1.55917,-3.48246 3.48246,-3.48246 1.92329,0 3.48245,1.55917 3.48245,3.48246 0,1.92329 -1.55916,3.48246 -3.48245,3.48246 z"
+         fill="url(#g)"
+         stroke-width="0.696492"
+         id="path359"
+         style="display:inline;enable-background:new;fill:url(#g);stroke-linecap:square" />
       <path
-         inkscape:connector-curvature="0"
-         style="display:inline;opacity:1;fill:#5d5d5d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         d="m 327.25001,202 c -0.1385,0 -0.25,0.1115 -0.25,0.25 V 203 h -0.75 c -0.1385,0 -0.25,0.1115 -0.25,0.25 v 0.5 c 0,0.1385 0.1115,0.25 0.25,0.25 h 0.75 v 0.75 c 0,0.1385 0.1115,0.25 0.25,0.25 h 0.5 c 0.1385,0 0.25,-0.1115 0.25,-0.25 V 204 h 0.75 c 0.1385,0 0.25,-0.1115 0.25,-0.25 v -0.5 c 0,-0.1385 -0.1115,-0.25 -0.25,-0.25 h -0.75 v -0.75 c 0,-0.1385 -0.1115,-0.25 -0.25,-0.25 z"
-         id="path1604" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer3"
-       inkscape:label="Highlights"
-       style="display:inline">
+         d="m -55.519507,139.47202 c -3.3137,0 -6,2.6863 -6,6 l -0.94141,7.5254 c -0.0384,0.15529 -0.0581,0.31463 -0.0586,0.47461 0,1.1046 0.89543,2 2,2 0.59429,-5.5e-4 1.1576,-0.26536 1.5371,-0.72266 l 0.002,0.004 2.8789,-3.3105 c 0.1917,0.0185 0.38548,0.0293 0.58203,0.0293 1.1777,-0.001 2.3291,-0.34898 3.3105,-1 h 5.3789 c 0.98145,0.65102 2.1328,0.99881 3.3105,1 0.19655,0 0.39033,-0.0108 0.58203,-0.0293 l 2.8789,3.3105 0.002,-0.004 c 0.37951,0.45729 0.94282,0.72211 1.5371,0.72266 1.1046,0 2,-0.89543 2,-2 -4.8e-4,-0.15998 -0.0202,-0.31932 -0.0586,-0.47461 l -0.94149,-7.5254 c 0,-3.3137 -2.6863,-6 -6,-6 h -5 -2 -5 z"
+         filter="url(#n)"
+         opacity="0.25"
+         id="path1549"
+         style="display:inline;enable-background:new;stroke-width:0.1;stroke-linecap:square"
+         transform="matrix(1.4302951,0,0,1.4302951,414.79958,-126.96857)" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188,44 C 67.625152,44 63.82701,47.626029 64,82.994141 v 2 C 63.82701,49.626029 67.625152,46 102.92188,46 h 98.15624 C 236.37485,46 240,49.625608 240,84.994141 v -2 C 240,47.625608 236.37485,44 201.07812,44 Z"
-         id="path931"
-         inkscape:connector-curvature="0" />
+         d="m 326.80853,81.099354 -1.34649,10.763542 c -0.0549,0.22211 -0.0831,0.450013 -0.0838,0.678832 0,1.579903 1.28073,2.860591 2.86059,2.860591 0.85001,-8.22e-4 1.65571,-0.379544 2.19851,-1.033618 l 0.003,0.0057 7.8107,-8.983968 z m 34.32709,0 -11.44236,4.290884 7.81069,8.98397 0.003,-0.0057 c 0.54282,0.65406 1.34844,1.032815 2.19851,1.033603 1.57991,0 2.86059,-1.28073 2.86059,-2.860592 -6.2e-4,-0.228817 -0.0289,-0.45672 -0.0838,-0.67883 z"
+         fill="url(#l)"
+         id="path1551"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1591);stroke-width:0.14303;stroke-linecap:square" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92728,268 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 C 63.832405,262.37397 67.630549,266 102.92728,266 h 98.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 C 240.0054,264.37439 236.38025,268 201.08352,268 Z"
-         id="path931-8"
-         inkscape:connector-curvature="0" />
+         d="m 335.3903,72.517581 c -4.73956,0 -8.58177,3.842204 -8.58177,8.581773 0,4.739569 3.84221,8.58177 8.58177,8.58177 1.68446,-0.0014 3.33131,-0.499145 4.735,-1.430296 h 7.69341 c 1.40376,0.931151 3.05054,1.428594 4.73499,1.430296 4.73957,0 8.58177,-3.842201 8.58177,-8.58177 0,-4.739569 -3.8422,-8.581773 -8.58177,-8.581773 h -7.15147 -2.86059 z"
+         fill="url(#j)"
+         id="path1553"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1589);stroke-width:0.14303;stroke-linecap:square" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 353.98414,76.808468 a 1.4302951,1.4302951 0 0 0 -1.43029,1.430296 1.4302951,1.4302951 0 0 0 1.43029,1.430294 1.4302951,1.4302951 0 0 0 1.4303,-1.430294 1.4302951,1.4302951 0 0 0 -1.4303,-1.430296 z"
+         fill="url(#e)"
+         id="path1557"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1587);stroke-width:0.14303;stroke-linecap:square" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994)" />
+         d="m 351.12355,79.669058 a 1.4302951,1.4302951 0 0 0 -1.43029,1.430296 1.4302951,1.4302951 0 0 0 1.43029,1.430294 1.4302951,1.4302951 0 0 0 1.4303,-1.430294 1.4302951,1.4302951 0 0 0 -1.4303,-1.430296 z"
+         fill="url(#c)"
+         id="path1559"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1585);stroke-width:0.14303;stroke-linecap:square" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 356.84473,79.669058 a 1.4302951,1.4302951 0 0 0 -1.43029,1.430296 1.4302951,1.4302951 0 0 0 1.43029,1.430294 1.4302951,1.4302951 0 0 0 1.4303,-1.430294 1.4302951,1.4302951 0 0 0 -1.4303,-1.430296 z"
+         fill="url(#d)"
+         id="path1561"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1583);stroke-width:0.14303;stroke-linecap:square" />
       <path
-         transform="matrix(0.66664182,0,0,0.63636364,106.67522,94.545454)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004-8);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-1)" />
+         d="m 353.98414,82.529648 a 1.4302951,1.4302951 0 0 0 -1.43029,1.430296 1.4302951,1.4302951 0 0 0 1.43029,1.430294 1.4302951,1.4302951 0 0 0 1.4303,-1.430294 1.4302951,1.4302951 0 0 0 -1.4303,-1.430296 z"
+         fill="url(#f)"
+         id="path1563"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1581);stroke-width:0.14303;stroke-linecap:square" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971)" />
+         d="m 332.52972,76.808468 v 2.86059 h -2.8606 v 2.86059 h 2.8606 v 2.86059 h 2.86058 v -2.86059 h 2.86059 v -2.86059 h -2.86059 v -2.86059 z"
+         fill="url(#k)"
+         id="path1565"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1579);stroke-width:0.14303;stroke-linecap:square" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 336.50843,211.51174 c 4.23214,0 5.02499,-0.46371 5.00275,-4.98757 v -6.5241 -6.52423 c 0.0222,-4.52386 -0.77061,-4.98757 -5.00275,-4.98757 H 327.491 c -4.23108,0 -5.00275,0.46366 -5.00275,4.98757 v 6.52423 6.5241 c 0,4.52391 0.77167,4.98757 5.00275,4.98757 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 339.68119,85.390238 a 2.8605903,2.8605903 0 0 0 -2.86059,2.86059 2.8605903,2.8605903 0 0 0 2.86059,2.86059 2.8605903,2.8605903 0 0 0 2.86059,-2.86059 2.8605903,2.8605903 0 0 0 -2.86059,-2.86059 z m 8.58177,0 a 2.8605903,2.8605903 0 0 0 -2.86059,2.86059 2.8605903,2.8605903 0 0 0 2.86059,2.86059 2.8605903,2.8605903 0 0 0 2.86059,-2.86059 2.8605903,2.8605903 0 0 0 -2.86059,-2.86059 z"
+         fill="url(#i)"
+         stroke-width="0.0476761"
+         id="path1567"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1577);stroke-linecap:square" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983)" />
+         d="m 339.68119,86.820534 a 1.4302808,1.4302808 0 0 0 -1.4303,1.430294 1.4302808,1.4302808 0 0 0 1.4303,1.430296 1.4302808,1.4302808 0 0 0 1.43029,-1.430296 1.4302808,1.4302808 0 0 0 -1.43029,-1.430294 z m 8.58177,0 a 1.4302951,1.4302951 0 0 0 -1.43029,1.430294 1.4302951,1.4302951 0 0 0 1.43029,1.430296 1.4302951,1.4302951 0 0 0 1.4303,-1.430296 1.4302951,1.4302951 0 0 0 -1.4303,-1.430294 z"
+         fill="url(#h)"
+         stroke-width="0.14303"
+         id="path1569"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1575);stroke-linecap:square" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.08645,251.51174 c 2.89732,0 3.44011,-0.30259 3.42488,-3.25454 v -4.25716 -4.25724 c 0.0152,-2.95195 -0.52756,-3.25453 -3.42488,-3.25453 h -6.17331 c -2.8966,0 -3.42488,0.30255 -3.42488,3.25453 v 4.25724 4.25716 c 0,2.95199 0.52828,3.25454 3.42488,3.25454 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 343.25693,82.529648 c -0.39496,0 -0.71515,-0.320185 -0.71515,-0.715148 0,-0.394962 0.32019,-0.715146 0.71515,-0.715146 0.39496,0 0.71515,0.320184 0.71515,0.715146 0,0.394963 -0.32019,0.715148 -0.71515,0.715148 z m 2.14544,-1.430294 -1.01126,-1.011263 1.84937,-1.849371 -1.84937,-1.849372 1.01126,-1.011261 2.86059,2.86059 -1.01126,1.011261 z m -3.57574,-1.430296 c -0.39496,0 -0.71513,-0.320187 -0.71515,-0.715148 2e-5,-0.394962 0.32019,-0.715146 0.71515,-0.715146 0.39496,0 0.71514,0.320184 0.71515,0.715146 -1e-5,0.394961 -0.32019,0.715148 -0.71515,0.715148 z m 1.4303,-2.86059 c -0.39496,0 -0.71515,-0.320187 -0.71515,-0.715149 0,-0.394961 0.32019,-0.715148 0.71515,-0.715148 0.39496,0 0.71515,0.320187 0.71515,0.715148 0,0.394962 -0.32019,0.715149 -0.71515,0.715149 z"
+         fill="url(#g)"
+         stroke-width="0.14303"
+         id="path1571"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1573);stroke-linecap:square" />
+      <path
+         d="m -55.519507,139.47202 c -3.3137,0 -6,2.6863 -6,6 l -0.94141,7.5254 c -0.0384,0.15529 -0.0581,0.31463 -0.0586,0.47461 0,1.1046 0.89543,2 2,2 0.59429,-5.5e-4 1.1576,-0.26536 1.5371,-0.72266 l 0.002,0.004 2.8789,-3.3105 c 0.1917,0.0185 0.38548,0.0293 0.58203,0.0293 1.1777,-0.001 2.3291,-0.34898 3.3105,-1 h 5.3789 c 0.98145,0.65102 2.1328,0.99881 3.3105,1 0.19655,0 0.39033,-0.0108 0.58203,-0.0293 l 2.8789,3.3105 0.002,-0.004 c 0.37951,0.45729 0.94282,0.72211 1.5371,0.72266 1.1046,0 2,-0.89543 2,-2 -4.8e-4,-0.15998 -0.0202,-0.31932 -0.0586,-0.47461 l -0.94149,-7.5254 c 0,-3.3137 -2.6863,-6 -6,-6 h -5 -2 -5 z"
+         filter="url(#n)"
+         opacity="0.25"
+         id="path1599"
+         style="display:inline;enable-background:new;stroke-width:0.1;stroke-linecap:square"
+         transform="matrix(0.93280112,0,0,0.93280112,382.17365,10.411808)" />
+      <path
+         d="m 324.78818,146.10827 -0.87815,7.01971 c -0.0358,0.14485 -0.0542,0.29348 -0.0546,0.44271 0,1.03037 0.83526,1.86561 1.8656,1.86561 0.55436,-5.4e-4 1.07981,-0.24753 1.43381,-0.6741 l 0.002,0.004 5.09394,-5.85911 z m 22.38723,0 -7.46241,2.79841 5.09393,5.85911 0.002,-0.004 c 0.35401,0.42656 0.87942,0.67357 1.43381,0.67409 1.03037,0 1.8656,-0.83526 1.8656,-1.86561 -4e-4,-0.14922 -0.0188,-0.29786 -0.0547,-0.44271 z"
+         fill="url(#l)"
+         id="path1601"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1641);stroke-width:0.0932804;stroke-linecap:square" />
+      <path
+         d="m 330.38499,140.51147 c -3.09102,0 -5.59681,2.50578 -5.59681,5.5968 0,3.09103 2.50579,5.59681 5.59681,5.59681 1.09856,-9.1e-4 2.17259,-0.32553 3.08804,-0.9328 h 5.01744 c 0.9155,0.60727 1.98948,0.93169 3.08804,0.9328 3.09102,0 5.5968,-2.50578 5.5968,-5.59681 0,-3.09102 -2.50578,-5.5968 -5.5968,-5.5968 h -4.664 -1.86561 z"
+         fill="url(#j)"
+         id="path1603"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1639);stroke-width:0.0932804;stroke-linecap:square" />
+      <path
+         d="m 342.5114,143.30987 a 0.93280112,0.93280112 0 0 0 -0.93279,0.9328 0.93280112,0.93280112 0 0 0 0.93279,0.9328 0.93280112,0.93280112 0 0 0 0.93281,-0.9328 0.93280112,0.93280112 0 0 0 -0.93281,-0.9328 z"
+         fill="url(#e)"
+         id="path1607"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1637);stroke-width:0.0932804;stroke-linecap:square" />
+      <path
+         d="m 340.6458,145.17547 a 0.93280112,0.93280112 0 0 0 -0.9328,0.9328 0.93280112,0.93280112 0 0 0 0.9328,0.93281 0.93280112,0.93280112 0 0 0 0.93281,-0.93281 0.93280112,0.93280112 0 0 0 -0.93281,-0.9328 z"
+         fill="url(#c)"
+         id="path1609"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1635);stroke-width:0.0932804;stroke-linecap:square" />
+      <path
+         d="m 344.37701,145.17547 a 0.93280112,0.93280112 0 0 0 -0.9328,0.9328 0.93280112,0.93280112 0 0 0 0.9328,0.93281 0.93280112,0.93280112 0 0 0 0.9328,-0.93281 0.93280112,0.93280112 0 0 0 -0.9328,-0.9328 z"
+         fill="url(#d)"
+         id="path1611"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1633);stroke-width:0.0932804;stroke-linecap:square" />
+      <path
+         d="m 342.5114,147.04108 a 0.93280112,0.93280112 0 0 0 -0.93279,0.9328 0.93280112,0.93280112 0 0 0 0.93279,0.9328 0.93280112,0.93280112 0 0 0 0.93281,-0.9328 0.93280112,0.93280112 0 0 0 -0.93281,-0.9328 z"
+         fill="url(#f)"
+         id="path1613"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1631);stroke-width:0.0932804;stroke-linecap:square" />
+      <path
+         d="m 328.51939,143.30987 v 1.8656 h -1.86561 v 1.86561 h 1.86561 v 1.8656 h 1.8656 v -1.8656 h 1.8656 v -1.86561 h -1.8656 v -1.8656 z"
+         fill="url(#k)"
+         id="path1615"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1629);stroke-width:0.0932804;stroke-linecap:square" />
+      <path
+         d="m 333.18339,148.90668 a 1.8656023,1.8656023 0 0 0 -1.8656,1.8656 1.8656023,1.8656023 0 0 0 1.8656,1.8656 1.8656023,1.8656023 0 0 0 1.8656,-1.8656 1.8656023,1.8656023 0 0 0 -1.8656,-1.8656 z m 5.59681,0 a 1.8656023,1.8656023 0 0 0 -1.8656,1.8656 1.8656023,1.8656023 0 0 0 1.8656,1.8656 1.8656023,1.8656023 0 0 0 1.8656,-1.8656 1.8656023,1.8656023 0 0 0 -1.8656,-1.8656 z"
+         fill="url(#i)"
+         stroke-width="0.0310931"
+         id="path1617"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1627);stroke-linecap:square" />
+      <path
+         d="m 333.18339,149.83948 a 0.9327918,0.9327918 0 0 0 -0.9328,0.9328 0.9327918,0.9327918 0 0 0 0.9328,0.9328 0.9327918,0.9327918 0 0 0 0.9328,-0.9328 0.9327918,0.9327918 0 0 0 -0.9328,-0.9328 z m 5.59681,0 a 0.93280112,0.93280112 0 0 0 -0.9328,0.9328 0.93280112,0.93280112 0 0 0 0.9328,0.9328 0.93280112,0.93280112 0 0 0 0.9328,-0.9328 0.93280112,0.93280112 0 0 0 -0.9328,-0.9328 z"
+         fill="url(#h)"
+         stroke-width="0.0932804"
+         id="path1619"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1625);stroke-linecap:square" />
+      <path
+         d="m 335.5154,147.04108 c -0.25759,0 -0.46641,-0.20882 -0.46641,-0.46641 0,-0.25758 0.20882,-0.4664 0.46641,-0.4664 0.25758,0 0.4664,0.20882 0.4664,0.4664 0,0.25759 -0.20882,0.46641 -0.4664,0.46641 z m 1.3992,-0.93281 -0.65952,-0.65951 1.20611,-1.20612 -1.20611,-1.20611 0.65952,-0.65952 1.8656,1.86561 -0.65952,0.65951 z m -2.33201,-0.9328 c -0.25758,0 -0.46639,-0.20881 -0.4664,-0.4664 10e-6,-0.25758 0.20882,-0.4664 0.4664,-0.4664 0.25759,0 0.4664,0.20882 0.4664,0.4664 0,0.25759 -0.20881,0.4664 -0.4664,0.4664 z m 0.93281,-1.8656 c -0.25759,0 -0.46641,-0.20882 -0.46641,-0.4664 0,-0.25758 0.20882,-0.4664 0.46641,-0.4664 0.25758,0 0.4664,0.20882 0.4664,0.4664 0,0.25758 -0.20882,0.4664 -0.4664,0.4664 z"
+         fill="url(#g)"
+         stroke-width="0.0932804"
+         id="path1621"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1623);stroke-linecap:square" />
+      <path
+         d="m -55.519507,139.47202 c -3.3137,0 -6,2.6863 -6,6 l -0.94141,7.5254 c -0.0384,0.15529 -0.0581,0.31463 -0.0586,0.47461 0,1.1046 0.89543,2 2,2 0.59429,-5.5e-4 1.1576,-0.26536 1.5371,-0.72266 l 0.002,0.004 2.8789,-3.3105 c 0.1917,0.0185 0.38548,0.0293 0.58203,0.0293 1.1777,-0.001 2.3291,-0.34898 3.3105,-1 h 5.3789 c 0.98145,0.65102 2.1328,0.99881 3.3105,1 0.19655,0 0.39033,-0.0108 0.58203,-0.0293 l 2.8789,3.3105 0.002,-0.004 c 0.37951,0.45729 0.94282,0.72211 1.5371,0.72266 1.1046,0 2,-0.89543 2,-2 -4.8e-4,-0.15998 -0.0202,-0.31932 -0.0586,-0.47461 l -0.94149,-7.5254 c 0,-3.3137 -2.6863,-6 -6,-6 h -5 -2 -5 z"
+         filter="url(#n)"
+         opacity="0.25"
+         id="path1649"
+         style="display:inline;enable-background:new;stroke-width:0.1;stroke-linecap:square"
+         transform="matrix(0.71514753,0,0,0.71514753,367.41378,94.535753)" />
+      <path
+         d="m 323.41825,198.5697 -0.67325,5.38178 c -0.0274,0.11105 -0.0416,0.225 -0.0419,0.33941 0,0.78995 0.64037,1.4303 1.4303,1.4303 0.42501,-4.1e-4 0.82785,-0.18977 1.09925,-0.51681 l 0.002,0.003 3.90536,-4.49198 z m 17.16354,0 -5.72118,2.14545 3.90535,4.49199 0.002,-0.003 c 0.27141,0.32703 0.67423,0.5164 1.09926,0.5168 0.78995,0 1.43029,-0.64036 1.43029,-1.4303 -3.1e-4,-0.1144 -0.0144,-0.22836 -0.0419,-0.33941 z"
+         fill="url(#l)"
+         id="path1651"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1691);stroke-width:0.071515;stroke-linecap:square" />
+      <path
+         d="m 327.70914,194.27882 c -2.36978,0 -4.29089,1.9211 -4.29089,4.29088 0,2.36979 1.92111,4.29089 4.29089,4.29089 0.84223,-7e-4 1.66565,-0.24957 2.3675,-0.71515 h 3.8467 c 0.70188,0.46558 1.52527,0.7143 2.3675,0.71515 2.36978,0 4.29088,-1.9211 4.29088,-4.29089 0,-2.36978 -1.9211,-4.29088 -4.29088,-4.29088 h -3.57574 -1.4303 z"
+         fill="url(#j)"
+         id="path1653"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1689);stroke-width:0.071515;stroke-linecap:square" />
+      <path
+         d="m 337.00605,196.42426 a 0.71514753,0.71514753 0 0 0 -0.71514,0.71515 0.71514753,0.71514753 0 0 0 0.71514,0.71515 0.71514753,0.71514753 0 0 0 0.71516,-0.71515 0.71514753,0.71514753 0 0 0 -0.71516,-0.71515 z"
+         fill="url(#e)"
+         id="path1657"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1687);stroke-width:0.071515;stroke-linecap:square" />
+      <path
+         d="m 335.57576,197.85456 a 0.71514753,0.71514753 0 0 0 -0.71515,0.71514 0.71514753,0.71514753 0 0 0 0.71515,0.71516 0.71514753,0.71514753 0 0 0 0.71515,-0.71516 0.71514753,0.71514753 0 0 0 -0.71515,-0.71514 z"
+         fill="url(#c)"
+         id="path1659"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1685);stroke-width:0.071515;stroke-linecap:square" />
+      <path
+         d="m 338.43635,197.85456 a 0.71514753,0.71514753 0 0 0 -0.71514,0.71514 0.71514753,0.71514753 0 0 0 0.71514,0.71516 0.71514753,0.71514753 0 0 0 0.71515,-0.71516 0.71514753,0.71514753 0 0 0 -0.71515,-0.71514 z"
+         fill="url(#d)"
+         id="path1661"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1683);stroke-width:0.071515;stroke-linecap:square" />
+      <path
+         d="M 337.00605,199.28486 A 0.71514753,0.71514753 0 0 0 336.29091,200 a 0.71514753,0.71514753 0 0 0 0.71514,0.71515 0.71514753,0.71514753 0 0 0 0.71516,-0.71515 0.71514753,0.71514753 0 0 0 -0.71516,-0.71514 z"
+         fill="url(#f)"
+         id="path1663"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1681);stroke-width:0.071515;stroke-linecap:square" />
+      <path
+         d="m 326.27885,196.42426 v 1.4303 h -1.43031 v 1.4303 h 1.43031 v 1.43029 h 1.43029 v -1.43029 h 1.43029 v -1.4303 h -1.43029 v -1.4303 z"
+         fill="url(#k)"
+         id="path1665"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1679);stroke-width:0.071515;stroke-linecap:square" />
+      <path
+         d="m 329.85458,200.71515 a 1.4302951,1.4302951 0 0 0 -1.43029,1.43029 1.4302951,1.4302951 0 0 0 1.43029,1.4303 1.4302951,1.4302951 0 0 0 1.43029,-1.4303 1.4302951,1.4302951 0 0 0 -1.43029,-1.43029 z m 4.29089,0 a 1.4302951,1.4302951 0 0 0 -1.4303,1.43029 1.4302951,1.4302951 0 0 0 1.4303,1.4303 1.4302951,1.4302951 0 0 0 1.43029,-1.4303 1.4302951,1.4302951 0 0 0 -1.43029,-1.43029 z"
+         fill="url(#i)"
+         stroke-width="0.023838"
+         id="path1667"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1677);stroke-linecap:square" />
+      <path
+         d="m 329.85458,201.4303 a 0.71514038,0.71514038 0 0 0 -0.71515,0.71514 0.71514038,0.71514038 0 0 0 0.71515,0.71515 0.71514038,0.71514038 0 0 0 0.71515,-0.71515 0.71514038,0.71514038 0 0 0 -0.71515,-0.71514 z m 4.29089,0 a 0.71514753,0.71514753 0 0 0 -0.71515,0.71514 0.71514753,0.71514753 0 0 0 0.71515,0.71515 0.71514753,0.71514753 0 0 0 0.71514,-0.71515 0.71514753,0.71514753 0 0 0 -0.71514,-0.71514 z"
+         fill="url(#h)"
+         stroke-width="0.071515"
+         id="path1669"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1675);stroke-linecap:square" />
+      <path
+         d="m 331.64245,199.28486 c -0.19748,0 -0.35758,-0.1601 -0.35758,-0.35758 0,-0.19748 0.1601,-0.35758 0.35758,-0.35758 0.19748,0 0.35758,0.1601 0.35758,0.35758 0,0.19748 -0.1601,0.35758 -0.35758,0.35758 z m 1.07272,-0.71516 -0.50563,-0.50562 0.92469,-0.92469 -0.92469,-0.92469 0.50563,-0.50563 1.4303,1.4303 -0.50564,0.50563 z m -1.78787,-0.71514 c -0.19748,0 -0.35757,-0.16009 -0.35757,-0.35758 0,-0.19747 0.16009,-0.35757 0.35757,-0.35757 0.19748,0 0.35757,0.1601 0.35757,0.35757 0,0.19749 -0.16009,0.35758 -0.35757,0.35758 z m 0.71515,-1.4303 c -0.19748,0 -0.35758,-0.16009 -0.35758,-0.35757 0,-0.19748 0.1601,-0.35757 0.35758,-0.35757 0.19748,0 0.35758,0.16009 0.35758,0.35757 0,0.19748 -0.1601,0.35757 -0.35758,0.35757 z"
+         fill="url(#g)"
+         stroke-width="0.071515"
+         id="path1671"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1673);stroke-linecap:square" />
+      <path
+         d="m -55.519507,139.47202 c -3.3137,0 -6,2.6863 -6,6 l -0.94141,7.5254 c -0.0384,0.15529 -0.0581,0.31463 -0.0586,0.47461 0,1.1046 0.89543,2 2,2 0.59429,-5.5e-4 1.1576,-0.26536 1.5371,-0.72266 l 0.002,0.004 2.8789,-3.3105 c 0.1917,0.0185 0.38548,0.0293 0.58203,0.0293 1.1777,-0.001 2.3291,-0.34898 3.3105,-1 h 5.3789 c 0.98145,0.65102 2.1328,0.99881 3.3105,1 0.19655,0 0.39033,-0.0108 0.58203,-0.0293 l 2.8789,3.3105 0.002,-0.004 c 0.37951,0.45729 0.94282,0.72211 1.5371,0.72266 1.1046,0 2,-0.89543 2,-2 -4.8e-4,-0.15998 -0.0202,-0.31932 -0.0586,-0.47461 l -0.94149,-7.5254 c 0,-3.3137 -2.6863,-6 -6,-6 h -5 -2 -5 z"
+         filter="url(#n)"
+         opacity="0.25"
+         id="path1699"
+         style="display:inline;enable-background:new;stroke-width:0.1;stroke-linecap:square"
+         transform="matrix(0.46640056,0,0,0.46640056,351.09595,175.21897)" />
+      <path
+         d="m 322.40322,243.06719 -0.43908,3.50986 c -0.0179,0.0724 -0.0271,0.14674 -0.0273,0.22135 0,0.51519 0.41763,0.93281 0.9328,0.93281 0.27718,-2.7e-4 0.5399,-0.12377 0.7169,-0.33705 l 10e-4,0.002 2.54697,-2.92955 z m 11.19361,0 -3.7312,1.39921 2.54696,2.92956 10e-4,-0.002 c 0.177,0.21328 0.43971,0.33678 0.71691,0.33704 0.51518,0 0.93279,-0.41762 0.93279,-0.9328 -2e-4,-0.0746 -0.009,-0.14893 -0.0273,-0.22135 z"
+         fill="url(#l)"
+         id="path1701"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1741);stroke-width:0.0466402;stroke-linecap:square" />
+      <path
+         d="m 325.20162,240.26879 c -1.5455,0 -2.7984,1.25289 -2.7984,2.7984 0,1.54552 1.2529,2.79841 2.7984,2.79841 0.54928,-4.6e-4 1.0863,-0.16276 1.54403,-0.4664 h 2.50871 c 0.45775,0.30364 0.99474,0.46584 1.54403,0.4664 1.5455,0 2.7984,-1.25289 2.7984,-2.79841 0,-1.54551 -1.2529,-2.7984 -2.7984,-2.7984 h -2.33201 -0.9328 z"
+         fill="url(#j)"
+         id="path1703"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1739);stroke-width:0.0466402;stroke-linecap:square" />
+      <path
+         d="m 331.26483,241.66799 a 0.46640056,0.46640056 0 0 0 -0.4664,0.4664 0.46640056,0.46640056 0 0 0 0.4664,0.46641 0.46640056,0.46640056 0 0 0 0.46641,-0.46641 0.46640056,0.46640056 0 0 0 -0.46641,-0.4664 z"
+         fill="url(#e)"
+         id="path1707"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1737);stroke-width:0.0466402;stroke-linecap:square" />
+      <path
+         d="m 330.33203,242.6008 a 0.46640056,0.46640056 0 0 0 -0.4664,0.46639 0.46640056,0.46640056 0 0 0 0.4664,0.46641 0.46640056,0.46640056 0 0 0 0.4664,-0.46641 0.46640056,0.46640056 0 0 0 -0.4664,-0.46639 z"
+         fill="url(#c)"
+         id="path1709"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1735);stroke-width:0.0466402;stroke-linecap:square" />
+      <path
+         d="m 332.19763,242.6008 a 0.46640056,0.46640056 0 0 0 -0.46639,0.46639 0.46640056,0.46640056 0 0 0 0.46639,0.46641 0.46640056,0.46640056 0 0 0 0.4664,-0.46641 0.46640056,0.46640056 0 0 0 -0.4664,-0.46639 z"
+         fill="url(#d)"
+         id="path1711"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1733);stroke-width:0.0466402;stroke-linecap:square" />
+      <path
+         d="m 331.26483,243.5336 a 0.46640056,0.46640056 0 0 0 -0.4664,0.4664 0.46640056,0.46640056 0 0 0 0.4664,0.4664 0.46640056,0.46640056 0 0 0 0.46641,-0.4664 0.46640056,0.46640056 0 0 0 -0.46641,-0.4664 z"
+         fill="url(#f)"
+         id="path1713"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1731);stroke-width:0.0466402;stroke-linecap:square" />
+      <path
+         d="m 324.26883,241.66799 v 0.93281 h -0.93281 v 0.9328 h 0.93281 v 0.9328 h 0.93279 v -0.9328 h 0.9328 v -0.9328 h -0.9328 v -0.93281 z"
+         fill="url(#k)"
+         id="path1715"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1729);stroke-width:0.0466402;stroke-linecap:square" />
+      <path
+         d="m 326.60082,244.4664 a 0.93280115,0.93280115 0 0 0 -0.93279,0.9328 0.93280115,0.93280115 0 0 0 0.93279,0.9328 0.93280115,0.93280115 0 0 0 0.9328,-0.9328 0.93280115,0.93280115 0 0 0 -0.9328,-0.9328 z m 2.79841,0 a 0.93280115,0.93280115 0 0 0 -0.9328,0.9328 0.93280115,0.93280115 0 0 0 0.9328,0.9328 0.93280115,0.93280115 0 0 0 0.9328,-0.9328 0.93280115,0.93280115 0 0 0 -0.9328,-0.9328 z"
+         fill="url(#i)"
+         stroke-width="0.0155465"
+         id="path1717"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1727);stroke-linecap:square" />
+      <path
+         d="m 326.60082,244.9328 a 0.4663959,0.4663959 0 0 0 -0.4664,0.4664 0.4663959,0.4663959 0 0 0 0.4664,0.4664 0.4663959,0.4663959 0 0 0 0.46641,-0.4664 0.4663959,0.4663959 0 0 0 -0.46641,-0.4664 z m 2.79841,0 a 0.46640056,0.46640056 0 0 0 -0.4664,0.4664 0.46640056,0.46640056 0 0 0 0.4664,0.4664 0.46640056,0.46640056 0 0 0 0.4664,-0.4664 0.46640056,0.46640056 0 0 0 -0.4664,-0.4664 z"
+         fill="url(#h)"
+         stroke-width="0.0466402"
+         id="path1719"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1725);stroke-linecap:square" />
+      <path
+         d="m 327.76683,243.5336 c -0.12879,0 -0.23321,-0.10441 -0.23321,-0.2332 0,-0.12879 0.10442,-0.23321 0.23321,-0.23321 0.12879,0 0.2332,0.10442 0.2332,0.23321 0,0.12879 -0.10441,0.2332 -0.2332,0.2332 z m 0.6996,-0.46641 -0.32976,-0.32975 0.60306,-0.60306 -0.60306,-0.60306 0.32976,-0.32976 0.9328,0.93281 -0.32976,0.32976 z m -1.16601,-0.46639 c -0.12879,0 -0.23319,-0.10441 -0.23319,-0.23321 0,-0.12878 0.1044,-0.2332 0.23319,-0.2332 0.1288,0 0.2332,0.10442 0.2332,0.2332 0,0.1288 -0.1044,0.23321 -0.2332,0.23321 z m 0.46641,-0.93281 c -0.12879,0 -0.23321,-0.1044 -0.23321,-0.2332 0,-0.12879 0.10442,-0.23319 0.23321,-0.23319 0.12879,0 0.2332,0.1044 0.2332,0.23319 0,0.1288 -0.10441,0.2332 -0.2332,0.2332 z"
+         fill="url(#g)"
+         stroke-width="0.0466402"
+         id="path1721"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1723);stroke-linecap:square" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/gparted.svg
+++ b/icons/src/fullcolor/default/apps/gparted.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="gparted.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\disk.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.8284271"
-     inkscape:cx="281.07495"
-     inkscape:cy="206.65196"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="371.23106"
+     inkscape:cy="190.21172"
+     inkscape:current-layer="layer7"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -93,571 +93,47 @@
   <defs
      id="defs3">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1757">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(0,-224.97488,224.97488,0,151.99999,267.99998)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#fb7c38;stop-opacity:1"
+         stop-color="#b2b2b2"
          offset="0"
-         id="stop1753" />
+         id="stop282" />
       <stop
-         style="stop-color:#fda463;stop-opacity:1"
+         stop-color="#e9e9e9"
          offset="1"
-         id="stop1755" />
+         id="stop284" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient1751">
-      <stop
-         style="stop-color:#76c22b;stop-opacity:1"
-         offset="0"
-         id="stop1747" />
-      <stop
-         style="stop-color:#a6d74f;stop-opacity:1"
-         offset="1"
-         id="stop1749" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1734">
-      <stop
-         style="stop-color:#f22c42;stop-opacity:1"
-         offset="0"
-         id="stop1730" />
-      <stop
-         style="stop-color:#f76363;stop-opacity:1"
-         offset="1"
-         id="stop1732" />
-    </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath9430">
-      <path
-         sodipodi:nodetypes="sssssssss"
-         inkscape:connector-curvature="0"
-         id="path9432"
-         d="m 166.0625,-196 h 179.875 C 491.2348,-196 512,-175.28677 512,-30.125 v 148.25 C 512,263.28618 491.2348,284 345.9375,284 H 166.0625 C 20.7652,284 0,263.28618 0,118.125 V -30.125 C 0,-175.28677 20.7652,-196 166.0625,-196 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1082">
-      <path
-         sodipodi:nodetypes="sssssssss"
-         inkscape:connector-curvature="0"
-         id="path1084"
-         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
-         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-    </clipPath>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4346"
-       x="-0.014454287"
-       width="1.0289086"
-       y="-0.011357288"
-       height="1.0227146">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.120027"
-         id="feGaussianBlur4348" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4380"
-       x="-0.057817147"
-       width="1.1156343"
-       y="-0.045429151"
-       height="1.0908583">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="8.4801079"
-         id="feGaussianBlur4382" />
-    </filter>
-    <linearGradient
+       xlink:href="#a"
+       id="linearGradient483"
        gradientUnits="userSpaceOnUse"
-       y2="169.65668"
-       x2="4.4137931"
-       y1="386.29544"
-       x1="494.34482"
-       id="linearGradient4226"
-       xlink:href="#linearGradient876"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.957,268)" />
+       gradientTransform="matrix(0,-46.200198,46.200198,0,344,107)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient876"
-       id="linearGradient916"
+       xlink:href="#a"
+       id="linearGradient499"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05921519,0.05978336,0,313.2699,214.63635)"
-       x1="441.37936"
-       y1="240.30258"
-       x2="52.965523"
-       y2="386.30795" />
+       gradientTransform="matrix(0,-30.130565,30.130565,0,336.00002,163)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient876"
-       id="linearGradient920"
+       xlink:href="#a"
+       id="linearGradient515"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.0386186,0.03904659,0,315.4715,253.54546)"
-       x1="441.37933"
-       y1="240.28154"
-       x2="52.9655"
-       y2="401.42957" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath959">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 330.1929,133.99999 c -5.61538,0 -6.21958,0.57678 -6.19206,6.20352 v 7.79648 7.79648 c -0.0276,5.62673 0.57668,6.20351 6.19206,6.20351 h 11.615 c 5.6154,0 6.19208,-0.5767 6.19208,-6.20351 v -7.79648 -7.79648 c 0,-5.6268 -0.5767,-6.20352 -6.19208,-6.20352 z"
-         id="path961"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
+       gradientTransform="matrix(0,-23.1001,23.1001,0,332.00001,211.5)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4336-3">
-      <stop
-         style="stop-color:#5884f4;stop-opacity:1"
-         offset="0"
-         id="stop4338-8" />
-      <stop
-         id="stop4344-3"
-         offset="0.27800092"
-         style="stop-color:#5884f4;stop-opacity:1" />
-      <stop
-         style="stop-color:#2f5fdd;stop-opacity:1"
-         offset="0.27800092"
-         id="stop4346-3" />
-      <stop
-         id="stop4350-1"
-         offset="0.70735365"
-         style="stop-color:#2f5fdd;stop-opacity:1" />
-      <stop
-         id="stop4348-6"
-         offset="0.70936078"
-         style="stop-color:#234db8;stop-opacity:1" />
-      <stop
-         style="stop-color:#234db8;stop-opacity:1"
-         offset="1"
-         id="stop4340-0" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient876"
-       id="linearGradient3194"
-       x1="335.23154"
-       y1="61.500046"
-       x2="352.27026"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004-8"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient876"
-       id="linearGradient3257"
-       x1="330.0751"
-       y1="133.5"
-       x2="341.92554"
-       y2="162.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient876">
-      <stop
-         style="stop-color:#b3b3b3;stop-opacity:1"
-         offset="0"
-         id="stop872" />
-      <stop
-         style="stop-color:#d9d9d9;stop-opacity:1"
-         offset="1"
-         id="stop874" />
-    </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1205">
-      <path
-         id="path1207"
-         d="M 115.03125,44 C 42.3826,44 32,54.356615 32,126.9375 v 58.125 c 0,13.772 0.379014,25.29352 1.482422,34.9375 H 270.51758 C 271.62099,210.35602 272,198.8345 272,185.0625 v -58.125 C 272,54.356615 261.6174,44 188.96875,44 Z"
-         style="opacity:1;fill:#f1f0e9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         inkscape:connector-curvature="0" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1392">
-      <stop
-         style="stop-color:#e6e6e6;stop-opacity:1;"
-         offset="0"
-         id="stop1388" />
-      <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
-         offset="1"
-         id="stop1390" />
-    </linearGradient>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1469"
-       x="-0.039928033"
-       width="1.0798561"
-       y="-0.12065239"
-       height="1.2413048">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.3209033"
-         id="feGaussianBlur1471" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1422"
-       x="-0.06"
-       width="1.12"
-       y="-0.059999993"
-       height="1.12">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="3.75"
-         id="feGaussianBlur1424" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient980"
-       id="linearGradient982"
-       x1="152"
-       y1="124"
-       x2="152"
-       y2="236"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient980">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop976" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop978" />
-    </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath999">
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#5d5d5d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.82599998;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 152,68 c -48.60106,0 -88,39.39894 -88,88 0,48.60106 39.39894,88 88,88 48.60106,0 88,-39.39894 88,-88 0,-48.60106 -39.39894,-88 -88,-88 z"
-         id="path1001"
-         sodipodi:nodetypes="sssss" />
-    </clipPath>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1003"
-       x="-0.091250001"
-       width="1.1825"
-       y="-0.091250001"
-       height="1.1825">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.4"
-         id="feGaussianBlur1005" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1757"
-       id="linearGradient1742-0"
+       xlink:href="#a"
+       id="linearGradient531"
        gradientUnits="userSpaceOnUse"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224"
-       gradientTransform="translate(-145.6918,-12.381665)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1751"
-       id="linearGradient1371"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1734"
-       id="linearGradient1373"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient1673"
-       x1="324"
-       y1="67"
-       x2="324"
-       y2="95"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(20)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1757"
-       id="linearGradient1744"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1734"
-       id="linearGradient1746"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1751"
-       id="linearGradient1748"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient1750"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(20)"
-       x1="324"
-       y1="67"
-       x2="324"
-       y2="95" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1757"
-       id="linearGradient1784"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1734"
-       id="linearGradient1786"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1751"
-       id="linearGradient1788"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient1790"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(20)"
-       x1="324"
-       y1="67"
-       x2="324"
-       y2="95" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1757"
-       id="linearGradient1824"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1734"
-       id="linearGradient1826"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1751"
-       id="linearGradient1828"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient1830"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(20)"
-       x1="324"
-       y1="67"
-       x2="324"
-       y2="95" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1757"
-       id="linearGradient1924"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1734"
-       id="linearGradient1926"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1751"
-       id="linearGradient1928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-145.6918,-12.381665)"
-       x1="-128"
-       y1="-64"
-       x2="-192"
-       y2="-224" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1392"
-       id="linearGradient1930"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(20)"
-       x1="324"
-       y1="67"
-       x2="324"
-       y2="95" />
+       gradientTransform="matrix(0,-15.065281,15.065281,0,328.00001,251.5)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -757,7 +233,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">gparted</tspan></text>
+           id="tspan924">gparted</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -792,1115 +268,214 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86523,189 c -1.12014,0 -2.01524,0.0241 -2.79101,0.1543 -0.77577,0.13022 -1.48014,0.38763 -2.00977,0.91601 -0.52962,0.52838 -0.79079,1.23687 -0.91992,2.01367 -0.12912,0.77681 -0.15002,1.67169 -0.14453,2.79493 V 201 v 6.125 c -0.005,1.12104 0.0156,2.01529 0.14453,2.79102 0.12912,0.77681 0.39029,1.48529 0.91992,2.01367 0.52964,0.52838 1.234,0.78579 2.00977,0.91601 0.77577,0.13022 1.67087,0.1543 2.79101,0.1543 h 8.26954 c 1.12013,0 2.01264,-0.024 2.78711,-0.1543 0.77446,-0.13033 1.48001,-0.38927 2.00781,-0.91797 0.5278,-0.52869 0.78594,-1.23438 0.91601,-2.00976 C 341.97577,209.14258 342,208.24735 342,207.125 V 201 194.875 c 0,-1.12235 -0.0242,-2.01758 -0.1543,-2.79297 -0.13007,-0.77538 -0.38821,-1.48107 -0.91601,-2.00976 -0.5278,-0.5287 -1.23334,-0.78764 -2.00781,-0.91797 C 338.1474,189.02397 337.25491,189 336.13477,189 Z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         d="m 151.99999,44.00007 c -61.443175,0 -111.999955,50.55676 -111.999955,111.99996 V 251.2 c 0,9.30719 7.492797,16.79999 16.79999,16.79999 h 95.199965 c 61.4432,0 111.99996,-50.55676 111.99996,-111.99996 0,-61.4432 -50.55676,-111.99996 -111.99996,-111.99996 z"
+         fill="url(#a)"
+         id="path453"
+         style="display:inline;enable-background:new;fill:url(#a);fill-rule:nonzero;stroke-width:5.6" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
+         d="m 344,61.000017 c -12.6178,0 -22.99999,10.382192 -22.99999,22.999992 V 103.55 c 0,1.9113 1.5387,3.45 3.45,3.45 H 344 c 12.6178,0 22.99999,-10.382191 22.99999,-22.999991 0,-12.6178 -10.38219,-22.999992 -22.99999,-22.999992 z"
+         fill="url(#a)"
+         id="path287"
+         style="display:inline;fill:url(#linearGradient483);fill-rule:nonzero;stroke-width:1.15;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 330.19336,134 c -1.42096,0 -2.54883,0.0308 -3.50586,0.19141 -0.95703,0.16064 -1.79146,0.4726 -2.41211,1.09179 -0.62065,0.61919 -0.93647,1.45612 -1.0957,2.41407 -0.15924,0.95795 -0.18666,2.08705 -0.17969,3.51171 V 149 v 7.79688 c -0.007,1.42131 0.0207,2.5495 0.17969,3.50585 0.15923,0.95796 0.47505,1.79488 1.0957,2.41407 0.62065,0.61919 1.45508,0.93115 2.41211,1.09179 0.95703,0.16065 2.0849,0.19141 3.50586,0.19141 h 11.61523 c 1.42097,0 2.54669,-0.0307 3.50196,-0.19141 0.95527,-0.16075 1.78779,-0.47425 2.40625,-1.09375 0.61845,-0.6195 0.93134,-1.45363 1.09179,-2.41015 C 348.96905,159.34816 349,158.22066 349,156.79688 V 149 141.20312 c 0,-1.42378 -0.031,-2.55128 -0.19141,-3.50781 -0.16045,-0.95653 -0.47334,-1.79065 -1.09179,-2.41015 -0.61846,-0.61951 -1.45098,-0.933 -2.40625,-1.09375 C 344.35528,134.03065 343.22956,134 341.80859,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
+         d="m 336.00001,133.00001 c -8.229,0 -14.99999,6.77099 -14.99999,14.99999 v 12.75 c 0,1.2465 1.0035,2.25 2.25,2.25 h 12.74999 c 8.229,0 15,-6.771 15,-15 0,-8.229 -6.771,-14.99999 -15,-14.99999 z"
+         fill="url(#a)"
+         id="path485"
+         style="display:inline;fill:url(#linearGradient499);fill-rule:nonzero;stroke-width:0.75;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.23093,61.500047 c -2.22316,0 -3.97368,0.05118 -5.41406,0.292969 -1.44039,0.241784 -2.61905,0.695299 -3.48243,1.55664 -0.86337,0.861342 -1.31906,2.039471 -1.55859,3.480469 -0.23953,1.440999 -0.28629,3.195341 -0.27539,5.423828 V 85 97.752143 c -0.0108,2.225063 0.0361,3.978517 0.27539,5.417967 0.23953,1.441 0.69522,2.61913 1.55859,3.48047 0.86338,0.86134 2.04204,1.31486 3.48243,1.55664 1.44039,0.24179 3.1909,0.29297 5.41406,0.29297 h 17.53883 c 2.22317,0 3.97276,-0.0511 5.41017,-0.29297 1.4374,-0.24189 2.61246,-0.69694 3.47265,-1.55859 0.8602,-0.86165 1.31319,-2.03894 1.55468,-3.47852 0.24149,-1.43957 0.29297,-3.190353 0.29297,-5.417967 V 85 72.248094 c 0,-2.227614 -0.0515,-3.978392 -0.29297,-5.417969 -0.24149,-1.439576 -0.69449,-2.616863 -1.55469,-3.478516 -0.86019,-0.861652 -2.03525,-1.316704 -3.47265,-1.558593 -1.4374,-0.24189 -3.187,-0.292969 -5.41016,-0.292969 z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
+         d="m 332,188.50001 c -6.3089,0 -11.5,5.19109 -11.5,11.49999 v 9.775 c 0,0.95564 0.76935,1.725 1.725,1.725 H 332 c 6.30889,0 11.5,-5.19111 11.5,-11.5 0,-6.3089 -5.19111,-11.49999 -11.5,-11.49999 z"
+         fill="url(#a)"
+         id="path501"
+         style="display:inline;fill:url(#linearGradient515);fill-rule:nonzero;stroke-width:0.575;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path4350"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 464,514.75001 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4380);enable-background:accumulate"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.02028775;marker:none;enable-background:accumulate"
-         d="M 101.8116,42 C 65.712789,42 61.828597,45.690158 62.005519,81.689842 V 156 230.31016 C 61.828597,266.30985 65.712789,270 101.8116,270 h 100.38732 c 36.09881,0 39.80608,-3.68973 39.80608,-39.68984 V 156 81.689842 C 242.005,45.689729 238.29773,42 202.19892,42 Z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 201.07298,44 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 156 229.00647 C 240.16759,264.37459 236.36971,268 201.07298,268 H 102.91622 C 67.619504,268 63.994604,264.375 63.994604,229.00647 V 156 82.99353 C 63.994604,47.624997 67.619504,44 102.91622,44 Z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 327.636,188.49999 c -4.65703,0 -5.15812,0.47378 -5.1353,5.09575 v 6.40425 6.40426 c -0.0229,4.62196 0.47827,5.09574 5.1353,5.09574 h 8.72869 c 4.65703,0 5.1353,-0.47372 5.1353,-5.09574 v -6.40426 -6.40425 c 0,-4.62202 -0.47828,-5.09575 -5.13531,-5.09575 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.8545,236.50001 c -3.04166,0 -3.36894,0.30899 -3.35403,3.32331 v 4.17669 4.17668 c -0.0149,3.01433 0.31237,3.32332 3.35403,3.32332 h 6.29146 c 3.04167,0 3.35404,-0.30895 3.35404,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.31238,-3.32331 -3.35404,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 63.994141,156 v 73.00586 C 63.994141,264.37439 67.6193,268 102.91602,268 h 98.15625 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 156 Z"
-         id="rect4158-8"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3257);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         transform="matrix(0.66664182,0,0,0.63636364,106.67522,94.545454)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004-8);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-1)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:1.85638201;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983)"
-         transform="matrix(1.0833332,0,0,1.0714286,-27.333287,-17.428571)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 336.50849,211.51179 c 4.23214,0 5.02499,-0.46371 5.00275,-4.98757 v -6.5241 -6.52423 c 0.0222,-4.52386 -0.77061,-4.98757 -5.00275,-4.98757 h -9.01743 c -4.23108,0 -5.00275,0.46366 -5.00275,4.98757 v 6.52423 6.5241 c 0,4.52391 0.77167,4.98757 5.00275,4.98757 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.08651,251.51179 c 2.89732,0 3.44011,-0.30259 3.42488,-3.25454 v -4.25716 -4.25724 c 0.0152,-2.95195 -0.52756,-3.25453 -3.42488,-3.25453 h -6.17331 c -2.8966,0 -3.42488,0.30255 -3.42488,3.25453 v 4.25724 4.25716 c 0,2.95199 0.52828,3.25454 3.42488,3.25454 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 152,44 v 224 h 49.07227 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 156 82.994141 C 240.16713,47.626029 236.369,44 201.07227,44 Z"
-         id="rect4158-3"
-         inkscape:connector-curvature="0" />
+         d="m 328,236.50001 c -4.1145,0 -7.5,3.38549 -7.5,7.49999 v 6.375 c 0,0.62325 0.50175,1.125 1.125,1.125 H 328 c 4.11449,0 7.5,-3.38551 7.5,-7.5 0,-4.1145 -3.38551,-7.49999 -7.5,-7.49999 z"
+         fill="url(#a)"
+         id="path517"
+         style="display:inline;fill:url(#linearGradient531);fill-rule:nonzero;stroke-width:0.375;enable-background:new" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
+      <path
+         d="m 62.400025,156.00003 c 0,49.15119 40.448775,89.59997 89.599965,89.59997 V 189.60002 C 133.56482,189.60002 118.4,174.4352 118.4,156.00003 Z m 178.925555,0 c 0.0729,1.0808 0.12303,2.16718 0.15663,3.24797 0.0558,-1.08079 0.0951,-2.16717 0.11785,-3.24797 z"
+         fill="#3d3d3d"
+         id="path455"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:5.6" />
+      <path
+         d="m 88.048015,93.35285 c -16.41359,16.72158 -25.61999,39.21121 -25.64799,62.64718 H 118.4 c 0.0207,-8.77519 3.47759,-17.19202 9.62638,-23.44719 -0.13439,0.12302 -0.2631,0.25225 -0.3975,0.38096 z"
+         fill="#ffc107"
+         id="path457"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:5.6" />
+      <path
+         d="m 179.60796,175.12961 c -0.12871,0.17368 -0.26311,0.35253 -0.3975,0.52642 0.12871,-0.17937 0.26879,-0.34736 0.3975,-0.52642 z m -4.51915,5.25843 c -6.23285,5.90797 -14.49842,9.20639 -23.08882,9.21198 V 245.6 c 23.99599,-0.0155 46.2896,-9.61522 62.65276,-25.64802 z"
+         fill="#ea3225"
+         id="path459"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:5.6" />
+      <path
+         d="m 151.99999,66.40006 c -24.06319,0.0258 -47.12957,9.74961 -63.951975,26.94721 l 39.580765,39.58637 c 6.33364,-6.70323 15.1536,-10.5168 24.37121,-10.5336 18.43517,0 33.59999,15.16482 33.59999,33.59999 -0.005,9.22319 -3.80799,18.05437 -10.51117,24.38801 l 39.60317,39.60875 c 17.1976,-16.84481 26.90239,-39.92799 26.90798,-63.99676 0,-49.15119 -40.44878,-89.59997 -89.59997,-89.59997 z"
+         fill="#079140"
+         id="path461"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:5.6" />
+      <path
+         d="M 66.532825,262.02477 117.24079,197.664 c 0.72243,-0.86241 1.15921,-1.96558 1.15921,-3.16961 0,-2.69918 -2.19519,-4.89437 -4.9,-4.89437 -1.20398,0 -2.31279,0.4311 -3.16962,1.15921 l -64.355146,50.71359 c -3.740798,2.72719 -5.963998,7.13438 -5.975199,11.82715 0,8.1256 6.579999,14.70002 14.7056,14.70002 4.63679,0.0155 9.02159,-2.19519 11.82719,-5.97522 z"
+         fill="#ffffff"
+         id="path463"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:5.6" />
       <circle
-         r="5"
-         cy="243"
+         cx="152"
+         cy="156"
+         r="11.199996"
+         fill="#ffffff"
+         stroke-width="5.6"
+         id="circle465"
+         style="display:inline;enable-background:new" />
+      <path
+         d="M 325.60001,84.000009 C 325.60001,94.093557 333.90645,102.4 344,102.4 V 90.900007 c -3.78579,0 -6.9,-3.114204 -6.9,-6.899998 z m 36.74364,0 c 0.015,0.22195 0.0253,0.445046 0.0322,0.666994 0.0115,-0.221948 0.0195,-0.445044 0.0242,-0.666994 z"
+         fill="#3d3d3d"
+         id="path289"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:1.15" />
+      <path
+         d="m 330.867,71.134963 c -3.37064,3.433896 -5.26124,8.052302 -5.26699,12.865046 H 337.1 c 0.004,-1.802048 0.71415,-3.530504 1.97685,-4.815048 -0.0276,0.02526 -0.054,0.0518 -0.0816,0.07823 z"
+         fill="#ffc107"
+         id="path291"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:1.15" />
+      <path
+         d="m 349.66949,87.928405 c -0.0264,0.03567 -0.054,0.07239 -0.0816,0.108104 0.0264,-0.03684 0.0552,-0.07133 0.0816,-0.108104 z m -0.92804,1.079856 C 347.46149,90.221505 345.7641,90.898859 344,90.900007 V 102.4 c 4.92775,-0.003 9.5059,-1.97455 12.86619,-5.267002 z"
+         fill="#ea3225"
+         id="path293"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:1.15" />
+      <path
+         d="m 344,65.600015 c -4.94155,0.0053 -9.67839,2.002152 -13.133,5.533802 l 8.1282,8.129344 c 1.30066,-1.376556 3.1119,-2.1597 5.0048,-2.16315 3.78579,0 6.9,3.114204 6.9,6.899998 -10e-4,1.894048 -0.782,3.707594 -2.15855,5.008252 l 8.1328,8.133939 c 3.53165,-3.459202 5.52459,-8.199497 5.52574,-13.142191 0,-10.093548 -8.30644,-18.399994 -18.39999,-18.399994 z"
+         fill="#079140"
+         id="path295"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:1.15" />
+      <path
+         d="M 326.44871,105.77295 336.86195,92.556002 C 337.01031,92.3789 337.1,92.152357 337.1,91.9051 c 0,-0.554295 -0.4508,-1.005093 -1.00625,-1.005093 -0.24724,0 -0.47495,0.08853 -0.6509,0.238052 l -13.21579,10.414401 c -0.7682,0.56004 -1.22475,1.46509 -1.22705,2.42879 0,1.66865 1.35125,3.01875 3.0199,3.01875 0.9522,0.003 1.85265,-0.4508 2.4288,-1.22705 z"
+         fill="#ffffff"
+         id="path297"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:1.15" />
+      <circle
+         cx="344"
+         cy="84"
+         r="2.2999992"
+         fill="#ffffff"
+         stroke-width="1.15"
+         id="circle301"
+         style="display:inline;enable-background:new" />
+      <path
+         d="m 324.00002,148 c 0,6.58275 5.41724,12 11.99999,12 v -7.5 c -2.46899,0 -4.5,-2.031 -4.5,-4.5 z m 23.96324,0 c 0.01,0.14475 0.0165,0.29025 0.021,0.435 0.008,-0.14475 0.0127,-0.29025 0.0158,-0.435 z"
+         fill="#3d3d3d"
+         id="path487"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.75" />
+      <path
+         d="m 327.43501,139.60975 c -2.19824,2.2395 -3.43124,5.25151 -3.43499,8.39025 h 7.49999 c 0.003,-1.17525 0.46575,-2.3025 1.28925,-3.14025 -0.018,0.0165 -0.0352,0.0338 -0.0532,0.051 z"
+         fill="#ffc107"
+         id="path489"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.75" />
+      <path
+         d="m 339.69751,150.562 c -0.0172,0.0233 -0.0352,0.0472 -0.0532,0.0705 0.0172,-0.024 0.036,-0.0465 0.0532,-0.0705 z m -0.60525,0.70425 c -0.83475,0.79125 -1.94175,1.233 -3.09225,1.23375 v 7.5 c 3.21375,-0.002 6.1995,-1.28775 8.391,-3.435 z"
+         fill="#ea3225"
+         id="path491"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.75" />
+      <path
+         d="m 336.00001,136.00001 c -3.22275,0.004 -6.31199,1.30575 -8.565,3.609 l 5.301,5.30174 c 0.84826,-0.89775 2.0295,-1.4085 3.264,-1.41075 2.469,0 4.5,2.03101 4.5,4.5 -6.5e-4,1.23525 -0.51,2.418 -1.40775,3.26625 l 5.304,5.30475 c 2.30325,-2.256 3.603,-5.3475 3.60375,-8.571 0,-6.58275 -5.41725,-11.99999 -12,-11.99999 z"
+         fill="#079140"
+         id="path493"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.75" />
+      <path
+         d="m 324.55352,162.19975 6.79124,-8.61975 c 0.0968,-0.1155 0.15525,-0.26325 0.15525,-0.4245 0,-0.3615 -0.294,-0.6555 -0.65625,-0.6555 -0.16124,0 -0.30975,0.0577 -0.4245,0.15525 l -8.61899,6.792 c -0.501,0.36525 -0.79875,0.9555 -0.80025,1.584 0,1.08825 0.88125,1.96875 1.9695,1.96875 0.621,0.002 1.20825,-0.294 1.584,-0.80025 z"
+         fill="#ffffff"
+         id="path495"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.75" />
+      <circle
+         cx="336"
+         cy="148"
+         r="1.4999995"
+         fill="#ffffff"
+         stroke-width="0.75"
+         id="circle497"
+         style="display:inline;enable-background:new" />
+      <path
+         d="m 322.80001,200 c 0,5.04678 4.15322,9.19999 9.19999,9.19999 v -5.75 c -1.89289,0 -3.45,-1.5571 -3.45,-3.44999 z m 18.37182,0 c 0.008,0.11098 0.0127,0.22253 0.0161,0.33349 0.006,-0.11097 0.01,-0.22252 0.0121,-0.33349 z"
+         fill="#3d3d3d"
+         id="path503"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.575" />
+      <path
+         d="m 325.4335,193.56747 c -1.68532,1.71695 -2.63062,4.02615 -2.63349,6.43253 H 328.55 c 0.002,-0.90102 0.35708,-1.76526 0.98843,-2.40753 -0.0138,0.0127 -0.027,0.0259 -0.0408,0.0391 z"
+         fill="#ffc107"
+         id="path505"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.575" />
+      <path
+         d="m 334.83475,201.9642 c -0.0132,0.0179 -0.027,0.0362 -0.0408,0.054 0.0132,-0.0184 0.0276,-0.0357 0.0408,-0.054 z m -0.46402,0.53993 c -0.63998,0.60661 -1.48868,0.9453 -2.37073,0.94587 v 5.75 c 2.46388,-0.002 4.75295,-0.98727 6.4331,-2.6335 z"
+         fill="#ea3225"
+         id="path507"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.575" />
+      <path
+         d="m 332,190.8 c -2.47078,0.003 -4.83919,1.00107 -6.56651,2.7669 l 4.0641,4.06467 c 0.65033,-0.68828 1.55595,-1.07985 2.50241,-1.08158 1.89289,0 3.44999,1.55711 3.44999,3.45 -4.9e-4,0.94703 -0.391,1.8538 -1.07927,2.50413 l 4.0664,4.06697 c 1.76582,-1.7296 2.7623,-4.09975 2.76287,-6.5711 0,-5.04677 -4.15321,-9.19999 -9.19999,-9.19999 z"
+         fill="#079140"
+         id="path509"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.575" />
+      <path
+         d="m 323.22436,210.88648 5.20662,-6.60848 c 0.0742,-0.0885 0.11902,-0.20182 0.11902,-0.32545 0,-0.27715 -0.2254,-0.50255 -0.50313,-0.50255 -0.12362,0 -0.23748,0.0442 -0.32545,0.11903 l -6.60789,5.2072 c -0.3841,0.28002 -0.61237,0.73255 -0.61352,1.2144 0,0.83432 0.67562,1.50937 1.50995,1.50937 0.4761,0.002 0.92632,-0.2254 1.2144,-0.61352 z"
+         fill="#ffffff"
+         id="path511"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.575" />
+      <circle
+         cx="332"
+         cy="200"
+         r="1.1499996"
+         fill="#ffffff"
+         stroke-width="0.575"
+         id="circle513"
+         style="display:inline;enable-background:new" />
+      <path
+         d="m 322.00001,244 c 0,3.29138 2.70862,6 5.99999,6 v -3.75 c -1.23449,0 -2.25,-1.01551 -2.25,-2.25 z m 11.98162,0 c 0.005,0.0724 0.008,0.14512 0.0105,0.2175 0.004,-0.0724 0.007,-0.14513 0.008,-0.2175 z"
+         fill="#3d3d3d"
+         id="path519"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.375" />
+      <path
+         d="m 323.7175,239.80486 c -1.09912,1.11976 -1.71562,2.62576 -1.71749,4.19514 H 325.75 c 10e-4,-0.58762 0.23288,-1.15126 0.64463,-1.57014 -0.009,0.008 -0.0176,0.0169 -0.0266,0.0255 z"
+         fill="#ffc107"
+         id="path521"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.375" />
+      <path
+         d="m 329.84875,245.281 c -0.009,0.0117 -0.0176,0.0236 -0.0266,0.0352 0.009,-0.012 0.018,-0.0233 0.0266,-0.0352 z m -0.30262,0.35212 c -0.41738,0.39563 -0.97088,0.6165 -1.54613,0.61688 V 250 c 1.60688,-0.001 3.09975,-0.64387 4.1955,-1.71751 z"
+         fill="#ea3225"
+         id="path523"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.375" />
+      <path
+         d="m 328,238 c -1.61138,0.002 -3.15599,0.65287 -4.28251,1.80449 l 2.6505,2.65087 c 0.42413,-0.44887 1.01475,-0.70425 1.63201,-0.70536 1.23449,0 2.24999,1.0155 2.24999,2.25 -3.2e-4,0.61761 -0.255,1.209 -0.70387,1.63311 l 2.652,2.65238 c 1.15162,-1.128 1.8015,-2.67375 1.80187,-4.2855 0,-3.29138 -2.70861,-6 -5.99999,-5.99999 z"
+         fill="#079140"
+         id="path525"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.375" />
+      <path
+         d="m 322.27676,251.09988 3.39562,-4.30988 c 0.0484,-0.0577 0.0776,-0.13162 0.0776,-0.21225 0,-0.18075 -0.147,-0.32775 -0.32813,-0.32775 -0.0806,0 -0.15488,0.0288 -0.21225,0.0776 l -4.30949,3.396 c -0.2505,0.18262 -0.39937,0.47775 -0.40012,0.792 0,0.54412 0.44062,0.98437 0.98475,0.98437 0.3105,0.001 0.60412,-0.147 0.792,-0.40011 z"
+         fill="#ffffff"
+         id="path527"
+         style="display:inline;enable-background:new;fill-rule:nonzero;stroke-width:0.375" />
+      <circle
          cx="328"
-         id="circle1588"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.23913042;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.71739128, 0.71739128;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <circle
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#5d5d5d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.82608676;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:11.47826029, 11.47826029;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="path4238"
-         cx="152.00017"
-         cy="-139.99983"
-         transform="scale(1,-1)"
-         r="80" />
-      <path
-         transform="matrix(0.90909091,0,0,0.90909091,13.818341,-1.818182)"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient982);stroke-width:11;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1003);enable-background:accumulate"
-         d="m 152,70 c -48.60106,0 -88,39.39894 -88,88 0,48.60106 39.39894,88 88,88 48.60106,0 88,-39.39894 88,-88 0,-48.60106 -39.39894,-88 -88,-88 z"
-         id="path962"
-         clip-path="url(#clipPath999)"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sssss" />
-      <path
-         sodipodi:nodetypes="sssss"
-         inkscape:connector-curvature="0"
-         id="path1414"
-         d="m 152.00017,216.99984 c -41.42135,0 -75,-33.57864 -75,-75 0,-41.42136 33.57865,-75.000018 75,-75.000018 41.42135,0 75,33.578658 75,75.000018 0,41.42136 -33.57865,75 -75,75 z"
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter1422);enable-background:new" />
-      <circle
-         r="16"
-         cy="81"
-         cx="344.00018"
-         id="circle1507"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.78260863;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.34782591, 2.34782591;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <circle
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.47826084;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.43478257, 1.43478257;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="circle1535"
-         cx="336.00018"
-         cy="146.99998"
-         r="11" />
-      <circle
-         r="8"
-         cy="199"
-         cx="332.00018"
-         id="circle1602"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.34782606;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.04347819, 1.04347819;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <g
-         id="g1680">
-        <g
-           id="g1379"
-           transform="matrix(0.1971831,0,0,0.1971831,285.30018,50.95294)"
-           style="stroke-width:5.07143">
-          <path
-             id="path1645-3-4"
-             style="display:inline;fill:url(#linearGradient1742-0);fill-opacity:1;stroke:none;stroke-width:5.07143;enable-background:new"
-             transform="scale(-1)"
-             d="m -226.69196,-152.38152 a 71,71 0 0 1 -35.5,61.487809 71,71 0 0 1 -71,-2e-6 71,71 0 0 1 -35.5,-61.487807 h 71 z" />
-          <path
-             id="path1645-3-5-5"
-             style="display:inline;fill:url(#linearGradient1373);fill-opacity:1;stroke:none;stroke-width:5.07143;enable-background:new"
-             transform="scale(-1)"
-             d="m -368.69196,-152.38152 a 71,71 0 0 1 71,-71 v 71 z" />
-          <path
-             id="path1645-2"
-             style="display:inline;fill:url(#linearGradient1371);fill-opacity:1;stroke:none;stroke-width:5.07143;enable-background:new"
-             transform="scale(-1)"
-             d="m -247.48722,-102.17709 a 71,71 0 0 1 -100.40916,0 71,71 0 0 1 -10e-6,-100.40916 l 50.20459,50.20458 z" />
-        </g>
-        <path
-           id="path1665"
-           style="fill:url(#linearGradient1673);fill-opacity:1"
-           d="M 344,95 A 14,14 0 0 1 334.1005,90.899495 14,14 0 0 1 330,81 h 14 z" />
-      </g>
-      <g
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:5.33333349;enable-background:new;"
-         transform="matrix(0.18111109,-0.04852857,0.04852857,0.18111109,274.93213,78.003037)"
-         id="g1733">
-        <path
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:85.33333588;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 392.7526,156.91646 c 0,0 -117.99478,44.0399 -124.39639,45.7552 -6.40159,1.71532 -12.98163,-2.08367 -14.69694,-8.48526 -1.7153,-6.40159 2.08369,-12.98164 8.48528,-14.69695 6.40161,-1.71529 130.60805,-22.57299 130.60805,-22.57299 z"
-           id="path1729"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssc" />
-        <circle
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:85.33333588;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1731"
-           cx="265.24741"
-           cy="191.08354"
-           r="4" />
-      </g>
-      <g
-         id="g1709"
-         transform="matrix(0.18111109,-0.04852857,0.04852857,0.18111109,274.93213,77.003255)"
-         style="display:inline;stroke-width:5.33333349;enable-background:new"
-         inkscape:transform-center-x="-9.6330497"
-         inkscape:transform-center-y="-5.0900557">
-        <path
-           sodipodi:nodetypes="csssc"
-           inkscape:connector-curvature="0"
-           id="path1038-3"
-           d="m 392.7526,156.91646 c 0,0 -117.99478,44.0399 -124.39639,45.7552 -6.40159,1.71532 -12.98163,-2.08367 -14.69694,-8.48526 -1.7153,-6.40159 2.08369,-12.98164 8.48528,-14.69695 6.40161,-1.71529 130.60805,-22.57299 130.60805,-22.57299 z"
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:85.33333588;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <circle
-           r="4"
-           cy="191.08354"
-           cx="265.24741"
-           id="path1041-6"
-           style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:85.33333588;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
-      <path
-         sodipodi:nodetypes="csssc"
-         inkscape:connector-curvature="0"
-         id="path1467"
-         d="m 211.50536,215.83276 c 0,0 -117.99478,44.0399 -124.39638,45.7552 -6.4016,1.71532 -12.98164,-2.08367 -14.69694,-8.48526 -1.71531,-6.40159 2.08368,-12.98164 8.48528,-14.69695 6.4016,-1.71529 130.60804,-22.57299 130.60804,-22.57299 z"
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter1469);enable-background:new"
-         transform="rotate(-15,90.582512,216.7248)" />
-      <ellipse
-         ry="6.8266683"
-         rx="6.8266664"
-         cy="80.999924"
-         cx="344.00015"
-         id="ellipse1518"
-         style="display:inline;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:15.99999809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      <ellipse
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:15.99999809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="ellipse1520"
-         cx="344.00015"
-         cy="80.999924"
-         rx="4.2666664"
-         ry="4.2666674" />
-      <g
-         style="opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:4.6875"
-         id="g1546"
-         transform="matrix(0.21333333,0,0,0.21333333,311.5735,47.719997)">
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1522"
-           cx="53.63586"
-           cy="185.09996"
-           r="2"
-           transform="rotate(-30)" />
-        <circle
-           r="2"
-           cy="237.09996"
-           cx="53.63586"
-           id="circle1524"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-30)" />
-        <circle
-           r="2"
-           cy="183.63586"
-           cx="-59.099964"
-           id="circle1526"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-60)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1528"
-           cx="-59.099964"
-           cy="235.63586"
-           r="2"
-           transform="rotate(-60)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1530"
-           cx="-156"
-           cy="126"
-           r="2"
-           transform="rotate(-90)" />
-        <circle
-           r="2"
-           cy="178"
-           cx="-156"
-           id="circle1532"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-90)" />
-        <circle
-           r="2"
-           cy="27.63586"
-           cx="-211.09996"
-           id="circle1534"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-120)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1536"
-           cx="-211.09996"
-           cy="79.635864"
-           r="2"
-           transform="rotate(-120)" />
-        <circle
-           transform="rotate(-150,152,156)"
-           r="2"
-           cy="130"
-           cx="152"
-           id="circle1538"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <circle
-           transform="rotate(-150,152,156)"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1540"
-           cx="152"
-           cy="182"
-           r="2" />
-        <circle
-           r="2"
-           cy="-182"
-           cx="-152"
-           id="circle1542"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="scale(-1)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1544"
-           cx="-152"
-           cy="-130"
-           r="2"
-           transform="scale(-1)" />
-      </g>
-      <ellipse
-         ry="3.4133341"
-         rx="3.4133332"
-         cy="80.999924"
-         cx="344.00015"
-         id="ellipse1548"
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:15.99999809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      <ellipse
-         ry="0.85333353"
-         rx="0.85333329"
-         cy="81.000023"
-         cx="344.00024"
-         id="ellipse1550"
-         style="display:inline;opacity:1;fill:#888888;fill-opacity:1;stroke:none;stroke-width:15.99998379;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      <g
-         id="g1680-5"
-         style="display:inline;stroke-width:1.47368;enable-background:new"
-         transform="matrix(0.67857136,0,0,0.67857136,102.57145,92.03572)">
-        <g
-           id="g1379-9"
-           transform="matrix(0.1971831,0,0,0.1971831,285.30018,50.95294)"
-           style="stroke-width:7.47369">
-          <path
-             id="path1645-3-4-7"
-             style="display:inline;fill:url(#linearGradient1744);fill-opacity:1;stroke:none;stroke-width:7.47369;enable-background:new"
-             transform="scale(-1)"
-             d="m -226.69196,-152.38152 a 71,71 0 0 1 -35.5,61.487809 71,71 0 0 1 -71,-2e-6 71,71 0 0 1 -35.5,-61.487807 h 71 z" />
-          <path
-             id="path1645-3-5-5-7"
-             style="display:inline;fill:url(#linearGradient1746);fill-opacity:1;stroke:none;stroke-width:7.47369;enable-background:new"
-             transform="scale(-1)"
-             d="m -368.69196,-152.38152 a 71,71 0 0 1 71,-71 v 71 z" />
-          <path
-             id="path1645-2-6"
-             style="display:inline;fill:url(#linearGradient1748);fill-opacity:1;stroke:none;stroke-width:7.47369;enable-background:new"
-             transform="scale(-1)"
-             d="m -247.48722,-102.17709 a 71,71 0 0 1 -100.40916,0 71,71 0 0 1 -10e-6,-100.40916 l 50.20459,50.20458 z" />
-        </g>
-        <path
-           id="path1665-7"
-           style="fill:url(#linearGradient1750);fill-opacity:1;stroke-width:1.47368"
-           d="M 344,95 A 14,14 0 0 1 334.1005,90.899495 14,14 0 0 1 330,81 h 14 z" />
-      </g>
-      <g
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:7.61116982;enable-background:new"
-         transform="matrix(0.12411971,-0.04308758,0.04308758,0.12411971,286.79532,145.95914)"
-         id="g1745">
-        <path
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:121.77871704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 391.48498,166.76206 c 0,0 -119.46113,39.89136 -125.91875,41.382 -6.4576,1.49066 -12.90092,-2.53586 -14.39157,-8.99346 -1.49064,-6.4576 2.53588,-12.90094 8.99348,-14.39159 6.45762,-1.49063 131.31684,-17.99695 131.31684,-17.99695 z"
-           id="path1741"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssc" />
-        <circle
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:121.77871704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1743"
-           cx="265.24741"
-           cy="191.08354"
-           r="4" />
-      </g>
-      <g
-         id="g1721"
-         transform="matrix(0.13127024,-0.00551051,0.00551051,0.13127024,291.84825,134.15374)"
-         style="display:inline;stroke-width:7.61116982;enable-background:new">
-        <path
-           sodipodi:nodetypes="csssc"
-           inkscape:connector-curvature="0"
-           id="path1717"
-           d="m 381.92298,128.90588 c 0,0 -104.7647,69.9045 -110.60296,73.04098 -5.83825,3.13649 -13.1137,0.94626 -16.25017,-4.89199 -3.13647,-5.83825 -0.94625,-13.11371 4.892,-16.25019 5.83827,-3.13646 121.96113,-51.8988 121.96113,-51.8988 z"
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:121.77871704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           inkscape:transform-center-x="-6.891158"
-           inkscape:transform-center-y="-3.3061164" />
-        <circle
-           r="4"
-           cy="191.08354"
-           cx="265.24741"
-           id="circle1719"
-           style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:121.77871704;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
-      <ellipse
-         ry="4.0533342"
-         rx="4.0533333"
-         cy="146.99995"
-         cx="336.00015"
-         id="ellipse1558"
-         style="display:inline;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      <ellipse
-         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="ellipse1560"
-         cx="336.00015"
-         cy="146.99995"
-         rx="2.5333333"
-         ry="2.5333338" />
-      <g
-         style="opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:7.89474"
-         id="g1586"
-         transform="matrix(0.12666667,0,0,0.12666667,316.74684,127.24)">
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1562"
-           cx="53.63586"
-           cy="185.09996"
-           r="2"
-           transform="rotate(-30)" />
-        <circle
-           r="2"
-           cy="237.09996"
-           cx="53.63586"
-           id="circle1564"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-30)" />
-        <circle
-           r="2"
-           cy="183.63586"
-           cx="-59.099964"
-           id="circle1566"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-60)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1568"
-           cx="-59.099964"
-           cy="235.63586"
-           r="2"
-           transform="rotate(-60)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1570"
-           cx="-156"
-           cy="126"
-           r="2"
-           transform="rotate(-90)" />
-        <circle
-           r="2"
-           cy="178"
-           cx="-156"
-           id="circle1572"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-90)" />
-        <circle
-           r="2"
-           cy="27.63586"
-           cx="-211.09996"
-           id="circle1574"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-120)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1576"
-           cx="-211.09996"
-           cy="79.635864"
-           r="2"
-           transform="rotate(-120)" />
-        <circle
-           transform="rotate(-150,152,156)"
-           r="2"
-           cy="130"
-           cx="152"
-           id="circle1578"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <circle
-           transform="rotate(-150,152,156)"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1580"
-           cx="152"
-           cy="182"
-           r="2" />
-        <circle
-           r="2"
-           cy="-182"
-           cx="-152"
-           id="circle1582"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="scale(-1)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:126.316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1584"
-           cx="-152"
-           cy="-130"
-           r="2"
-           transform="scale(-1)" />
-      </g>
-      <ellipse
-         ry="2.0266671"
-         rx="2.0266666"
-         cy="146.99995"
-         cx="336.00015"
-         id="ellipse1588"
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      <ellipse
-         ry="0.50666678"
-         rx="0.50666666"
-         cy="147.00002"
-         cx="336.00021"
-         id="ellipse1590"
-         style="display:inline;fill:#888888;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      <g
-         id="g1680-1"
-         style="display:inline;stroke-width:2;enable-background:new"
-         transform="matrix(0.49999995,0,0,0.49999995,160.00003,158.49999)">
-        <g
-           id="g1379-2"
-           transform="matrix(0.1971831,0,0,0.1971831,285.30018,50.95294)"
-           style="stroke-width:10.1429">
-          <path
-             id="path1645-3-4-9"
-             style="display:inline;fill:url(#linearGradient1784);fill-opacity:1;stroke:none;stroke-width:10.1429;enable-background:new"
-             transform="scale(-1)"
-             d="m -226.69196,-152.38152 a 71,71 0 0 1 -35.5,61.487809 71,71 0 0 1 -71,-2e-6 71,71 0 0 1 -35.5,-61.487807 h 71 z" />
-          <path
-             id="path1645-3-5-5-3"
-             style="display:inline;fill:url(#linearGradient1786);fill-opacity:1;stroke:none;stroke-width:10.1429;enable-background:new"
-             transform="scale(-1)"
-             d="m -368.69196,-152.38152 a 71,71 0 0 1 71,-71 v 71 z" />
-          <path
-             id="path1645-2-9"
-             style="display:inline;fill:url(#linearGradient1788);fill-opacity:1;stroke:none;stroke-width:10.1429;enable-background:new"
-             transform="scale(-1)"
-             d="m -247.48722,-102.17709 a 71,71 0 0 1 -100.40916,0 71,71 0 0 1 -10e-6,-100.40916 l 50.20459,50.20458 z" />
-        </g>
-        <path
-           id="path1665-0"
-           style="fill:url(#linearGradient1790);fill-opacity:1;stroke-width:2"
-           d="M 344,95 A 14,14 0 0 1 334.1005,90.899495 14,14 0 0 1 330,81 h 14 z" />
-      </g>
-      <g
-         id="g1739"
-         transform="matrix(0.07853257,-0.0247671,0.0247671,0.07853257,300.44496,200.16417)"
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:12.14396286;enable-background:new">
-        <path
-           sodipodi:nodetypes="csssc"
-           inkscape:connector-curvature="0"
-           id="path1735"
-           d="m 392.7526,156.91646 c 0,0 -117.99478,44.0399 -124.39639,45.7552 -6.40159,1.71532 -12.98163,-2.08367 -14.69694,-8.48526 -1.7153,-6.40159 2.08369,-12.98164 8.48528,-14.69695 6.40161,-1.71529 130.60805,-22.57299 130.60805,-22.57299 z"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:194.30340576;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <circle
-           r="4"
-           cy="191.08354"
-           cx="265.24741"
-           id="circle1737"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:194.30340576;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      </g>
-      <g
-         style="display:inline;stroke-width:12.14396286;enable-background:new"
-         transform="matrix(0.07837764,-0.02525309,0.02525309,0.07837764,300.38139,199.34845)"
-         id="g1715"
-         inkscape:transform-center-x="-4.096619"
-         inkscape:transform-center-y="-2.432834">
-        <path
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:194.30340576;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 392.7526,156.91646 c 0,0 -117.99478,44.0399 -124.39639,45.7552 -6.40159,1.71532 -12.98163,-2.08367 -14.69694,-8.48526 -1.7153,-6.40159 2.08369,-12.98164 8.48528,-14.69695 6.40161,-1.71529 130.60805,-22.57299 130.60805,-22.57299 z"
-           id="path1711"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssc" />
-        <circle
-           style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:194.30340576;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1713"
-           cx="265.24741"
-           cy="191.08354"
-           r="4" />
-      </g>
-      <ellipse
-         style="display:inline;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="ellipse1598"
-         cx="332.00015"
-         cy="198.99997"
-         rx="2.9866664"
-         ry="2.9866672" />
-      <ellipse
-         ry="1.8666669"
-         rx="1.8666666"
-         cy="198.99997"
-         cx="332.00015"
-         id="ellipse1600"
-         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-      <g
-         id="g1627"
-         style="opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:10.7143"
-         transform="matrix(0.09333333,0,0,0.09333333,317.8135,184.44001)">
-        <circle
-           transform="rotate(-30)"
-           r="2"
-           cy="185.09996"
-           cx="53.63586"
-           id="circle1603"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <circle
-           transform="rotate(-30)"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1605"
-           cx="53.63586"
-           cy="237.09996"
-           r="2" />
-        <circle
-           transform="rotate(-60)"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1607"
-           cx="-59.099964"
-           cy="183.63586"
-           r="2" />
-        <circle
-           transform="rotate(-60)"
-           r="2"
-           cy="235.63586"
-           cx="-59.099964"
-           id="circle1609"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <circle
-           transform="rotate(-90)"
-           r="2"
-           cy="126"
-           cx="-156"
-           id="circle1611"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <circle
-           transform="rotate(-90)"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1613"
-           cx="-156"
-           cy="178"
-           r="2" />
-        <circle
-           transform="rotate(-120)"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1615"
-           cx="-211.09996"
-           cy="27.63586"
-           r="2" />
-        <circle
-           transform="rotate(-120)"
-           r="2"
-           cy="79.635864"
-           cx="-211.09996"
-           id="circle1617"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        <circle
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1619"
-           cx="152"
-           cy="130"
-           r="2"
-           transform="rotate(-150,152,156)" />
-        <circle
-           r="2"
-           cy="182"
-           cx="152"
-           id="circle1621"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           transform="rotate(-150,152,156)" />
-        <circle
-           transform="scale(-1)"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1623"
-           cx="-152"
-           cy="-182"
-           r="2" />
-        <circle
-           transform="scale(-1)"
-           r="2"
-           cy="-130"
-           cx="-152"
-           id="circle1625"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:171.429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      </g>
-      <ellipse
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="ellipse1629"
-         cx="332.00015"
-         cy="198.99997"
-         rx="1.4933332"
-         ry="1.4933336" />
-      <ellipse
-         style="display:inline;fill:#888888;fill-opacity:1;stroke:none;stroke-width:15.9999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="ellipse1631"
-         cx="332.00021"
-         cy="199.00002"
-         rx="0.37333331"
-         ry="0.37333339" />
-      <g
-         id="g1680-56"
-         style="display:inline;stroke-width:3.5;enable-background:new"
-         transform="matrix(0.28571426,0,0,0.28571426,229.71429,219.85715)">
-        <g
-           id="g1379-1"
-           transform="matrix(0.1971831,0,0,0.1971831,285.30018,50.95294)"
-           style="stroke-width:17.75">
-          <path
-             id="path1645-3-4-1"
-             style="display:inline;fill:url(#linearGradient1824);fill-opacity:1;stroke:none;stroke-width:17.75;enable-background:new"
-             transform="scale(-1)"
-             d="m -226.69196,-152.38152 a 71,71 0 0 1 -35.5,61.487809 71,71 0 0 1 -71,-2e-6 71,71 0 0 1 -35.5,-61.487807 h 71 z" />
-          <path
-             id="path1645-3-5-5-5"
-             style="display:inline;fill:url(#linearGradient1826);fill-opacity:1;stroke:none;stroke-width:17.75;enable-background:new"
-             transform="scale(-1)"
-             d="m -368.69196,-152.38152 a 71,71 0 0 1 71,-71 v 71 z" />
-          <path
-             id="path1645-2-98"
-             style="display:inline;fill:url(#linearGradient1828);fill-opacity:1;stroke:none;stroke-width:17.75;enable-background:new"
-             transform="scale(-1)"
-             d="m -247.48722,-102.17709 a 71,71 0 0 1 -100.40916,0 71,71 0 0 1 -10e-6,-100.40916 l 50.20459,50.20458 z" />
-        </g>
-        <path
-           id="path1665-4"
-           style="fill:url(#linearGradient1830);fill-opacity:1;stroke-width:3.5"
-           d="M 344,95 A 14,14 0 0 1 334.1005,90.899495 14,14 0 0 1 330,81 h 14 z" />
-      </g>
-      <g
-         style="display:inline;stroke-width:17.77777863;enable-background:new"
-         transform="matrix(0.05233474,-0.02061886,0.02061886,0.05233474,305.85292,244.29336)"
-         id="g1727"
-         inkscape:transform-center-x="-2.6475068"
-         inkscape:transform-center-y="-1.8731172">
-        <path
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:284.44445801;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 392.7526,156.91646 c 0,0 -117.99478,44.0399 -124.39639,45.7552 -6.40159,1.71532 -12.98163,-2.08367 -14.69694,-8.48526 -1.7153,-6.40159 2.08369,-12.98164 8.48528,-14.69695 6.40161,-1.71529 130.60805,-22.57299 130.60805,-22.57299 z"
-           id="path1723"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssc" />
-        <circle
-           style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:284.44445801;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1725"
-           cx="265.24741"
-           cy="191.08354"
-           r="4" />
-      </g>
-      <ellipse
-         ry="1.7066669"
-         rx="1.7066666"
-         cy="242.9998"
-         cx="328.00015"
-         id="ellipse1639"
-         style="display:inline;enable-background:new;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <ellipse
-         style="display:inline;enable-background:new;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="ellipse1641"
-         cx="328.00015"
-         cy="242.9998"
-         rx="1.0666666"
-         ry="1.0666668" />
-      <g
-         style="display:inline;enable-background:new;opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:18.75"
-         id="g1667"
-         transform="matrix(0.05333333,0,0,0.05333333,319.8935,234.67982)">
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1643"
-           cx="53.63586"
-           cy="185.09996"
-           r="2"
-           transform="rotate(-30)" />
-        <circle
-           r="2"
-           cy="237.09996"
-           cx="53.63586"
-           id="circle1645"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-30)" />
-        <circle
-           r="2"
-           cy="183.63586"
-           cx="-59.099964"
-           id="circle1647"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-60)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1649"
-           cx="-59.099964"
-           cy="235.63586"
-           r="2"
-           transform="rotate(-60)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1651"
-           cx="-156"
-           cy="126"
-           r="2"
-           transform="rotate(-90)" />
-        <circle
-           r="2"
-           cy="178"
-           cx="-156"
-           id="circle1653"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-90)" />
-        <circle
-           r="2"
-           cy="27.63586"
-           cx="-211.09996"
-           id="circle1655"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="rotate(-120)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1657"
-           cx="-211.09996"
-           cy="79.635864"
-           r="2"
-           transform="rotate(-120)" />
-        <circle
-           transform="rotate(-150,152,156)"
-           r="2"
-           cy="130"
-           cx="152"
-           id="circle1659"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <circle
-           transform="rotate(-150,152,156)"
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="circle1661"
-           cx="152"
-           cy="182"
-           r="2" />
-        <circle
-           r="2"
-           cy="-182"
-           cx="-152"
-           id="circle1663"
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           transform="scale(-1)" />
-        <circle
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:300;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1665"
-           cx="-152"
-           cy="-130"
-           r="2"
-           transform="scale(-1)" />
-      </g>
-      <ellipse
-         ry="0.85333347"
-         rx="0.85333329"
-         cy="242.9998"
-         cx="328.00015"
-         id="ellipse1669"
-         style="display:inline;enable-background:new;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <ellipse
-         ry="0.21333337"
-         rx="0.21333332"
-         cy="242.99983"
-         cx="328.00018"
-         id="ellipse1671"
-         style="display:inline;enable-background:new;fill:#888888;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <g
-         id="g1680-4"
-         style="display:inline;stroke-width:0.197183;enable-background:new"
-         transform="matrix(5.0714281,0,0,5.0714281,-1592.5713,-270.78583)">
-        <g
-           id="g1379-7"
-           transform="matrix(0.1971831,0,0,0.1971831,285.30018,50.95294)"
-           style="stroke-width:1">
-          <path
-             id="path1645-3-4-6"
-             style="display:inline;fill:url(#linearGradient1924);fill-opacity:1;stroke:none;stroke-width:1;enable-background:new"
-             transform="scale(-1)"
-             d="m -226.69196,-152.38152 a 71,71 0 0 1 -35.5,61.487809 71,71 0 0 1 -71,-2e-6 71,71 0 0 1 -35.5,-61.487807 h 71 z" />
-          <path
-             id="path1645-3-5-5-31"
-             style="display:inline;fill:url(#linearGradient1926);fill-opacity:1;stroke:none;stroke-width:1;enable-background:new"
-             transform="scale(-1)"
-             d="m -368.69196,-152.38152 a 71,71 0 0 1 71,-71 v 71 z" />
-          <path
-             id="path1645-2-7"
-             style="display:inline;fill:url(#linearGradient1928);fill-opacity:1;stroke:none;stroke-width:1;enable-background:new"
-             transform="scale(-1)"
-             d="m -247.48722,-102.17709 a 71,71 0 0 1 -100.40916,0 71,71 0 0 1 -10e-6,-100.40916 l 50.20459,50.20458 z" />
-        </g>
-        <path
-           id="path1665-5"
-           style="fill:url(#linearGradient1930);fill-opacity:1;stroke-width:0.197183"
-           d="M 344,95 A 14,14 0 0 1 334.1005,90.899495 14,14 0 0 1 330,81 h 14 z" />
-      </g>
-      <g
-         id="g1890">
-        <path
-           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           d="M 102.92188,44 C 67.625152,44 63.82701,47.626029 64,82.994141 v 2 C 63.82701,49.626029 67.625152,46 102.92188,46 h 98.15624 C 236.37485,46 240,49.625608 240,84.994141 v -2 C 240,47.625608 236.37485,44 201.07812,44 Z"
-           id="path931"
-           inkscape:connector-curvature="0" />
-        <path
-           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           d="m 102.92728,268 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 C 63.832405,262.37397 67.630549,266 102.92728,266 h 98.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 C 240.0054,264.37439 236.38025,268 201.08352,268 Z"
-           id="path931-8"
-           inkscape:connector-curvature="0" />
-        <path
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 206.6365,182.63416 c 0,0 -102.57584,73.07858 -108.315358,76.39228 -5.739513,3.31373 -13.078595,1.34723 -16.392301,-4.39228 -3.313715,-5.73951 -1.347215,-13.0786 4.392301,-16.39232 5.739521,-3.31369 120.315358,-55.60768 120.315358,-55.60768 z"
-           id="path1038"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssc" />
-        <circle
-           style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="path1041"
-           cx="24.821136"
-           cy="264.05957"
-           r="4"
-           transform="rotate(-15)" />
-        <path
-           style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 212.00017,243.99984 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
-           id="circle1473"
-           inkscape:connector-curvature="0" />
-        <path
-           inkscape:connector-curvature="0"
-           style="display:inline;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:15.99999905;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 152.00016,68.999851 c -39.21221,0 -70.99999,31.787789 -70.99999,70.999999 0,0.31752 0.01988,0.63015 0.02405,0.94667 0.509032,-38.77386 32.08126,-70.053337 70.97596,-70.053337 38.89468,0 70.4669,31.279477 70.97595,70.053337 0.004,-0.31652 0.024,-0.62915 0.024,-0.94667 0,-39.21221 -31.78778,-70.999999 -70.99999,-70.999999 z"
-           id="path1446" />
-        <path
-           style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 92.00017,59.999822 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
-           id="path2571"
-           inkscape:connector-curvature="0" />
-        <path
-           style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           d="m 212.00017,59.999822 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z"
-           id="path2569"
-           inkscape:connector-curvature="0" />
-        <ellipse
-           style="display:inline;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:15.99999809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="ellipse971"
-           cx="152.00008"
-           cy="139.99948"
-           rx="32"
-           ry="32.000008" />
-        <ellipse
-           ry="20.000004"
-           rx="20"
-           cy="139.99948"
-           cx="152.00008"
-           id="ellipse966"
-           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:15.99999905;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
-        <g
-           id="g1374"
-           style="opacity:0.1;fill:#000000;fill-opacity:1"
-           transform="translate(1.5981281e-4,-16.000173)">
-          <circle
-             transform="rotate(-30)"
-             r="2"
-             cy="185.09996"
-             cx="53.63586"
-             id="path973-2"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-          <circle
-             transform="rotate(-30)"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle975"
-             cx="53.63586"
-             cy="237.09996"
-             r="2" />
-          <circle
-             transform="rotate(-60)"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1308"
-             cx="-59.099964"
-             cy="183.63586"
-             r="2" />
-          <circle
-             transform="rotate(-60)"
-             r="2"
-             cy="235.63586"
-             cx="-59.099964"
-             id="circle1310"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-          <circle
-             transform="rotate(-90)"
-             r="2"
-             cy="126"
-             cx="-156"
-             id="circle1314"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-          <circle
-             transform="rotate(-90)"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1316"
-             cx="-156"
-             cy="178"
-             r="2" />
-          <circle
-             transform="rotate(-120)"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1320"
-             cx="-211.09996"
-             cy="27.63586"
-             r="2" />
-          <circle
-             transform="rotate(-120)"
-             r="2"
-             cy="79.635864"
-             cx="-211.09996"
-             id="circle1322"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-          <circle
-             style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-             id="circle1326"
-             cx="152"
-             cy="130"
-             r="2"
-             transform="rotate(-150,152,156)" />
-          <circle
-             r="2"
-             cy="182"
-             cx="152"
-             id="circle1328"
-             style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-             transform="rotate(-150,152,156)" />
-          <circle
-             transform="scale(-1)"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             id="circle1332"
-             cx="-152"
-             cy="-182"
-             r="2" />
-          <circle
-             transform="scale(-1)"
-             r="2"
-             cy="-130"
-             cx="-152"
-             id="circle1334"
-             style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-        </g>
-        <ellipse
-           style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:15.99999809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="ellipse1434"
-           cx="152.00008"
-           cy="139.99948"
-           rx="16"
-           ry="16.000004" />
-        <ellipse
-           style="display:inline;opacity:1;fill:#888888;fill-opacity:1;stroke:none;stroke-width:15.99998379;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-           id="ellipse1438"
-           cx="152.00052"
-           cy="139.99995"
-           rx="4"
-           ry="4.000001" />
-      </g>
+         cy="244"
+         r="0.74999964"
+         fill="#ffffff"
+         stroke-width="0.375"
+         id="circle529"
+         style="display:inline;enable-background:new" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/image-viewer.svg
+++ b/icons/src/fullcolor/default/apps/image-viewer.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="image-viewer.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\image-viewer.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="3.0714951"
-     inkscape:cx="229.52991"
-     inkscape:cy="195.83297"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="410.82904"
+     inkscape:cy="93.338095"
+     inkscape:current-layer="layer2"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -92,232 +92,319 @@
   </sodipodi:namedview>
   <defs
      id="defs3">
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4346"
-       x="-0.014454287"
-       width="1.0289086"
-       y="-0.011357288"
-       height="1.0227146">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.120027"
-         id="feGaussianBlur4348" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4380"
-       x="-0.057817147"
-       width="1.1156343"
-       y="-0.045429151"
-       height="1.0908583">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="8.4801079"
-         id="feGaussianBlur4382" />
-    </filter>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient927">
+       xlink:href="#linearGradient941"
+       id="linearGradient943"
+       x1="500"
+       y1="32.362179"
+       x2="500"
+       y2="1052.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93137255,0,0,0.93137255,-286.65103,-388.72721)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient941">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0"
-         id="stop923" />
+         id="stop937" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="1"
-         id="stop925" />
+         id="stop939" />
     </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter955"
+       x="-0.079182007"
+       width="1.158364"
+       y="-0.079182007"
+       height="1.158364">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="17.884641"
+         id="feGaussianBlur957" />
+    </filter>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="66.000679"
-       x2="344"
-       y2="102.00067"
+       xlink:href="#linearGradient4829"
+       id="linearGradient7394"
+       x1="-156.75342"
+       y1="50.380817"
+       x2="-156.75342"
+       y2="118.3975"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,344,84)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
+       gradientTransform="matrix(3.0246865,0,0,3.0246865,626.07236,-99.250948)" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="331.99966"
-       y1="191.00034"
-       x2="331.99966"
-       y2="209.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,331.99966,200)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="238.00043"
-       x2="328"
-       y2="250"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,328,244)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004-8"
-       x1="344"
-       y1="65.144272"
-       x2="344"
-       y2="102.85715"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.04758,0.95458104,0,263.81519,444.36752)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1129">
+       id="linearGradient4829">
       <stop
-         style="stop-color:#000000;stop-opacity:0"
+         style="stop-color:#f8f4fc;stop-opacity:1;"
          offset="0"
-         id="stop1123" />
+         id="stop4831" />
       <stop
-         id="stop1125"
+         style="stop-color:#d6d6d6;stop-opacity:1;"
          offset="1"
-         style="stop-color:#000000;stop-opacity:1" />
+         id="stop4833" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4657"
+       id="radialGradient6921"
+       cx="100"
+       cy="82.38073"
+       fx="100"
+       fy="82.38073"
+       r="100"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0174483,0,0,0.7641378,50.254791,70.78041)" />
+    <linearGradient
+       id="linearGradient4657">
+      <stop
+         id="stop4653"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4655"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4463"
-       inkscape:collect="always">
+       gradientTransform="matrix(0.21456216,0,0,0.21456216,42.133071,46.13327)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient849"
+       x1="520"
+       y1="4"
+       x2="520"
+       y2="1024"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient940">
       <stop
-         id="stop4465"
+         id="stop936"
          offset="0"
-         style="stop-color:#000000;stop-opacity:0" />
+         style="stop-color:#f6f7f7;stop-opacity:1" />
       <stop
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.42311791"
-         id="stop4471" />
-      <stop
-         id="stop4467"
+         id="stop938"
          offset="1"
-         style="stop-color:#000000;stop-opacity:0;" />
+         style="stop-color:#dce7f0;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="translate(4.2e-4)"
        inkscape:collect="always"
-       xlink:href="#linearGradient4463"
-       id="linearGradient1121-8"
+       xlink:href="#linearGradient940"
+       id="linearGradient4835"
+       x1="102.29776"
+       y1="-0.42686829"
+       x2="102.29776"
+       y2="199.16539"
        gradientUnits="userSpaceOnUse"
-       x1="128"
-       y1="100"
-       x2="264"
-       y2="180" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1117-7"
-       x="-0.0105"
-       width="1.021"
-       y="-0.014"
-       height="1.028">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.7"
-         id="feGaussianBlur1119-2" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1001-5"
-       x="-0.060000002"
-       width="1.12"
-       y="-0.060000002"
-       height="1.12">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.2"
-         id="feGaussianBlur1003-2" />
-    </filter>
+       gradientTransform="matrix(1.0596167,0,0,1.0596167,46.037951,50.03815)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1129"
-       id="linearGradient1091-3"
-       x1="128"
-       y1="100"
-       x2="185.54404"
-       y2="133.84943"
+       xlink:href="#linearGradient941"
+       id="linearGradient1026"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(4.2e-4,2)" />
-    <filter
+       gradientTransform="matrix(0.93137255,0,0,0.93137255,-286.65103,-388.72721)"
+       x1="500"
+       y1="32.362179"
+       x2="500"
+       y2="1052.3622" />
+    <linearGradient
        inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1101-7"
-       x="-0.14"
-       width="1.28"
-       y="-0.18334825"
-       height="1.3666965">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="7"
-         id="feGaussianBlur1103-1" />
-    </filter>
-    <filter
+       xlink:href="#linearGradient4829"
+       id="linearGradient1028"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62114091,0,0,0.62114091,441.35412,31.582396)"
+       x1="-156.75342"
+       y1="50.380817"
+       x2="-156.75342"
+       y2="118.3975" />
+    <radialGradient
        inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1027"
-       x="-0.024012256"
-       width="1.0480245"
-       y="-0.023987756"
-       height="1.0479755">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.5307812"
-         id="feGaussianBlur1029" />
-    </filter>
+       xlink:href="#linearGradient4657"
+       id="radialGradient1030"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20894028,0,0,0.15692116,323.10589,66.499546)"
+       cx="100"
+       cy="82.38073"
+       fx="100"
+       fy="82.38073"
+       r="100" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient1032"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04406187,0,0,0.04406187,321.43804,61.43808)"
+       x1="520"
+       y1="4"
+       x2="520"
+       y2="1024" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient1034"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21759987,0,0,0.21759987,322.23993,62.239975)"
+       x1="102.29776"
+       y1="-0.42686829"
+       x2="102.29776"
+       y2="199.16539" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient941"
+       id="linearGradient1096"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93137255,0,0,0.93137255,-286.65103,-388.72721)"
+       x1="500"
+       y1="32.362179"
+       x2="500"
+       y2="1052.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4829"
+       id="linearGradient1098"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40509187,0,0,0.40509187,399.6374,113.87101)"
+       x1="-156.75342"
+       y1="50.380817"
+       x2="-156.75342"
+       y2="118.3975" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4657"
+       id="radialGradient1100"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13626541,0,0,0.1023399,322.519,136.64306)"
+       cx="100"
+       cy="82.38073"
+       fx="100"
+       fy="82.38073"
+       r="100" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient1102"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.028736,0,0,0.028736,321.43127,133.34211)"
+       x1="520"
+       y1="4"
+       x2="520"
+       y2="1024" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient1104"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.14191297,0,0,0.14191297,321.95424,133.86508)"
+       x1="102.29776"
+       y1="-0.42686829"
+       x2="102.29776"
+       y2="199.16539" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient941"
+       id="linearGradient1166"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93137255,0,0,0.93137255,-286.65103,-388.72721)"
+       x1="500"
+       y1="32.362179"
+       x2="500"
+       y2="1052.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4829"
+       id="linearGradient1168"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31057046,0,0,0.31057046,380.78868,173.83444)"
+       x1="-156.75342"
+       y1="50.380817"
+       x2="-156.75342"
+       y2="118.3975" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4657"
+       id="radialGradient1170"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.10447013,0,0,0.07846058,321.66456,191.29302)"
+       cx="100"
+       cy="82.38073"
+       fx="100"
+       fy="82.38073"
+       r="100" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient1172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02203093,0,0,0.02203093,320.83064,188.76229)"
+       x1="520"
+       y1="4"
+       x2="520"
+       y2="1024" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient1174"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.10879993,0,0,0.10879993,321.23158,189.16323)"
+       x1="102.29776"
+       y1="-0.42686829"
+       x2="102.29776"
+       y2="199.16539" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient941"
+       id="linearGradient1236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93137255,0,0,0.93137255,-286.65103,-388.72721)"
+       x1="500"
+       y1="32.362179"
+       x2="500"
+       y2="1052.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4829"
+       id="linearGradient1238"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20254585,0,0,0.20254585,359.7454,226.90733)"
+       x1="-156.75342"
+       y1="50.380817"
+       x2="-156.75342"
+       y2="118.3975" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4657"
+       id="radialGradient1240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06813268,0,0,0.05116994,321.1862,238.29336)"
+       cx="100"
+       cy="82.38073"
+       fx="100"
+       fy="82.38073"
+       r="100" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient1242"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.014368,0,0,0.014368,320.64234,236.64288)"
+       x1="520"
+       y1="4"
+       x2="520"
+       y2="1024" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient1244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07095647,0,0,0.07095647,320.90383,236.90436)"
+       x1="102.29776"
+       y1="-0.42686829"
+       x2="102.29776"
+       y2="199.16539" />
   </defs>
   <metadata
      id="metadata4">
@@ -417,7 +504,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">image-viewer-app</tspan></text>
+           id="tspan924">image-viewer-app</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -452,566 +539,964 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 343.99961,196.86562 c 0,-1.12014 -0.0241,-2.01524 -0.1543,-2.79101 -0.13022,-0.77577 -0.38763,-1.48014 -0.91601,-2.00977 -0.52838,-0.52962 -1.23687,-0.79079 -2.01367,-0.91992 -0.77681,-0.12912 -1.67169,-0.15002 -2.79493,-0.14453 h -6.12109 -6.125 c -1.12104,-0.005 -2.01529,0.0156 -2.79102,0.14453 -0.77681,0.12912 -1.48529,0.39029 -2.01367,0.91992 -0.52838,0.52964 -0.78579,1.234 -0.91601,2.00977 -0.13022,0.77577 -0.1543,1.67087 -0.1543,2.79101 v 8.26954 c 0,1.12013 0.024,2.01264 0.1543,2.78711 0.13033,0.77446 0.38927,1.48001 0.91797,2.00781 0.52869,0.5278 1.23438,0.78594 2.00976,0.91601 0.77539,0.13007 1.67062,0.1543 2.79297,0.1543 h 6.125 6.125 c 1.12235,0 2.01758,-0.0242 2.79297,-0.1543 0.77538,-0.13007 1.48107,-0.38821 2.00976,-0.91601 0.5287,-0.5278 0.78764,-1.23334 0.91797,-2.00781 0.13033,-0.77448 0.1543,-1.66697 0.1543,-2.78711 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.49972,241.59598 c 0,-0.71904 -0.0139,-1.30185 -0.10352,-1.83593 -0.0897,-0.53409 -0.27628,-1.0683 -0.68359,-1.47657 -0.4073,-0.40826 -0.94323,-0.59657 -1.47851,-0.68554 -0.53529,-0.089 -1.12048,-0.10119 -1.8418,-0.0977 h -2.89258 -3.89844 c -0.71816,-0.003 -1.30235,0.009 -1.83594,0.0977 -0.53528,0.089 -1.07121,0.27727 -1.47851,0.68554 -0.40731,0.40827 -0.59394,0.94248 -0.68359,1.47657 -0.0897,0.53408 -0.10352,1.11689 -0.10352,1.83593 v 5.8086 c 0,0.71904 0.0137,1.30058 0.10352,1.83398 0.0898,0.53341 0.27792,1.06768 0.68554,1.47461 0.40762,0.40693 0.94271,0.59404 1.47656,0.68359 0.53386,0.0896 1.11551,0.10352 1.83594,0.10352 h 3.89844 2.89844 c 0.72043,0 1.30208,-0.014 1.83594,-0.10352 0.53385,-0.0895 1.06894,-0.27666 1.47656,-0.68359 0.40762,-0.40693 0.59578,-0.9412 0.68554,-1.47461 0.0898,-0.5334 0.10352,-1.11494 0.10352,-1.83398 z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 350.99951,143.19385 c 0,-1.42096 -0.0308,-2.54883 -0.19141,-3.50586 -0.16064,-0.95703 -0.4726,-1.79146 -1.09179,-2.41211 -0.61919,-0.62065 -1.45612,-0.93647 -2.41407,-1.0957 -0.95795,-0.15924 -2.08705,-0.18666 -3.51171,-0.17969 h -7.79102 -7.79688 c -1.42131,-0.007 -2.5495,0.0207 -3.50585,0.17969 -0.95796,0.15923 -1.79488,0.47505 -2.41407,1.0957 -0.61919,0.62065 -0.93115,1.45508 -1.09179,2.41211 -0.16065,0.95703 -0.19141,2.0849 -0.19141,3.50586 v 11.61523 c 0,1.42097 0.0307,2.54669 0.19141,3.50196 0.16075,0.95527 0.47425,1.78779 1.09375,2.40625 0.6195,0.61845 1.45363,0.93134 2.41015,1.09179 0.95653,0.16046 2.08403,0.19141 3.50781,0.19141 h 7.79688 7.79688 c 1.42378,0 2.55128,-0.031 3.50781,-0.19141 0.95653,-0.16045 1.79065,-0.47334 2.41015,-1.09179 0.61951,-0.61846 0.933,-1.45098 1.09375,-2.40625 0.16076,-0.95527 0.19141,-2.08099 0.19141,-3.50196 z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 367.49969,76.231427 c 0,-2.22316 -0.0512,-3.97368 -0.29297,-5.41406 -0.24178,-1.44039 -0.69529,-2.61905 -1.55664,-3.48243 -0.86134,-0.86337 -2.03947,-1.31906 -3.48046,-1.55859 -1.441,-0.23953 -3.19535,-0.28629 -5.42383,-0.27539 H 343.99974 331.2476 c -2.22507,-0.0108 -3.97852,0.0361 -5.41797,0.27539 -1.441,0.23953 -2.61913,0.69522 -3.48047,1.55859 -0.86134,0.86338 -1.31486,2.04204 -1.55664,3.48243 -0.24179,1.44039 -0.29297,3.1909 -0.29297,5.41406 v 17.53883 c 0,2.22317 0.0511,3.97276 0.29297,5.41017 0.24189,1.437403 0.69694,2.612463 1.55859,3.472653 0.86165,0.8602 2.03894,1.31319 3.47852,1.55468 1.43957,0.24149 3.19035,0.29297 5.41797,0.29297 h 12.75214 12.75191 c 2.22761,0 3.97839,-0.0515 5.41797,-0.29297 1.43957,-0.24149 2.61686,-0.69449 3.47851,-1.55469 0.86165,-0.86019 1.31671,-2.03525 1.55859,-3.472653 0.24189,-1.4374 0.29297,-3.187 0.29297,-5.41016 z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0,0.5,-0.5,0,300.9973,13.002698)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path4350"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 464,514.75001 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4380);enable-background:accumulate"
-         transform="matrix(0,0.5,-0.5,0,300.9973,13.002698)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.02028775;marker:none;enable-background:accumulate"
-         d="m 266.0025,105.8091 c 0,-36.098811 -3.69016,-39.983003 -39.68984,-39.806081 H 152.0025 77.69234 C 41.69265,65.826097 38.0025,69.710289 38.0025,105.8091 v 100.38732 c 0,36.09881 3.68973,39.80608 39.68984,39.80608 h 74.31016 74.31016 c 36.00011,0 39.68984,-3.70727 39.68984,-39.80608 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f1f0e9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 366.50065,75.231076 c 0,-8.23154 -0.90635,-9.77365 -9.74838,-9.7304 H 344.0007 331.24889 c -8.84203,-0.0433 -9.74838,1.49886 -9.74838,9.7304 v 17.53897 c 0,8.229494 0.90625,9.730394 9.74838,9.730394 h 12.75181 12.75157 c 8.84213,0 9.74838,-1.5009 9.74838,-9.730404 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f1f0e9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 263.9973,205.07568 c 0,35.29673 -3.62542,39.09461 -38.99353,38.92162 H 151.9973 78.99083 C 43.62271,244.17029 39.9973,240.37241 39.9973,205.07568 v -98.15676 c 0,-35.296716 3.625,-38.921616 38.99353,-38.921616 h 73.00647 73.00647 c 35.36853,0 38.99353,3.6249 38.99353,38.921616 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 343.49998,195.636 c 0,-4.65703 -0.47377,-5.15811 -5.09574,-5.13529 h -6.40426 -6.40425 c -4.62197,-0.0229 -5.09574,0.47826 -5.09574,5.13529 v 8.7287 c 0,4.65703 0.47371,5.13529 5.09574,5.13529 h 6.40425 6.40426 c 4.62202,0 5.09574,-0.47827 5.09574,-5.1353 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f1f0e9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f1f0e9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.50001,240.8545 c 0,-3.04166 -0.30899,-3.36894 -3.32331,-3.35403 h -4.17669 -4.17669 c -3.01432,-0.0149 -3.32331,0.31237 -3.32331,3.35403 v 6.29146 c 0,3.04167 0.30895,3.35404 3.32331,3.35404 h 4.17669 4.17669 c 3.01435,0 3.32331,-0.31238 3.32331,-3.35404 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f1f0e9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 350.50001,142.07508 c 0,-5.56175 -0.58409,-6.6037 -6.28227,-6.57447 h -8.21765 -8.21781 c -5.69818,-0.0293 -6.28227,1.01272 -6.28227,6.57447 v 11.85044 c 0,5.56037 0.58403,6.57447 6.28227,6.57447 h 8.21781 8.21765 c 5.69824,0 6.28227,-1.0141 6.28227,-6.57447 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer6"
-       inkscape:label="Pictograms"
-       style="display:inline">
-      <path
-         style="display:inline;opacity:1;fill:#aea795;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 321.52539 94 C 321.64039 101.08643 322.89491 102.5 331.24805 102.5 L 344 102.5 L 356.75195 102.5 C 365.1051 102.5 366.36156 101.08646 366.47656 94 L 321.52539 94 z "
-         id="path1082-8" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 353.12109 65.5 L 333.75391 102.5 L 344 102.5 L 356.75195 102.5 C 365.59408 102.5 366.5 100.99904 366.5 92.769531 L 366.5 75.230469 C 366.5 66.998929 365.59398 65.45675 356.75195 65.5 L 353.12109 65.5 z "
-         id="path4390-1-6" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#dad9ce;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 344.86914 65.5 L 330 94 L 339 94 L 353.86914 65.5 L 344.86914 65.5 z "
-         id="rect4248-2-0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 353.86914 65.5 L 339 94 L 352.5 94 L 365.76562 68.574219 C 364.73403 66.076814 362.31355 65.472796 356.75195 65.5 L 353.86914 65.5 z "
-         id="path4266-7-6" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1181-5"
-         d="m 355.50042,72.5 a 4.5,4.5 0 0 0 -4.5,4.5 4.5,4.5 0 0 0 4.5,4.5 4.5,4.5 0 0 0 4.5,-4.5 4.5,4.5 0 0 0 -4.5,-4.5 z M 338.93206,77.820312 330.00042,95 h 17.86328 4.63672 l -6.75,-12.9375 -2.31055,4.427734 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#dad9ce;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 365.76562 68.574219 L 352.5 94 L 361.5 94 L 366.5 84.416016 L 366.5 75.230469 C 366.5 72.176529 366.3741 70.047281 365.76562 68.574219 z "
-         id="path1051-0-3" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path4244-2-6-1"
-         d="M 330.00042,94 338.93199,76.819702 347.86356,94 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="m 339.00042,94 6.75,-12.9375 6.75,12.9375 z"
-         id="path4246-6-0-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <circle
-         style="opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="path1076-6-5"
-         cx="355.50043"
-         cy="76"
-         r="4.5" />
-      <path
-         style="display:inline;opacity:1;fill:#aea795;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 321.52148 155 C 321.62048 159.57637 322.49219 160.5 327.7832 160.5 L 336 160.5 L 344.2168 160.5 C 349.50781 160.5 350.37952 159.57637 350.47852 155 L 321.52148 155 z "
-         id="path1094-8" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 343.16797 135.5 L 330.08203 160.5 L 336 160.5 L 344.2168 160.5 C 349.91504 160.5 350.5 159.48615 350.5 153.92578 L 350.5 142.07422 C 350.5 136.51247 349.91498 135.47077 344.2168 135.5 L 343.16797 135.5 z "
-         id="path1023-4" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#dad9ce;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 337.17383 135.5 L 327 155 L 333 155 L 343.17383 135.5 L 337.17383 135.5 z "
-         id="path1026-5" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 343.17383 135.5 L 333 155 L 342 155 L 350.34961 138.99805 C 349.96838 136.12769 348.63347 135.47734 344.2168 135.5 L 343.17383 135.5 z "
-         id="path1028-2" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#dad9ce;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 350.34961 138.99805 L 342 155 L 348 155 L 350.5 150.20703 L 350.5 142.07422 C 350.5 140.8234 350.46022 139.83088 350.34961 138.99805 z "
-         id="path1030-5" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f2f2f2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="M 327.00042,155 332.95481,143.54646 338.90919,155 Z"
-         id="path1032-3"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path1034-1"
-         d="m 333.00042,155 4.5,-8.625 4.5,8.625 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="m 344.00042,141 a 3,3 0 0 0 -3,3 3,3 0 0 0 3,3 3,3 0 0 0 3,-3 3,3 0 0 0 -3,-3 z M 332.9555,144.54688 327.00042,156 h 11.9082 3.0918 l -4.5,-8.625 -1.54102,2.95312 z"
-         id="path1195-7" />
-      <circle
-         r="3"
-         cy="143"
-         cx="344.00043"
-         id="circle1036-7"
-         style="opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         id="path1188-0"
-         d="m 344.00042,140 a 3,3 0 0 0 -3,3 3,3 0 0 0 3,3 3,3 0 0 0 3,-3 3,3 0 0 0 -3,-3 z M 332.9555,143.54688 327.00042,155 h 11.9082 3.0918 l -4.5,-8.625 -1.54102,2.95312 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;opacity:1;fill:#aea795;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 320.55469 205 C 320.66389 206.86817 320.96706 208.11118 321.64844 208.93945 C 322.39425 209.40915 323.61046 209.5 325.5957 209.5 L 332 209.5 L 338.4043 209.5 C 340.39079 209.5 341.60783 209.40993 342.35352 208.93945 C 343.03447 208.11118 343.33615 206.86763 343.44531 205 L 320.55469 205 z "
-         id="path1099-4" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 337.06055 190.5 L 327.11523 209.5 L 332 209.5 L 338.4043 209.5 C 343.02632 209.5 343.5 209.02226 343.5 204.36523 L 343.5 195.63672 C 343.5 190.97969 343.02627 190.47718 338.4043 190.5 L 337.06055 190.5 z "
-         id="path1040-2" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#dad9ce;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 332.56445 190.5 L 325 205 L 329.5 205 L 337.06445 190.5 L 332.56445 190.5 z "
-         id="path1042-0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 337.06445 190.5 L 329.5 205 L 336.25 205 L 343.08008 191.91016 C 342.52273 190.67557 341.25321 190.48593 338.4043 190.5 L 337.06445 190.5 z "
-         id="path1044-5" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="m 337.75043,194.75001 a 2.2500001,2.2500001 0 0 0 -2.25,2.25 2.2500001,2.2500001 0 0 0 2.25,2.25 2.2500001,2.2500001 0 0 0 2.25,-2.25 2.2500001,2.2500001 0 0 0 -2.25,-2.25 z m -8.28516,2.66016 -4.46484,8.58984 h 8.93164 2.31836 l -3.375,-6.46875 -1.15625,2.21484 z"
-         id="path1197-1"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#dad9ce;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 343.08008 191.91016 L 336.25 205 L 340.75 205 L 343.5 199.72852 L 343.5 195.63672 C 343.5 193.85021 343.42695 192.67852 343.08008 191.91016 z "
-         id="path1046-0" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path1048-7"
-         d="m 325.00042,205 4.46579,-8.59014 L 333.932,205 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="m 329.50042,205 3.375,-6.46875 3.375,6.46875 z"
-         id="path1052-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <circle
-         style="opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="circle1054-9"
-         cx="337.75043"
-         cy="196"
-         r="2.25" />
-      <path
-         style="display:inline;opacity:1;fill:#aea795;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 320.5 247 L 320.5 247.14648 C 320.5 250.18815 320.80986 250.5 323.82422 250.5 L 328 250.5 L 332.17578 250.5 C 335.19013 250.5 335.5 250.18814 335.5 247.14648 L 335.5 247 L 320.5 247 z "
-         id="path1134-0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 331.76758 237.5 L 324.96289 250.5 L 328 250.5 L 332.17578 250.5 C 335.19013 250.5 335.5 250.18814 335.5 247.14648 L 335.5 240.85547 C 335.5 237.81381 335.1901 237.48509 332.17578 237.5 L 331.76758 237.5 z "
-         id="path1058-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#dad9ce;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 328.95703 237.5 L 324 247 L 326.8125 247 L 331.76953 237.5 L 328.95703 237.5 z "
-         id="path1060-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 331.76953 237.5 L 326.8125 247 L 331.03125 247 L 335.32812 238.76367 C 335.03765 237.66629 334.25744 237.4897 332.17578 237.5 L 331.76953 237.5 z "
-         id="path1062-4" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#dad9ce;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 335.32812 238.76367 L 331.03125 247 L 333.84375 247 L 335.5 243.82617 L 335.5 240.85547 C 335.5 239.91435 335.45827 239.25534 335.32812 238.76367 z "
-         id="path1064-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f2f2f2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="m 324.00042,247 2.79111,-5.36884 2.79112,5.36884 z"
-         id="path1067-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path1069-3"
-         d="m 326.81292,247 2.10937,-4.04297 2.10938,4.04297 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate" />
-      <circle
-         r="1.40625"
-         cy="241.375"
-         cx="331.96918"
-         id="circle1071-8"
-         style="opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         style="display:inline;opacity:1;fill:#aea795;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 40.068359 212 C 40.668648 240.84911 46.098353 244.15893 78.990234 243.99805 L 151.99805 243.99805 L 225.00391 243.99805 C 257.89578 244.15893 263.32549 240.84911 263.92578 212 L 56.5 212 L 40.068359 212 z "
-         id="path1031-0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 195.06445 67.998047 L 102.93945 243.99805 L 151.99805 243.99805 L 225.00391 243.99805 C 260.37202 244.17104 263.99805 240.3729 263.99805 205.07617 L 263.99805 106.91797 C 263.99805 71.621249 260.37244 67.998047 225.00391 67.998047 L 195.06445 67.998047 z "
-         id="path4390-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#dad9ce;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 147.13086 67.998047 L 72 212 L 120 212 L 195.13086 67.998047 L 151.99805 67.998047 L 147.13086 67.998047 z "
-         id="rect4248-4" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c8c4b7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 195.13086 67.998047 L 120 212 L 192 212 L 261.13672 79.486328 C 257.05663 69.461977 247.3969 67.998047 225.00391 67.998047 L 195.13086 67.998047 z "
-         id="path4266-2" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#dad9ce;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         d="M 261.13672 79.486328 L 192 212 L 240 212 L 263.99805 166.00391 L 263.99805 106.91797 C 263.99805 93.968781 263.50091 85.294898 261.13672 79.486328 z "
-         id="path1051-6" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient1091-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;filter:url(#filter1101-7);enable-background:accumulate"
-         d="M 119.63519,122.37109 72.00042,214 h 95.26953 24.73047 l -36,-69 -12.32227,23.61914 z"
-         id="path1078-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1115-2"
-         d="m 208.00042,92 a 24,24 0 0 0 -24,24 24,24 0 0 0 24,24 24,24 0 0 0 24,-24 24,24 0 0 0 -24,-24 z M 119.63519,120.37109 72.00042,212 h 95.26953 24.73047 l -36,-69 -12.32227,23.61914 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient1121-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;filter:url(#filter1117-7);enable-background:accumulate" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path4244-2-5"
-         d="M 72.00042,212 119.63547,120.37174 167.27052,212 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;enable-background:accumulate"
-         d="m 120.00042,212 36,-69 36,69 z"
-         id="path4246-6-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-      <circle
-         r="24"
-         cy="118"
-         cx="208.00043"
-         id="circle967-5"
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter1001-5);enable-background:new" />
-      <circle
-         style="display:inline;opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="path1076-1"
-         cx="208.00043"
-         cy="116"
-         r="24" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:11.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1027);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 139.87487,82.000002 c -35.29804,0 -63.999995,28.701958 -63.999995,63.999998 0,35.29804 28.701955,64 63.999995,64 15.45232,0 29.63935,-5.50209 40.70897,-14.64844 l 6.89063,6.89063 -1.41406,1.41406 31.5,31.5 11.31445,-11.3125 -31.5,-31.5 -1.41406,1.41406 -6.88086,-6.88086 C 198.31151,175.78253 203.87486,161.5323 203.87486,146 c 0,-35.29804 -28.70196,-63.999998 -63.99999,-63.999998 z m 0,8.136719 c 30.90124,0 55.86327,24.962039 55.86327,55.863279 0,30.90124 -24.96203,55.86523 -55.86327,55.86523 -30.90124,0 -55.865225,-24.96399 -55.865225,-55.86523 0,-30.90124 24.963985,-55.863279 55.865225,-55.863279 z"
-         id="path1001"
-         inkscape:connector-curvature="0" />
-      <g
-         style="display:inline;enable-background:new"
-         id="g1125"
-         transform="translate(-8.0001253,4.0000026)">
-        <g
-           transform="matrix(-1,0,0,1,319.8747,3.1e-4)"
-           id="g1131"
-           style="display:inline;enable-background:new">
-          <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4480"
-             d="m 116.15722,195.99999 12.00001,-12"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#888888;stroke-width:11.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <path
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:15.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-             d="m 88.657217,223.49999 31.500013,-31.5"
-             id="path4478"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
-        </g>
-        <g
-           transform="matrix(-1,0,0,1,317.8747,3.1e-4)"
-           id="g1087"
-           style="display:inline;enable-background:new" />
-        <circle
-           r="59.932201"
-           cy="140.00032"
-           cx="147.87471"
-           id="path4260"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:#666666;stroke-width:8.13559246;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      </g>
-      <g
-         style="display:inline;enable-background:new"
-         id="g1050"
-         transform="matrix(0.1,0,0,0.1,298.19277,191.15412)">
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#888888;stroke-width:11.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 380.06781,130.4619 -12.00001,-12"
-           id="path4480-9"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4478-1"
-           d="m 408.0678,158.4619 -30,-30"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:15.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <g
-           transform="matrix(-1,0,0,1,495,-64.578123)"
-           id="g1087-2"
-           style="display:inline;enable-background:new" />
-        <circle
-           r="55"
-           cy="78.461899"
-           cx="328.06778"
-           id="path4260-0"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:#666666;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <circle
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:none;stroke-width:7.76698875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           id="circle4415-6"
-           cx="313.06781"
-           cy="63.461899"
-           r="15" />
-      </g>
-      <g
-         transform="matrix(0.20789396,0,0,0.20789397,273.23041,65.057042)"
-         id="g1064"
-         style="display:inline;stroke-width:0.48101443;enable-background:new">
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path1054"
-           d="m 376.46053,127.17058 -12.00001,-12"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#888888;stroke-width:9.62028885;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:14.43043327;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 404.46052,155.17058 -30,-30"
-           id="path1056"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <g
-           style="display:inline;stroke-width:0.48101443;enable-background:new"
-           id="g1058"
-           transform="matrix(-1,0,0,1,495,-64.578123)" />
-        <circle
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:#666666;stroke-width:9.62028885;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           id="circle1060"
-           cx="325.97937"
-           cy="76.68943"
-           r="52.911591" />
-        <circle
-           r="14.430433"
-           cy="62.258999"
-           cx="311.54892"
-           id="circle1062"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:none;stroke-width:3.73603368;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      </g>
-      <g
-         style="display:inline;enable-background:new"
-         transform="matrix(0.1,0,0,0.1,302.19277,137.15412)"
-         id="g988">
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path978"
-           d="m 380.06781,150.4619 -12.00001,-12"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#888888;stroke-width:11.99999905;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:15.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 418.0678,188.4619 -40,-40"
-           id="path980"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <g
-           style="display:inline;enable-background:new"
-           id="g982"
-           transform="matrix(-1,0,0,1,495,-64.578123)" />
-        <circle
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:#666666;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           id="circle984"
-           cx="318.06778"
-           cy="88.461899"
-           r="65" />
-        <circle
-           r="20"
-           cy="68.461899"
-           cx="298.06781"
-           id="circle986"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:none;stroke-width:7.76698923;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      </g>
-      <g
-         style="display:inline;enable-background:new"
-         transform="matrix(0.1,0,0,0.1,295.19277,237.15412)"
-         id="g1252">
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path1242"
-           d="m 350.06781,90.4619 -7.50566,-7"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#888888;stroke-width:11.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:15.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 368.0678,108.4619 -20,-20"
-           id="path1244"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <g
-           style="display:inline;enable-background:new"
-           id="g1246"
-           transform="matrix(-1,0,0,1,495,-64.578123)" />
-        <circle
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:#666666;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           id="circle1248"
-           cx="318.06778"
-           cy="58.461903"
-           r="35" />
-        <circle
-           r="10"
-           cy="48.461899"
-           cx="308.06781"
-           id="circle1250"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:none;stroke-width:7.76698875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      </g>
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer2"
-       inkscape:label="Highlights"
+       inkscape:label="Background"
+       style="display:inline">
+      <circle
+         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient4835);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.67891;marker:none"
+         id="path4188"
+         cx="151.99962"
+         cy="155.9998"
+         r="105.96167" />
+      <path
+         id="path1"
+         d="m 241.64368,108.2812 c -0.50421,-0.93335 -1.06206,-1.93106 -1.64139,-2.91805 -4.35561,-7.40239 -9.82695,-14.41858 -16.38181,-20.97345 -15.57721,-15.577211 -33.71846,-25.028671 -54.4237,-28.33293 -3.48663,-0.557861 -7.03764,-0.944081 -10.73884,-1.14791 -2.08125,-0.11801 -4.25906,-0.18238 -6.45832,-0.18238 -2.00616,0 -3.99085,0.0536 -5.98628,0.16092 -25.39343,1.30883 -47.268051,11.14651 -65.623841,29.5023 -4.39853,4.398519 -8.314277,9.000879 -11.736547,13.8178 -3.29353,4.62382 -6.12575,9.44074 -8.49666,14.41858 l -0.005,-0.005 q -9.42464,19.73929 -9.42464,43.3791 c 0,27.96818 9.89132,51.84895 29.663217,71.62085 12.16568,12.15495 25.865471,20.57651 41.002831,25.22179 7.88516,2.41383 16.04925,3.82994 24.62101,4.28054 0.0322,0 0.0536,0 0.0858,0 1.82378,0.0965 3.56173,0.15016 5.25678,0.15016 0.25747,0 0.45058,0 0.64368,0 2.20999,0 4.39853,-0.0643 6.45832,-0.17161 0.53641,-0.0322 1.01917,-0.0644 1.49121,-0.0966 4.33416,-0.31109 8.56103,-0.86897 12.5948,-1.65212 1.70577,-0.33259 3.39008,-0.70807 5.02075,-1.10501 17.33662,-4.35561 32.64564,-13.21703 46.05578,-26.62717 10.42771,-10.42772 18.10904,-21.99262 23.03323,-34.71615 3.95869,-10.22389 6.14721,-21.19875 6.55489,-32.9353 0.0429,-1.2981 0.0644,-2.62838 0.0644,-3.9694 0,-0.13946 0,-0.28966 0,-0.42912 0,-0.0751 0,-0.13947 0,-0.21456 -0.0429,-8.72195 -1.06207,-17.0577 -3.06823,-25.10378 -0.23602,-0.93334 -0.50422,-1.93106 -0.78316,-2.91804 -0.21457,-0.72951 -0.42911,-1.46975 -0.67588,-2.2529 -0.34329,-1.105 -0.7295,-2.25291 -1.13715,-3.40082 -1.08355,-3.05751 -2.32802,-6.06138 -3.74413,-9.04379 -0.39695,-0.81534 -0.8046,-1.6414 -1.223,-2.46747 -0.31113,-0.6115 -0.63296,-1.223 -0.99773,-1.88814 z"
+         style="display:inline;enable-background:new;fill:url(#linearGradient849);fill-opacity:1;stroke-width:0.214562"
+         inkscape:connector-curvature="0" />
+      <circle
+         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient6921);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.29373;marker:none"
+         id="path4188-6-4"
+         cx="151.99962"
+         cy="155.9998"
+         r="101.74483" />
+      <circle
+         r="447.11603"
+         cy="114.55128"
+         cx="190.2117"
+         id="circle965"
+         style="display:inline;enable-background:new;opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient943);stroke-width:55.7679;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;filter:url(#filter955)"
+         transform="matrix(0.2162483,0,0,0.2162483,110.86666,131.2283)" />
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1034);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.98763;marker:none;enable-background:accumulate"
+         id="circle966"
+         cx="343.99991"
+         cy="83.999962"
+         r="21.759987" />
+      <path
+         id="path968"
+         d="m 362.40897,74.200602 c -0.10355,-0.19167 -0.21811,-0.396557 -0.33708,-0.599243 -0.89445,-1.520133 -2.01803,-2.960959 -3.36412,-4.307047 -3.19889,-3.198892 -6.92432,-5.139817 -11.17629,-5.81837 -0.71601,-0.11456 -1.44523,-0.193874 -2.2053,-0.235731 -0.4274,-0.02423 -0.87463,-0.03745 -1.32626,-0.03745 -0.41198,0 -0.81955,0.01101 -1.22933,0.03305 -5.21472,0.268777 -9.70683,2.289016 -13.47632,6.058509 -0.90327,0.903267 -1.7074,1.848394 -2.41019,2.837584 -0.67635,0.949534 -1.25796,1.938723 -1.74485,2.960958 l -10e-4,-0.001 q -1.93541,4.053604 -1.93541,8.908208 c 0,5.743465 2.03125,10.647552 6.09155,14.707851 2.49831,2.49611 5.31166,4.22554 8.42022,5.17948 1.61928,0.49569 3.29583,0.7865 5.0561,0.87904 0.007,0 0.011,0 0.0176,0 0.37453,0.0198 0.73143,0.0308 1.07952,0.0308 0.0529,0 0.0925,0 0.13219,0 0.45383,0 0.90327,-0.0132 1.32626,-0.0352 0.11015,-0.007 0.20929,-0.0132 0.30623,-0.0198 0.89005,-0.0639 1.75807,-0.17845 2.58643,-0.33928 0.35029,-0.0683 0.69618,-0.14541 1.03105,-0.22692 3.5602,-0.89446 6.70401,-2.71421 9.45788,-5.468081 2.14141,-2.141406 3.71882,-4.51634 4.73004,-7.129208 0.81295,-2.099549 1.26237,-4.353315 1.34609,-6.763499 0.009,-0.266575 0.0132,-0.539756 0.0132,-0.815145 0,-0.02864 0,-0.05948 0,-0.08812 0,-0.01542 0,-0.02864 0,-0.04406 -0.009,-1.791114 -0.2181,-3.50292 -0.63008,-5.15524 -0.0485,-0.191668 -0.10354,-0.396557 -0.16083,-0.599241 -0.0441,-0.14981 -0.0881,-0.301823 -0.13879,-0.462649 -0.0705,-0.226919 -0.14981,-0.462651 -0.23353,-0.698382 -0.22251,-0.627882 -0.47807,-1.244748 -0.76888,-1.857207 -0.0815,-0.167436 -0.16523,-0.337074 -0.25115,-0.506713 -0.0639,-0.125576 -0.12998,-0.251152 -0.20489,-0.387743 z"
+         style="display:inline;fill:url(#linearGradient1032);fill-opacity:1;stroke-width:0.0440618;enable-background:new"
+         inkscape:connector-curvature="0" />
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient1030);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.90853;marker:none;enable-background:accumulate"
+         id="circle970"
+         cx="343.99991"
+         cy="83.999962"
+         r="20.894028" />
+      <circle
+         r="447.11603"
+         cy="114.55128"
+         cx="190.2117"
+         id="circle1024"
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1026);stroke-width:55.7679;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;filter:url(#filter955);enable-background:new"
+         transform="matrix(0.04440813,0,0,0.04440813,335.55297,78.912953)" />
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1104);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.29628;marker:none;enable-background:accumulate"
+         id="circle1036"
+         cx="336.14554"
+         cy="148.05638"
+         r="14.191297" />
+      <path
+         id="path1038"
+         d="m 348.15144,141.66549 c -0.0675,-0.125 -0.14224,-0.25862 -0.21983,-0.39081 -0.58334,-0.99139 -1.31611,-1.93106 -2.19399,-2.80894 -2.08623,-2.08624 -4.51586,-3.35206 -7.28889,-3.79459 -0.46696,-0.0747 -0.94254,-0.12644 -1.43824,-0.15374 -0.27874,-0.0158 -0.57041,-0.0244 -0.86495,-0.0244 -0.26868,0 -0.53449,0.007 -0.80174,0.0216 -3.4009,0.17529 -6.33054,1.49284 -8.7889,3.9512 -0.58909,0.58909 -1.11352,1.20548 -1.57186,1.8506 -0.4411,0.61926 -0.82041,1.26438 -1.13795,1.93106 l -6.5e-4,-6.5e-4 q -1.26223,2.64365 -1.26223,5.8097 c 0,3.74574 1.32473,6.94406 3.97275,9.59208 1.62934,1.62789 3.46413,2.75578 5.49145,3.37792 1.05605,0.32327 2.14946,0.51293 3.29746,0.57329 0.005,0 0.007,0 0.0115,0 0.24426,0.0129 0.47702,0.0201 0.70403,0.0201 0.0345,0 0.0603,0 0.0862,0 0.29598,0 0.58909,-0.009 0.86496,-0.023 0.0718,-0.005 0.13649,-0.009 0.19971,-0.0129 0.58047,-0.0417 1.14657,-0.11638 1.6868,-0.22127 0.22845,-0.0445 0.45403,-0.0948 0.67243,-0.14799 2.32187,-0.58335 4.37218,-1.77014 6.16818,-3.56615 1.39657,-1.39656 2.42532,-2.94543 3.08481,-4.64948 0.53018,-1.36927 0.82328,-2.83912 0.87788,-4.41098 0.006,-0.17385 0.009,-0.35201 0.009,-0.53161 0,-0.0187 0,-0.0388 0,-0.0575 0,-0.0101 0,-0.0187 0,-0.0287 -0.006,-1.16812 -0.14224,-2.28452 -0.41092,-3.36212 -0.0316,-0.125 -0.0675,-0.25862 -0.10489,-0.39081 -0.0288,-0.0977 -0.0575,-0.19684 -0.0905,-0.30172 -0.046,-0.14799 -0.0977,-0.30173 -0.15231,-0.45547 -0.14511,-0.40949 -0.31178,-0.81179 -0.50144,-1.21122 -0.0531,-0.1092 -0.10776,-0.21983 -0.16379,-0.33047 -0.0417,-0.0819 -0.0848,-0.16379 -0.13363,-0.25287 z"
+         style="display:inline;fill:url(#linearGradient1102);fill-opacity:1;stroke-width:0.028736;enable-background:new"
+         inkscape:connector-curvature="0" />
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient1100);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.24469;marker:none;enable-background:accumulate"
+         id="circle1040"
+         cx="336.14554"
+         cy="148.05638"
+         r="13.626541" />
+      <circle
+         r="447.11603"
+         cy="114.55128"
+         cx="190.2117"
+         id="circle1094"
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1096);stroke-width:55.7679;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;filter:url(#filter955);enable-background:new"
+         transform="matrix(0.02896183,0,0,0.02896183,330.63666,144.73876)" />
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1174);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.993815;marker:none;enable-background:accumulate"
+         id="circle1106"
+         cx="332.11157"
+         cy="200.04323"
+         r="10.879992" />
+      <path
+         id="path1108"
+         d="m 341.3161,195.14355 c -0.0517,-0.0958 -0.10905,-0.19828 -0.16854,-0.29963 -0.44722,-0.76006 -1.00901,-1.48047 -1.68205,-2.15352 -1.59945,-1.59945 -3.46216,-2.56991 -5.58815,-2.90918 -0.35801,-0.0573 -0.72262,-0.0969 -1.10265,-0.11787 -0.2137,-0.0121 -0.43732,-0.0187 -0.66313,-0.0187 -0.20599,0 -0.40978,0.005 -0.61467,0.0166 -2.60736,0.13439 -4.85341,1.14452 -6.73816,3.02926 -0.45163,0.45163 -0.85369,0.9242 -1.20509,1.41879 -0.33817,0.47477 -0.62898,0.96936 -0.87243,1.48048 l -4.9e-4,-5e-4 q -0.96771,2.0268 -0.96771,4.4541 c 0,2.87174 1.01562,5.32378 3.04577,7.35393 1.24916,1.24805 2.65583,2.11277 4.21011,2.58974 0.80964,0.24784 1.64792,0.39325 2.52805,0.43952 0.004,0 0.005,0 0.009,0 0.18727,0.01 0.36572,0.0154 0.53976,0.0154 0.0265,0 0.0462,0 0.0661,0 0.22692,0 0.45164,-0.007 0.66314,-0.0176 0.055,-0.004 0.10464,-0.007 0.15311,-0.01 0.44503,-0.032 0.87904,-0.0892 1.29321,-0.16964 0.17515,-0.0341 0.34809,-0.0727 0.51553,-0.11346 1.7801,-0.44724 3.35201,-1.35711 4.72894,-2.73405 1.0707,-1.07069 1.85941,-2.25816 2.36502,-3.5646 0.40647,-1.04977 0.63118,-2.17666 0.67304,-3.38175 0.005,-0.13329 0.007,-0.26987 0.007,-0.40757 0,-0.0143 0,-0.0297 0,-0.0441 0,-0.008 0,-0.0143 0,-0.022 -0.005,-0.89556 -0.10905,-1.75147 -0.31504,-2.57763 -0.0242,-0.0958 -0.0517,-0.19827 -0.0804,-0.29962 -0.0221,-0.0749 -0.0441,-0.15091 -0.0694,-0.23132 -0.0353,-0.11346 -0.0749,-0.23133 -0.11678,-0.34919 -0.11125,-0.31395 -0.23903,-0.62238 -0.38443,-0.9286 -0.0407,-0.0837 -0.0826,-0.16854 -0.12558,-0.25337 -0.032,-0.0628 -0.065,-0.12557 -0.10244,-0.19386 z"
+         style="display:inline;fill:url(#linearGradient1172);fill-opacity:1;stroke-width:0.0220309;enable-background:new"
+         inkscape:connector-curvature="0" />
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient1170);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.954262;marker:none;enable-background:accumulate"
+         id="circle1110"
+         cx="332.11157"
+         cy="200.04323"
+         r="10.447014" />
+      <circle
+         r="447.11603"
+         cy="114.55128"
+         cx="190.2117"
+         id="circle1164"
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1166);stroke-width:55.7679;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;filter:url(#filter955);enable-background:new"
+         transform="matrix(0.02220407,0,0,0.02220407,327.8881,197.49972)" />
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1244);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.64814;marker:none;enable-background:accumulate"
+         id="circle1176"
+         cx="327.99948"
+         cy="244.00003"
+         r="7.0956459" />
+      <path
+         id="path1178"
+         d="m 334.00242,240.80457 c -0.0337,-0.0625 -0.0711,-0.12931 -0.10991,-0.19541 -0.29167,-0.49569 -0.65805,-0.96552 -1.09699,-1.40447 -1.04312,-1.04312 -2.25793,-1.67602 -3.64445,-1.89729 -0.23348,-0.0374 -0.47127,-0.0632 -0.71912,-0.0769 -0.13937,-0.008 -0.28521,-0.0122 -0.43247,-0.0122 -0.13434,0 -0.26725,0.003 -0.40088,0.0108 -1.70045,0.0876 -3.16526,0.74643 -4.39445,1.97561 -0.29454,0.29454 -0.55675,0.60273 -0.78592,0.92529 -0.22055,0.30964 -0.41021,0.63219 -0.56898,0.96553 l -3.2e-4,-3.2e-4 q -0.63112,1.32182 -0.63112,2.90484 c 0,1.87288 0.66237,3.47203 1.98638,4.79605 0.81467,0.81394 1.73206,1.37789 2.74572,1.68896 0.52803,0.16163 1.07473,0.25646 1.64873,0.28664 0.003,0 0.003,0 0.006,0 0.12213,0.007 0.23851,0.01 0.35201,0.01 0.0173,0 0.0301,0 0.0431,0 0.14799,0 0.29455,-0.005 0.43249,-0.0115 0.0359,-0.003 0.0682,-0.005 0.0999,-0.007 0.29024,-0.0209 0.57329,-0.0582 0.8434,-0.11063 0.11423,-0.0222 0.22701,-0.0474 0.33621,-0.074 1.16094,-0.29168 2.1861,-0.88507 3.08409,-1.78307 0.69829,-0.69828 1.21266,-1.47272 1.54241,-2.32474 0.26509,-0.68463 0.41164,-1.41956 0.43894,-2.20549 0.003,-0.0869 0.005,-0.176 0.005,-0.26581 0,-0.009 0,-0.0194 0,-0.0288 0,-0.005 0,-0.009 0,-0.0144 -0.003,-0.58406 -0.0711,-1.14226 -0.20546,-1.68106 -0.0158,-0.0625 -0.0337,-0.12931 -0.0524,-0.1954 -0.0144,-0.0489 -0.0288,-0.0984 -0.0453,-0.15086 -0.023,-0.074 -0.0489,-0.15087 -0.0762,-0.22774 -0.0726,-0.20475 -0.15588,-0.4059 -0.25071,-0.60561 -0.0265,-0.0546 -0.0539,-0.10991 -0.0819,-0.16524 -0.0209,-0.041 -0.0424,-0.0819 -0.0668,-0.12643 z"
+         style="display:inline;fill:url(#linearGradient1242);fill-opacity:1;stroke-width:0.014368;enable-background:new"
+         inkscape:connector-curvature="0" />
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient1240);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.622345;marker:none;enable-background:accumulate"
+         id="circle1180"
+         cx="327.99948"
+         cy="244.00003"
+         r="6.8132691" />
+      <circle
+         r="447.11603"
+         cy="114.55128"
+         cx="190.2117"
+         id="circle1234"
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1236);stroke-width:55.7679;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;filter:url(#filter955);enable-background:new"
+         transform="matrix(0.01448091,0,0,0.01448091,325.24503,242.34121)" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.990234,67.998047 c -35.36853,0 -38.992187,3.623202 -38.992187,38.919923 v 98.1582 c 0,0.0882 0.0019,0.16224 0.002,0.25 V 108.91602 C 40,73.6193 43.625611,69.994141 78.994141,69.994141 H 152 225.00586 c 35.28016,0 38.97394,3.621035 38.99219,38.671879 v -1.74805 c 0,-35.296721 -3.62561,-38.919923 -38.99414,-38.919923 h -73.00586 z"
-         id="rect4158-78"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 39.998047,203.07617 v 2 c 0,35.29673 3.624067,39.09487 38.992187,38.92188 h 73.007816 73.00586 c 35.36811,0.17299 38.99414,-3.62515 38.99414,-38.92188 v -2 c 0,35.29673 -3.62603,39.09487 -38.99414,38.92188 H 151.99805 78.990234 c -35.36812,0.17299 -38.992187,-3.62515 -38.992187,-38.92188 z"
-         id="rect4158-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983)"
-         transform="rotate(90,328,244)" />
+         id="path7033-6-4"
+         d="m 175.17438,215.53213 c 0,0 20.49799,12.4358 34.90969,-1.97586 14.41166,-14.41157 1.14875,-31.64294 1.14875,-31.64294 l -35.10603,-1.13626 z"
+         style="display:inline;fill:#50bac0;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="csccc" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.51173,240.91355 c 0,-2.89732 -0.30259,-3.44011 -3.25454,-3.42488 h -4.25716 -4.25724 c -2.95195,-0.0152 -3.25453,0.52756 -3.25453,3.42488 v 6.17331 c 0,2.8966 0.30255,3.42488 3.25453,3.42488 h 4.25724 4.25716 c 2.95199,0 3.25454,-0.52828 3.25454,-3.42488 z"
-         id="path958-6-0"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         id="path7035"
+         d="m 92.173836,178.8489 c 0,0 -0.147605,0.44306 36.627074,0.0738 l 15.97346,-16.52646 -1.52955,-7.6073 -27.63907,0.40101 z"
+         style="display:inline;fill:#b32f58;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="cccccc" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 343.51172,195.49156 c 0,-4.23214 -0.46371,-5.02499 -4.98757,-5.00275 h -6.5241 -6.52423 c -4.52386,-0.0222 -4.98757,0.77061 -4.98757,5.00275 v 9.01743 c 0,4.23108 0.46366,5.00275 4.98757,5.00275 h 6.52423 6.5241 c 4.52391,0 4.98757,-0.77167 4.98757,-5.00275 z"
-         id="path958-6"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         id="path7033"
+         d="m 93.390788,131.09784 c 0,0 -22.484281,4.33026 -22.484281,24.71144 0,20.38119 21.562719,23.18732 21.562719,23.18732 l 24.281454,-23.14528 z"
+         style="display:inline;fill:#ef5f8a;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="csccc" />
       <path
-         sodipodi:nodetypes="scccssscsss"
          inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971)"
-         transform="rotate(90,331.99966,200)" />
+         id="path7035-1"
+         d="m 128.1918,214.87509 c 0,0 2.4814,-0.6517 25.28312,-22.10416 l 1.78786,-28.36803 -9.47838,-3.07636 -22.7364,23.45985 z"
+         style="display:inline;fill:#5d569b;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="cccccc" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 350.50001,142.07508 c 0,-5.56175 -0.58409,-6.6037 -6.28227,-6.57447 h -8.21765 -8.21781 c -5.69818,-0.0293 -6.28227,1.01272 -6.28227,6.57447 v 11.85044 c 0,5.56037 0.58403,6.57447 6.28227,6.57447 h 8.21781 8.21765 c 5.69824,0 6.28227,-1.0141 6.28227,-6.57447 z"
-         id="path958-1"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         id="path7033-6"
+         d="m 92.413269,178.77909 c 0,0 -12.435818,20.23062 1.975845,34.64229 14.411696,14.41166 33.715006,1.54974 33.715006,1.54974 l 0.80202,-36.10849 z"
+         style="display:inline;fill:#ae81b7;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="csccc" />
       <path
-         transform="matrix(0,0.66664182,-0.63636364,0,389.45455,-81.324786)"
-         sodipodi:nodetypes="scccssscsss"
          inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004-8);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-1)" />
+         id="path7035-9"
+         d="m 175.51154,215.77155 c 0,0 0.77725,-1.79064 2.68047,-34.42142 l -19.7475,-21.11872 -5.92826,4.06442 0.4726,33.45764 z"
+         style="display:inline;fill:#2a729d;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="cccccc" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 366.50065,75.231076 c 0,-8.23154 -0.90635,-9.77365 -9.74838,-9.7304 H 344.0007 331.24889 c -8.84203,-0.0433 -9.74838,1.49886 -9.74838,9.7304 v 17.53897 c 0,8.229494 0.90625,9.730394 9.74838,9.730394 h 12.75181 12.75157 c 8.84213,0 9.74838,-1.5009 9.74838,-9.730404 z"
-         id="path958"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         id="path7033-62"
+         d="m 127.80776,214.88538 c 0,0 4.28298,22.15354 24.66417,22.15354 20.38121,0 23.1873,-21.56276 23.1873,-21.56276 L 152.91502,192.732 Z"
+         style="display:inline;fill:#60a8d8;fill-opacity:1;stroke:none;stroke-width:0.988922" />
       <path
-         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path7035-1-7"
+         d="m 211.05369,181.94306 c 0,0 -2.32344,-2.95003 -23.29495,-26.51857 l -29.69909,0.009 0.0811,5.35384 19.89823,21.41058 z"
+         style="display:inline;fill:#3a9b6b;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path7035-2"
+         d="m 211.82541,133.15072 c 0,0 2.06759,-3.06455 -34.7071,-2.69533 l -19.123,20.01088 0.0523,5.20715 h 35.75971 z"
+         style="display:inline;fill:#82ba3c;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path7033-7"
+         d="m 210.75022,181.89425 c 0,0 22.34252,-5.32273 22.34252,-25.70391 0,-20.38119 -21.56272,-23.18732 -21.56272,-23.18732 l -26.33603,22.46067 z"
+         style="display:inline;fill:#abd17f;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path7035-1-0"
+         d="m 178.30451,97.537997 c 0,0 -4.45474,-0.783661 -30.19727,25.481053 l 4.00656,24.18083 6.11559,3.49012 23.23618,-24.69825 z"
+         style="display:inline;fill:#d8ab2d;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path7033-6-5"
+         d="m 211.57451,133.00662 c 0,0 12.44729,-20.0167 -1.96438,-34.428396 -14.41169,-14.411664 -32.45828,-0.723386 -32.45828,-0.723386 l -0.0535,32.658842 z"
+         style="display:inline;fill:#c1dc7b;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path7035-9-2"
+         d="m 128.48771,96.22804 c 0,0 -3.15832,-1.609649 -2.78906,35.16504 l 17.96418,20.3663 8.85251,-4.57599 -0.57292,-32.55147 z"
+         style="display:inline;fill:#e75427;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path7033-62-2"
+         d="m 177.16156,97.849141 c 0,0 -5.25306,-22.888428 -25.63424,-22.888428 -20.38121,0 -23.18731,21.562719 -23.18731,21.562719 l 23.70423,27.322598 z"
+         style="display:inline;fill:#f9a740;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path7035-1-7-2"
+         d="m 92.804815,130.54411 c 0,0 -2.995348,-0.10315 23.269365,25.63945 7.97165,-0.43516 13.96531,-0.4978 27.18371,-1.21982 l 0.7582,-5.6853 -17.64034,-18.6085 z"
+         style="display:inline;fill:#dd2735;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path7033-6-4-4"
+         d="m 128.38063,96.227497 c 0,0 -20.05376,-12.196141 -34.465422,2.215522 -14.411694,14.411691 -0.887685,33.000661 -0.887685,33.000661 l 33.575017,-0.46994 z"
+         style="display:inline;fill:#ec7a84;fill-opacity:1;stroke:none;stroke-width:0.988922"
+         sodipodi:nodetypes="csccc" />
+      <circle
+         id="path7176"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient7394);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:42.3759;marker:none;enable-background:accumulate"
+         cx="150.91301"
+         cy="155.57889"
+         r="9.168581" />
+      <ellipse
+         transform="rotate(-2.1080528)"
+         id="path7178"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7c061b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:42.3759;marker:none;enable-background:accumulate"
+         cx="123.62688"
+         cy="160.24977"
+         rx="12.382311"
+         ry="4.3479872" />
+      <ellipse
+         id="path7178-5"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#275f18;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:42.3759;marker:none;enable-background:accumulate"
+         cx="172.41527"
+         cy="155.82806"
+         rx="12.382311"
+         ry="4.3479867" />
+      <ellipse
+         id="path7178-6"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ae3e09;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:40.8027;marker:none;enable-background:accumulate"
+         transform="rotate(91.152265)"
+         cx="132.1615"
+         cy="-154.83113"
+         rx="11.480015"
+         ry="4.3479867" />
+      <ellipse
+         id="path7178-6-1"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#151b4a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:43.8375;marker:none;enable-background:accumulate"
+         transform="rotate(90.556993)"
+         cx="176.2422"
+         cy="-154.44644"
+         rx="13.251187"
+         ry="4.3479872" />
+      <ellipse
+         id="path7178-9"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#950a0d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:43.0921;marker:none;enable-background:accumulate"
+         transform="matrix(0.68033194,0.73290412,-0.68033194,0.73290412,0,0)"
+         cx="195.2934"
+         cy="-3.415282"
+         rx="12.591621"
+         ry="4.4214854" />
+      <ellipse
+         id="path7178-5-9"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#093129;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:47.5619;marker:none;enable-background:accumulate"
+         transform="matrix(0.68204929,0.73130621,-0.7555727,0.6550648,0,0)"
+         cx="239.34209"
+         cy="-5.9369922"
+         rx="13.897672"
+         ry="4.8800983" />
+      <ellipse
+         id="path7178-6-4"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#526718;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:45.1244;marker:none;enable-background:accumulate"
+         transform="matrix(-0.6998983,0.71424252,-0.6998983,-0.71424252,0,0)"
+         cx="-21.262569"
+         cy="-217.96724"
+         rx="13.185418"
+         ry="4.6299939" />
+      <ellipse
+         id="path7178-6-1-8"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#3d0c34;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:39.0196;marker:none;enable-background:accumulate"
+         transform="rotate(135)"
+         cx="23.672981"
+         cy="-217.78752"
+         rx="11.401566"
+         ry="4.003603" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path972"
+         d="m 348.75901,96.225343 c 0,0 4.20941,2.55378 7.16896,-0.405758 2.95953,-2.959518 0.2359,-6.498102 0.2359,-6.498102 l -7.20927,-0.233339 z"
+         style="display:inline;fill:#50bac0;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path974"
+         d="m 331.71426,88.69218 c 0,0 -0.0303,0.09099 7.52163,0.01515 l 3.28027,-3.393827 -0.31411,-1.562214 -5.67588,0.08235 z"
+         style="display:inline;fill:#b32f58;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path976"
+         d="m 331.96417,78.886159 c 0,0 -4.61731,0.889251 -4.61731,5.074672 0,4.185421 4.42806,4.76168 4.42806,4.76168 l 4.98637,-4.753047 z"
+         style="display:inline;fill:#ef5f8a;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path978"
+         d="m 339.11081,96.090416 c 0,0 0.50957,-0.133832 5.19206,-4.539248 l 0.36715,-5.825577 -1.94645,-0.631752 -4.66908,4.817647 z"
+         style="display:inline;fill:#5d569b;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path980"
+         d="m 331.76343,88.677845 c 0,0 -2.55378,4.154502 0.40575,7.11404 2.95955,2.959537 6.92362,0.31825 6.92362,0.31825 l 0.1647,-7.415136 z"
+         style="display:inline;fill:#ae81b7;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path982"
+         d="m 348.82825,96.27451 c 0,0 0.15962,-0.367722 0.55046,-7.068684 l -4.05529,-4.33688 -1.21742,0.834658 0.0971,6.870763 z"
+         style="display:inline;fill:#2a729d;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path984"
+         d="m 339.03194,96.092527 c 0,0 0.87954,4.549383 5.06496,4.549383 4.18543,0 4.76168,-4.428061 4.76168,-4.428061 l -4.67069,-4.670676 z"
+         style="display:inline;fill:#60a8d8;fill-opacity:1;stroke:none;stroke-width:0.203082" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path986"
+         d="m 356.12709,89.327588 c 0,0 -0.47714,-0.60581 -4.78379,-5.445778 l -6.09892,0.0018 0.0167,1.099449 4.08625,4.396816 z"
+         style="display:inline;fill:#3a9b6b;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path988"
+         d="m 356.28556,79.307734 c 0,0 0.4246,-0.629328 -7.12735,-0.553505 l -3.92704,4.109375 0.0107,1.069326 h 7.34351 z"
+         style="display:inline;fill:#82ba3c;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="cccccc" />
+      <path
          inkscape:connector-curvature="0"
          id="path990"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994)"
-         transform="rotate(90,344,84)" />
+         d="m 356.06477,89.317564 c 0,0 4.58819,-1.09306 4.58819,-5.278481 0,-4.185422 -4.42806,-4.76168 -4.42806,-4.76168 l -5.40829,4.612457 z"
+         style="display:inline;fill:#abd17f;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path992"
+         d="m 349.40181,71.994407 c 0,0 -0.91481,-0.16093 -6.20123,5.232717 l 0.82278,4.965704 1.25588,0.716722 4.77171,-5.071963 z"
+         style="display:inline;fill:#d8ab2d;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path994"
+         d="m 356.23404,79.278142 c 0,0 2.55614,-4.110573 -0.4034,-7.070117 -2.95954,-2.959538 -6.66554,-0.148552 -6.66554,-0.148552 l -0.011,6.706726 z"
+         style="display:inline;fill:#c1dc7b;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path996"
+         d="m 339.17157,71.725398 c 0,0 -0.64858,-0.330553 -0.57275,7.221392 l 3.68907,4.182364 1.81793,-0.939712 -0.11766,-6.684675 z"
+         style="display:inline;fill:#e75427;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path998"
+         d="m 349.1671,72.058303 c 0,0 -1.07876,-4.700302 -5.26418,-4.700302 -4.18543,0 -4.76168,4.428058 -4.76168,4.428058 l 4.86783,5.61089 z"
+         style="display:inline;fill:#f9a740;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1000"
+         d="m 331.84384,78.772447 c 0,0 -0.61512,-0.02118 4.77853,5.265245 1.63703,-0.08937 2.86787,-0.102228 5.58236,-0.2505 l 0.15571,-1.167516 -3.62257,-3.821388 z"
+         style="display:inline;fill:#dd2735;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1002"
+         d="m 339.14958,71.725287 c 0,0 -4.11818,-2.504565 -7.07772,0.454973 -2.95954,2.959544 -0.18229,6.776921 -0.18229,6.776921 l 6.89487,-0.09651 z"
+         style="display:inline;fill:#ec7a84;fill-opacity:1;stroke:none;stroke-width:0.203082"
+         sodipodi:nodetypes="csccc" />
+      <circle
+         id="circle1004"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1028);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8.70219;marker:none;enable-background:accumulate"
+         cx="343.77676"
+         cy="83.913521"
+         r="1.8828335" />
+      <ellipse
+         transform="rotate(-2.1080593)"
+         id="ellipse1006"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7c061b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8.70219;marker:none;enable-background:accumulate"
+         cx="336.0502"
+         cy="96.343147"
+         rx="2.5427961"
+         ry="0.89289021" />
+      <ellipse
+         id="ellipse1008"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#275f18;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8.70219;marker:none;enable-background:accumulate"
+         cx="348.19241"
+         cy="83.964684"
+         rx="2.5427959"
+         ry="0.89289004" />
+      <ellipse
+         id="ellipse1010"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ae3e09;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8.37913;marker:none;enable-background:accumulate"
+         transform="rotate(91.152265)"
+         cx="72.804131"
+         cy="-345.56311"
+         rx="2.3575027"
+         ry="0.89289004" />
+      <ellipse
+         id="ellipse1012"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#151b4a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.00234;marker:none;enable-background:accumulate"
+         transform="rotate(90.556994)"
+         cx="85.113762"
+         cy="-344.99277"
+         rx="2.7212262"
+         ry="0.89289021" />
+      <ellipse
+         id="ellipse1014"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#950a0d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8.84927;marker:none;enable-background:accumulate"
+         transform="matrix(0.68033193,0.73290413,-0.68033193,0.73290413,0,0)"
+         cx="305.43311"
+         cy="-195.12769"
+         rx="2.5857794"
+         ry="0.9079836" />
+      <ellipse
+         id="ellipse1016"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#093129;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.76718;marker:none;enable-background:accumulate"
+         transform="matrix(0.68204917,0.73130632,-0.75557264,0.65506488,0,0)"
+         cx="293.46921"
+         cy="-194.64655"
+         rx="2.853986"
+         ry="1.0021629" />
+      <ellipse
+         id="ellipse1018"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#526718;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.26662;marker:none;enable-background:accumulate"
+         transform="matrix(-0.69989838,0.71424244,-0.69989838,-0.71424244,0,0)"
+         cx="-191.44002"
+         cy="-304.58914"
+         rx="2.7077196"
+         ry="0.95080227" />
+      <ellipse
+         id="ellipse1020"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#3d0c34;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8.01294;marker:none;enable-background:accumulate"
+         transform="rotate(135)"
+         cx="-179.56718"
+         cy="-302.64142"
+         rx="2.341393"
+         ry="0.82216853" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1042"
+         d="m 339.24929,156.02945 c 0,0 2.74527,1.66551 4.67541,-0.26463 1.93013,-1.93012 0.15385,-4.23789 0.15385,-4.23789 l -4.7017,-0.15218 z"
+         style="display:inline;fill:#50bac0;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1044"
+         d="m 328.13315,151.11652 c 0,0 -0.0198,0.0593 4.90541,0.01 l 2.13931,-2.21337 -0.20486,-1.01883 -3.70166,0.0537 z"
+         style="display:inline;fill:#b32f58;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1046"
+         d="m 328.29614,144.72129 c 0,0 -3.01129,0.57994 -3.01129,3.30956 0,2.72963 2.88786,3.10545 2.88786,3.10545 l 3.25198,-3.09982 z"
+         style="display:inline;fill:#ef5f8a;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1048"
+         d="m 332.95699,155.94145 c 0,0 0.33233,-0.0873 3.38613,-2.96038 l 0.23944,-3.79929 -1.26942,-0.41201 -3.04506,3.14195 z"
+         style="display:inline;fill:#5d569b;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1050"
+         d="m 328.16522,151.10717 c 0,0 -1.66551,2.70945 0.26462,4.63959 1.93014,1.93013 4.5154,0.20755 4.5154,0.20755 l 0.10742,-4.83596 z"
+         style="display:inline;fill:#ae81b7;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1052"
+         d="m 339.29445,156.06151 c 0,0 0.1041,-0.23982 0.35899,-4.61001 l -2.64475,-2.8284 -0.79397,0.54434 0.0633,4.48094 z"
+         style="display:inline;fill:#2a729d;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1054"
+         d="m 332.90555,155.94283 c 0,0 0.57362,2.96699 3.30324,2.96699 2.72962,0 3.10544,-2.88787 3.10544,-2.88787 l -3.0461,-3.04609 z"
+         style="display:inline;fill:#60a8d8;fill-opacity:1;stroke:none;stroke-width:0.132445" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1056"
+         d="m 344.05456,151.53091 c 0,0 -0.31118,-0.39509 -3.11986,-3.55159 l -3.97756,0.001 0.0109,0.71703 2.66494,2.86749 z"
+         style="display:inline;fill:#3a9b6b;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1058"
+         d="m 344.15791,144.99623 c 0,0 0.27691,-0.41044 -4.64827,-0.36099 l -2.56111,2.68003 0.007,0.69739 h 4.78925 z"
+         style="display:inline;fill:#82ba3c;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1060"
+         d="m 344.01391,151.52437 c 0,0 2.99231,-0.71286 2.99231,-3.44248 0,-2.72962 -2.88787,-3.10545 -2.88787,-3.10545 l -3.52714,3.00813 z"
+         style="display:inline;fill:#abd17f;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1062"
+         d="m 339.66851,140.22667 c 0,0 -0.59662,-0.10496 -4.04428,3.41264 l 0.53659,3.2385 0.81906,0.46743 3.11198,-3.30781 z"
+         style="display:inline;fill:#d8ab2d;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1064"
+         d="m 344.12431,144.97693 c 0,0 1.66705,-2.68081 -0.26309,-4.61095 -1.93013,-1.93013 -4.34709,-0.0969 -4.34709,-0.0969 l -0.007,4.37395 z"
+         style="display:inline;fill:#c1dc7b;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1066"
+         d="m 332.99662,140.05122 c 0,0 -0.42299,-0.21557 -0.37354,4.70961 l 2.40592,2.72763 1.1856,-0.61286 -0.0767,-4.35957 z"
+         style="display:inline;fill:#e75427;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1068"
+         d="m 339.51543,140.26834 c 0,0 -0.70353,-3.06542 -3.43315,-3.06542 -2.72963,0 -3.10544,2.88787 -3.10544,2.88787 l 3.17467,3.65927 z"
+         style="display:inline;fill:#f9a740;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1070"
+         d="m 328.21766,144.64713 c 0,0 -0.40116,-0.0138 3.11643,3.43385 1.06763,-0.0583 1.87035,-0.0667 3.64067,-0.16337 l 0.10155,-0.76142 -2.36255,-2.49221 z"
+         style="display:inline;fill:#dd2735;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1072"
+         d="m 332.98228,140.05115 c 0,0 -2.68578,-1.63341 -4.61591,0.29672 -1.93014,1.93014 -0.11889,4.41973 -0.11889,4.41973 l 4.49666,-0.0629 z"
+         style="display:inline;fill:#ec7a84;fill-opacity:1;stroke:none;stroke-width:0.132445"
+         sodipodi:nodetypes="csccc" />
+      <circle
+         id="circle1074"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1098);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.67534;marker:none;enable-background:accumulate"
+         cx="336"
+         cy="148"
+         r="1.2279347" />
+      <ellipse
+         transform="rotate(-2.1080534)"
+         id="ellipse1076"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7c061b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.67534;marker:none;enable-background:accumulate"
+         cx="327.45428"
+         cy="160.15552"
+         rx="1.6583447"
+         ry="0.5823195" />
+      <ellipse
+         id="ellipse1078"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#275f18;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.67534;marker:none;enable-background:accumulate"
+         cx="338.87976"
+         cy="148.03337"
+         rx="1.658345"
+         ry="0.58231956" />
+      <ellipse
+         id="ellipse1080"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ae3e09;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.46465;marker:none;enable-background:accumulate"
+         transform="rotate(91.152265)"
+         cx="138.48769"
+         cy="-339.0181"
+         rx="1.5375017"
+         ry="0.58231956" />
+      <ellipse
+         id="ellipse1082"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#151b4a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.87109;marker:none;enable-background:accumulate"
+         transform="rotate(90.556994)"
+         cx="147.69154"
+         cy="-337.69449"
+         rx="1.7747126"
+         ry="0.58231962" />
+      <ellipse
+         id="ellipse1084"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#950a0d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.77126;marker:none;enable-background:accumulate"
+         transform="matrix(0.68033204,0.73290403,-0.68033204,0.73290403,0,0)"
+         cx="344.99261"
+         cy="-145.78825"
+         rx="1.6863774"
+         ry="0.59216303" />
+      <ellipse
+         id="ellipse1086"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#093129;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.3699;marker:none;enable-background:accumulate"
+         transform="matrix(0.68204919,0.73130629,-0.75557282,0.65506466,0,0)"
+         cx="335.19754"
+         cy="-145.09645"
+         rx="1.861295"
+         ry="0.65358448" />
+      <ellipse
+         id="ellipse1088"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#526718;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.04345;marker:none;enable-background:accumulate"
+         transform="matrix(-0.69989827,0.71424255,-0.69989827,-0.71424255,0,0)"
+         cx="-139.42377"
+         cy="-343.80786"
+         rx="1.7659035"
+         ry="0.62008822" />
+      <ellipse
+         id="ellipse1090"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#3d0c34;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.22583;marker:none;enable-background:accumulate"
+         transform="rotate(135)"
+         cx="-130.20746"
+         cy="-342.38232"
+         rx="1.5269947"
+         ry="0.53619665" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1112"
+         d="m 334.49113,206.15591 c 0,0 2.1047,1.27689 3.58447,-0.20288 1.47977,-1.47976 0.11795,-3.24905 0.11795,-3.24905 l -3.60463,-0.11667 z"
+         style="display:inline;fill:#50bac0;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1114"
+         d="m 325.96875,202.38933 c 0,0 -0.0152,0.0455 3.76082,0.008 l 1.64013,-1.69692 -0.15705,-0.78111 -2.83794,0.0412 z"
+         style="display:inline;fill:#b32f58;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1116"
+         d="m 326.0937,197.48632 c 0,0 -2.30865,0.44462 -2.30865,2.53734 0,2.09271 2.21403,2.38084 2.21403,2.38084 l 2.49319,-2.37653 z"
+         style="display:inline;fill:#ef5f8a;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1118"
+         d="m 329.66702,206.08845 c 0,0 0.25479,-0.0669 2.59604,-2.26963 l 0.18357,-2.91278 -0.97322,-0.31588 -2.33455,2.40882 z"
+         style="display:inline;fill:#5d569b;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1120"
+         d="m 325.99333,202.38216 c 0,0 -1.27689,2.07725 0.20288,3.55702 1.47977,1.47977 3.46181,0.15913 3.46181,0.15913 l 0.0823,-3.70757 z"
+         style="display:inline;fill:#ae81b7;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1122"
+         d="m 334.52575,206.18049 c 0,0 0.0798,-0.18386 0.27522,-3.53434 l -2.02764,-2.16844 -0.60871,0.41733 0.0485,3.43538 z"
+         style="display:inline;fill:#2a729d;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1124"
+         d="m 329.62759,206.0895 c 0,0 0.43977,2.2747 2.53248,2.2747 2.09271,0 2.38084,-2.21404 2.38084,-2.21404 l -2.33534,-2.33533 z"
+         style="display:inline;fill:#60a8d8;fill-opacity:1;stroke:none;stroke-width:0.101541" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1126"
+         d="m 338.17516,202.70703 c 0,0 -0.23857,-0.3029 -2.39189,-2.72289 l -3.04946,9.2e-4 0.008,0.54972 2.04312,2.19841 z"
+         style="display:inline;fill:#3a9b6b;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1128"
+         d="m 338.2544,197.69711 c 0,0 0.2123,-0.31467 -3.56367,-0.27676 l -1.96353,2.05469 0.005,0.53466 h 3.67175 z"
+         style="display:inline;fill:#82ba3c;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1130"
+         d="m 338.144,202.70202 c 0,0 2.2941,-0.54653 2.2941,-2.63924 0,-2.09271 -2.21403,-2.38084 -2.21403,-2.38084 l -2.70414,2.30623 z"
+         style="display:inline;fill:#abd17f;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1132"
+         d="m 334.81252,194.04044 c 0,0 -0.4574,-0.0805 -3.10061,2.61636 l 0.41139,2.48285 0.62794,0.35836 2.38586,-2.53598 z"
+         style="display:inline;fill:#d8ab2d;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1134"
+         d="m 338.22864,197.68231 c 0,0 1.27807,-2.05529 -0.2017,-3.53506 -1.47977,-1.47977 -3.33277,-0.0743 -3.33277,-0.0743 l -0.005,3.35336 z"
+         style="display:inline;fill:#c1dc7b;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1136"
+         d="m 329.69741,193.90594 c 0,0 -0.3243,-0.16528 -0.28638,3.61069 l 1.84454,2.09119 0.90896,-0.46986 -0.0588,-3.34234 z"
+         style="display:inline;fill:#e75427;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1138"
+         d="m 334.69517,194.07239 c 0,0 -0.53938,-2.35015 -2.63209,-2.35015 -2.09271,0 -2.38084,2.21403 -2.38084,2.21403 l 2.43392,2.80544 z"
+         style="display:inline;fill:#f9a740;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1140"
+         d="m 326.03354,197.42946 c 0,0 -0.30756,-0.0106 2.38926,2.63263 0.81852,-0.0447 1.43394,-0.0511 2.79119,-0.12525 l 0.0778,-0.58376 -1.81129,-1.9107 z"
+         style="display:inline;fill:#dd2735;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1142"
+         d="m 329.68641,193.90588 c 0,0 -2.05909,-1.25228 -3.53886,0.22749 -1.47977,1.47977 -0.0911,3.38846 -0.0911,3.38846 l 3.44743,-0.0482 z"
+         style="display:inline;fill:#ec7a84;fill-opacity:1;stroke:none;stroke-width:0.101541"
+         sodipodi:nodetypes="csccc" />
+      <circle
+         id="circle1144"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1168);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.3511;marker:none;enable-background:accumulate"
+         cx="332"
+         cy="200"
+         r="0.94141674" />
+      <ellipse
+         transform="rotate(-2.1080529)"
+         id="ellipse1146"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7c061b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.3511;marker:none;enable-background:accumulate"
+         cx="322.21487"
+         cy="211.99741"
+         rx="1.2713981"
+         ry="0.44644511" />
+      <ellipse
+         id="ellipse1148"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#275f18;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.3511;marker:none;enable-background:accumulate"
+         cx="334.20782"
+         cy="200.02559"
+         rx="1.2713979"
+         ry="0.44644502" />
+      <ellipse
+         id="ellipse1150"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ae3e09;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.18956;marker:none;enable-background:accumulate"
+         transform="rotate(91.152265)"
+         cx="191.19359"
+         cy="-336.03897"
+         rx="1.1787513"
+         ry="0.44644502" />
+      <ellipse
+         id="ellipse1152"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#151b4a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.50117;marker:none;enable-background:accumulate"
+         transform="rotate(90.556994)"
+         cx="199.03616"
+         cy="-334.13681"
+         rx="1.3606128"
+         ry="0.44644499" />
+      <ellipse
+         id="ellipse1154"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#950a0d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.42463;marker:none;enable-background:accumulate"
+         transform="matrix(0.6803318,0.73290425,-0.6803318,0.73290425,0,0)"
+         cx="378.20813"
+         cy="-107.41575"
+         rx="1.2928895"
+         ry="0.45399174" />
+      <ellipse
+         id="ellipse1156"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#093129;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.88359;marker:none;enable-background:accumulate"
+         transform="matrix(0.68204917,0.73130632,-0.75557274,0.65506475,0,0)"
+         cx="371.17902"
+         cy="-106.62678"
+         rx="1.426993"
+         ry="0.50108159" />
+      <ellipse
+         id="ellipse1158"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#526718;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.63331;marker:none;enable-background:accumulate"
+         transform="matrix(-0.69989825,0.71424256,-0.69989825,-0.71424256,0,0)"
+         cx="-99.465149"
+         cy="-377.3136"
+         rx="1.35386"
+         ry="0.47540122" />
+      <ellipse
+         id="ellipse1160"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#3d0c34;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.00647;marker:none;enable-background:accumulate"
+         transform="rotate(135)"
+         cx="-91.246155"
+         cy="-376.29016"
+         rx="1.1706965"
+         ry="0.41108426" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1182"
+         d="m 329.55135,247.98654 c 0,0 1.37264,0.83275 2.3377,-0.13231 0.96507,-0.96506 0.0769,-2.11895 0.0769,-2.11895 l -2.35085,-0.0761 z"
+         style="display:inline;fill:#50bac0;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1184"
+         d="m 323.99328,245.53007 c 0,0 -0.01,0.0297 2.45271,0.005 l 1.06965,-1.10669 -0.10243,-0.50941 -1.85082,0.0268 z"
+         style="display:inline;fill:#b32f58;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1186"
+         d="m 324.07478,242.33246 c 0,0 -1.50565,0.28997 -1.50565,1.65478 0,1.36481 1.44394,1.55273 1.44394,1.55273 l 1.62598,-1.54991 z"
+         style="display:inline;fill:#ef5f8a;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1188"
+         d="m 326.4052,247.94254 c 0,0 0.16617,-0.0436 1.69307,-1.48019 l 0.11972,-1.89964 -0.63471,-0.20601 -1.52253,1.57097 z"
+         style="display:inline;fill:#5d569b;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1190"
+         d="m 324.00932,245.5254 c 0,0 -0.83276,1.35473 0.13231,2.31979 0.96507,0.96507 2.2577,0.10378 2.2577,0.10378 l 0.0537,-2.41798 z"
+         style="display:inline;fill:#ae81b7;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1192"
+         d="m 329.57393,248.00257 c 0,0 0.0521,-0.11991 0.1795,-2.305 l -1.32238,-1.4142 -0.39698,0.27217 0.0317,2.24046 z"
+         style="display:inline;fill:#2a729d;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1194"
+         d="m 326.37948,247.94323 c 0,0 0.28681,1.4835 1.65162,1.4835 1.36481,0 1.55272,-1.44394 1.55272,-1.44394 l -1.52305,-1.52304 z"
+         style="display:inline;fill:#60a8d8;fill-opacity:1;stroke:none;stroke-width:0.0662224" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1196"
+         d="m 331.95399,245.73727 c 0,0 -0.15559,-0.19754 -1.55993,-1.77579 l -1.98878,5.9e-4 0.005,0.35852 1.33247,1.43374 z"
+         style="display:inline;fill:#3a9b6b;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1198"
+         d="m 332.00566,242.46993 c 0,0 0.13846,-0.20521 -2.32413,-0.18049 l -1.28056,1.34001 0.004,0.3487 h 2.39463 z"
+         style="display:inline;fill:#82ba3c;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1200"
+         d="m 331.93366,245.734 c 0,0 1.49615,-0.35643 1.49615,-1.72124 0,-1.36481 -1.44393,-1.55272 -1.44393,-1.55272 l -1.76357,1.50406 z"
+         style="display:inline;fill:#abd17f;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1202"
+         d="m 329.76096,240.08515 c 0,0 -0.29831,-0.0525 -2.02214,1.70632 l 0.2683,1.61925 0.40953,0.23372 1.55599,-1.6539 z"
+         style="display:inline;fill:#d8ab2d;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1204"
+         d="m 331.98886,242.46028 c 0,0 0.83352,-1.3404 -0.13154,-2.30547 -0.96507,-0.96507 -2.17355,-0.0484 -2.17355,-0.0484 l -0.004,2.18697 z"
+         style="display:inline;fill:#c1dc7b;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1206"
+         d="m 326.42502,239.99743 c 0,0 -0.2115,-0.10779 -0.18677,2.3548 l 1.20296,1.36382 0.5928,-0.30643 -0.0384,-2.17979 z"
+         style="display:inline;fill:#e75427;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1208"
+         d="m 329.68442,240.10599 c 0,0 -0.35176,-1.53271 -1.71657,-1.53271 -1.36482,0 -1.55272,1.44393 -1.55272,1.44393 l 1.58733,1.82964 z"
+         style="display:inline;fill:#f9a740;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="csccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1210"
+         d="m 324.03554,242.29538 c 0,0 -0.20058,-0.007 1.55821,1.71693 0.53382,-0.0291 0.93518,-0.0333 1.82034,-0.0817 l 0.0508,-0.38071 -1.18127,-1.2461 z"
+         style="display:inline;fill:#dd2735;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1212"
+         d="m 326.41785,239.99739 c 0,0 -1.34289,-0.8167 -2.30796,0.14837 -0.96506,0.96506 -0.0594,2.20986 -0.0594,2.20986 l 2.24833,-0.0315 z"
+         style="display:inline;fill:#ec7a84;fill-opacity:1;stroke:none;stroke-width:0.0662224"
+         sodipodi:nodetypes="csccc" />
+      <circle
+         id="circle1214"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1238);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.83767;marker:none;enable-background:accumulate"
+         cx="327.9267"
+         cy="243.97182"
+         r="0.61396712" />
+      <ellipse
+         transform="rotate(-2.1080525)"
+         id="ellipse1216"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7c061b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.83767;marker:none;enable-background:accumulate"
+         cx="317.29337"
+         cy="255.81731"
+         rx="0.82917237"
+         ry="0.29115975" />
+      <ellipse
+         id="ellipse1218"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#275f18;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.83767;marker:none;enable-background:accumulate"
+         cx="329.36658"
+         cy="243.98849"
+         rx="0.82917213"
+         ry="0.29115966" />
+      <ellipse
+         id="ellipse1220"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ae3e09;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.73232;marker:none;enable-background:accumulate"
+         transform="rotate(91.152265)"
+         cx="235.96524"
+         cy="-332.82144"
+         rx="0.76875025"
+         ry="0.29115957" />
+      <ellipse
+         id="ellipse1222"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#151b4a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.93554;marker:none;enable-background:accumulate"
+         transform="rotate(90.556994)"
+         cx="242.25488"
+         cy="-330.41873"
+         rx="0.88735592"
+         ry="0.29115972" />
+      <ellipse
+         id="ellipse1224"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#950a0d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.88563;marker:none;enable-background:accumulate"
+         transform="matrix(0.68033202,0.73290404,-0.68033202,0.73290404,0,0)"
+         cx="405.98984"
+         cy="-74.472153"
+         rx="0.84318823"
+         ry="0.29608136" />
+      <ellipse
+         id="ellipse1226"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#093129;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.18495;marker:none;enable-background:accumulate"
+         transform="matrix(0.68204899,0.73130649,-0.75557285,0.65506463,0,0)"
+         cx="400.94083"
+         cy="-73.575272"
+         rx="0.93064719"
+         ry="0.32679206" />
+      <ellipse
+         id="ellipse1228"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#526718;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.02172;marker:none;enable-background:accumulate"
+         transform="matrix(-0.69989826,0.71424255,-0.69989826,-0.71424255,0,0)"
+         cx="-64.974388"
+         cy="-405.14136"
+         rx="0.88295126"
+         ry="0.31004396" />
+      <ellipse
+         id="ellipse1230"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#3d0c34;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.61292;marker:none;enable-background:accumulate"
+         transform="rotate(135)"
+         cx="-58.000763"
+         cy="-404.46466"
+         rx="0.76349735"
+         ry="0.26809832" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/libreoffice-base.svg
+++ b/icons/src/fullcolor/default/apps/libreoffice-base.svg
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="libreoffice-base.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
      id="base"
-     pagecolor="#878787"
+     pagecolor="#ffffff"
      bordercolor="#000000"
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2"
-     inkscape:cx="179.63841"
-     inkscape:cy="170.49077"
-     inkscape:current-layer="layer5"
-     showgrid="true"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="336.22927"
+     inkscape:cy="170.41273"
+     inkscape:current-layer="layer6"
+     showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -50,7 +50,7 @@
      gridtolerance="10000"
      inkscape:object-nodes="true"
      inkscape:snap-grids="true"
-     showguides="false"
+     showguides="true"
      inkscape:guide-bbox="true"
      inkscape:window-maximized="1"
      inkscape:bbox-paths="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,396 +93,131 @@
   <defs
      id="defs3">
     <linearGradient
-       id="linearGradient19927">
+       id="c"
+       x2="1"
+       gradientTransform="matrix(89.685004,-108.90312,108.90312,89.685004,1589.101,1450.2939)"
+       gradientUnits="userSpaceOnUse">
       <stop
+         stop-color="#f6fbff"
          offset="0"
-         style="stop-color:#c04fba;stop-opacity:1"
-         id="stop19923" />
+         id="stop12" />
       <stop
+         stop-color="#eaeff2"
          offset="1"
-         style="stop-color:#9911aa;stop-opacity:1"
-         id="stop19925" />
+         id="stop14" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="b"
+       x2="1"
+       gradientTransform="matrix(0,-203.23056,203.23056,0,561.91611,254.13381)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#661e85"
          offset="0"
-         id="stop923" />
+         id="stop7" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#c06de2"
          offset="1"
-         id="stop925" />
+         id="stop9" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-5">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient3194"
-       x1="335.73108"
-       y1="62"
-       x2="352.26993"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="169.66859"
-       x2="4.4137931"
-       y1="386.30838"
-       x1="494.34482"
-       id="linearGradient4226-1"
-       xlink:href="#linearGradient4338"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.96286,268)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6646"
-       x="-0.01363613"
-       width="1.0272723"
-       y="-0.01071443"
-       height="1.0214289">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.0000135"
-         id="feGaussianBlur6648" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6668"
-       x="-0.054544518"
-       width="1.109089"
-       y="-0.042857721"
-       height="1.0857154">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.000054"
-         id="feGaussianBlur6670" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4338">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(-0.00528208,-207.68287,207.68287,-0.00528208,235.61349,259.06168)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
+         stop-color="#b7b4b4"
          offset="0"
-         id="stop4340" />
+         id="stop2" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:1"
+         stop-color="#f1f1f1"
          offset="1"
-         id="stop4342" />
+         id="stop4" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient19927"
-       id="linearGradient18935"
-       x1="352.77151"
-       y1="106.5"
-       x2="335.23242"
-       y2="61.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983-6">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985-0"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971-6">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1311"
-       x1="327.99951"
-       y1="188"
-       x2="335.99951"
-       y2="212"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1309"
-       x1="332"
-       y1="236"
-       x2="324"
-       y2="252"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient19927"
-       id="linearGradient916"
+       xlink:href="#c"
+       id="linearGradient426"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05664062,-0.05663901,0,349.74506,214)"
-       x1="44.137936"
-       y1="240.29004"
-       x2="450.20694"
-       y2="386.29437" />
+       gradientTransform="matrix(18.417456,-22.364033,22.364033,18.417456,638.89156,349.3039)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient19927"
-       id="linearGradient920"
+       xlink:href="#b"
+       id="linearGradient428"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.03604403,-0.03604301,0,339.56482,252.90909)"
-       x1="39.093575"
-       y1="240.26906"
-       x2="455.25125"
-       y2="401.58029" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient19927"
-       id="linearGradient18935-0"
-       x1="352.89749"
-       y1="106.50614"
-       x2="334.86411"
-       y2="61.500103"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="matrix(0,-41.734847,41.734847,0,427.95181,103.66389)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient4316"
-       x1="372"
-       y1="134"
-       x2="372"
-       y2="162"
+       xlink:href="#a"
+       id="linearGradient430"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-37.000489)" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient18935-0-8"
-       x1="336.64893"
-       y1="59.040947"
-       x2="348.54202"
-       y2="108.83411"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="matrix(-0.00108471,-42.64916,42.64916,-0.00108471,360.94323,104.67587)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient9348"
+       xlink:href="#c"
+       id="linearGradient440"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.334262,0,0,0.351648,162.28952,-105.30615)"
-       x1="520.58502"
-       y1="735.05206"
-       x2="516.15179"
-       y2="720.86298" />
-    <linearGradient
-       id="linearGradient14494">
-      <stop
-         id="stop14496"
-         style="stop-color:#dc85e9;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop14498"
-         style="stop-color:#f2cbf8;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
+       gradientTransform="matrix(12.011383,-14.585237,14.585237,12.011383,528.46885,321.3429)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient9339"
+       xlink:href="#b"
+       id="linearGradient442"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.334262,0,0,0.351648,162.28952,-109.5037)"
-       x1="520.58502"
-       y1="735.05206"
-       x2="516.15179"
-       y2="720.86298" />
+       gradientTransform="matrix(0,-27.218375,27.218375,0,390.89947,161.14291)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient9342"
+       xlink:href="#a"
+       id="linearGradient444"
        gradientUnits="userSpaceOnUse"
-       x1="520.58502"
-       y1="735.05206"
-       x2="516.15179"
-       y2="720.86298"
-       gradientTransform="matrix(0.334262,0,0,0.351648,162.28952,-112.76174)" />
+       gradientTransform="matrix(-7.0741949e-4,-27.814666,27.814666,-7.0741949e-4,347.19821,161.8029)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient1389"
+       xlink:href="#c"
+       id="linearGradient454"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97892669,0,0,1.0007266,-171.40557,-739.99963)"
-       x1="525.4375"
-       y1="836.1875"
-       x2="516.65625"
-       y2="828.5" />
+       gradientTransform="matrix(8.8083482,-10.695841,10.695841,8.8083482,473.1438,327.11814)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient1391"
+       xlink:href="#b"
+       id="linearGradient456"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97892669,0,0,1.0007266,755.5951,-1698.6771)"
-       x1="525.4375"
-       y1="836.1875"
-       x2="516.65625"
-       y2="828.5" />
+       gradientTransform="matrix(0,-19.960143,19.960143,0,372.25958,209.63814)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient1393"
+       xlink:href="#a"
+       id="linearGradient458"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-125.5,-1702.459)"
-       x1="525.4375"
-       y1="836.1875"
-       x2="516.65625"
-       y2="828.5" />
+       gradientTransform="matrix(-5.1877433e-4,-20.397423,20.397423,-5.1877433e-4,340.21199,210.12213)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient1395"
+       xlink:href="#c"
+       id="linearGradient468"
        gradientUnits="userSpaceOnUse"
-       x1="520.58502"
-       y1="735.05206"
-       x2="516.15179"
-       y2="720.86298" />
+       gradientTransform="matrix(5.6053135,-6.8064455,6.8064455,5.6053135,417.81882,324.89338)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient19808"
+       xlink:href="#b"
+       id="linearGradient470"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97892669,0,0,1.0007266,-171.40557,-739.99963)"
-       x1="525.4375"
-       y1="836.1875"
-       x2="516.65625"
-       y2="828.5" />
+       gradientTransform="matrix(0,-12.701911,12.701911,0,353.61976,250.13337)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient19810"
+       xlink:href="#a"
+       id="linearGradient472"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97892669,0,0,1.0007266,755.5951,-1698.6771)"
-       x1="525.4375"
-       y1="836.1875"
-       x2="516.65625"
-       y2="828.5" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient19812"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-125.5,-1702.459)"
-       x1="525.4375"
-       y1="836.1875"
-       x2="516.65625"
-       y2="828.5" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient19814"
-       gradientUnits="userSpaceOnUse"
-       x1="520.58502"
-       y1="735.05206"
-       x2="516.15179"
-       y2="720.86298" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient19812-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-125.5,-1702.459)"
-       x1="525.4375"
-       y1="836.1875"
-       x2="516.65625"
-       y2="828.5" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient19814-9"
-       gradientUnits="userSpaceOnUse"
-       x1="520.58502"
-       y1="735.05206"
-       x2="516.15179"
-       y2="720.86298" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient19892"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97892669,0,0,1.0007266,-171.40557,-739.99963)"
-       x1="525.4375"
-       y1="836.1875"
-       x2="516.65625"
-       y2="828.5" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient14494"
-       id="linearGradient19894"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97892669,0,0,1.0007266,755.5951,-1698.6771)"
-       x1="525.4375"
-       y1="836.1875"
-       x2="516.65625"
-       y2="828.5" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient19927"
-       id="linearGradient18820-3"
-       x1="201.07812"
-       y1="269.99988"
-       x2="102.92188"
-       y2="45.999878"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="matrix(-3.3012918e-4,-12.980181,12.980181,-3.3012918e-4,333.22584,250.44136)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -581,7 +317,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">libreoffice-base</tspan></text>
+           id="tspan924">libreoffice-base</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -616,399 +352,129 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99158418;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 342.28786,133.99591 c -0.0832,0 -0.1556,0.007 -0.2168,0.0156 l -0.0371,0.006 -0.0371,0.0117 c -1.02052,0.30458 -1.3544,1.66824 -0.54687,2.36914 0,0 0,0.002 0,0.002 l 5.08984,4.76563 0.006,0.004 c 0.44144,0.39204 1.03582,0.39851 1.50781,0.21874 0.47199,-0.17975 0.9171,-0.5946 0.94141,-1.18945 v -0.01 -1.35352 -0.002 c 0.006,-1.0363 0.0251,-1.82214 -0.0176,-2.45508 -0.0427,-0.63344 -0.14348,-1.14825 -0.47266,-1.55274 -0.32917,-0.40448 -0.82834,-0.59266 -1.42968,-0.68554 -0.60135,-0.0929 -1.35232,-0.1114 -2.36133,-0.13281 h -0.006 -2.26953 c -0.0478,-0.005 -0.0951,-0.0117 -0.15039,-0.0117 z m -7.25782,0.002 -4.95507,0.002 c -2.79936,0 -4.57517,0.10197 -5.71875,1.13282 -0.24259,0.21892 -0.43083,0.4754 -0.5879,0.74414 -0.0117,0.02 -0.0564,0.0782 -0.11132,0.1875 -0.0907,0.18027 -0.17065,0.37241 -0.23828,0.57617 -0.0671,0.20198 -0.12496,0.41859 -0.17383,0.65039 -0.0486,0.23023 -0.0869,0.47111 -0.11914,0.72851 v 0.002 c -0.0646,0.51578 -0.10015,1.09026 -0.11524,1.73633 -0.007,0.32198 -0.0116,0.66266 -0.01,1.02343 v 8.21875 8.22071 c -0.002,0.3594 0.002,0.69873 0.01,1.02148 0.0151,0.64603 0.0505,1.22236 0.11524,1.73828 0.0323,0.25754 0.0707,0.4986 0.11914,0.72852 0.0971,0.4603 0.23097,0.86702 0.41211,1.22656 0.18147,0.36018 0.41279,0.67544 0.69922,0.93359 0.14342,0.12929 0.30075,0.24284 0.46679,0.34375 0.33271,0.20222 0.70911,0.35057 1.12891,0.46094 v 0.002 c 1.04936,0.27537 2.37421,0.32422 4.12305,0.32422 h 11.85546 c 0.69562,0 1.32241,-0.0101 1.89063,-0.0371 h 0.002 c 0.23885,-0.0115 0.45772,-0.0289 0.66992,-0.0469 h 0.002 0.002 c 0.006,-5.4e-4 0.052,-0.004 0.0898,-0.006 h 0.0137 c 0.0155,-0.001 0.0141,-1.1e-4 0.0332,-0.002 h 0.002 c 0.51385,-0.0486 0.97388,-0.12251 1.38867,-0.23047 0.20576,-0.0536 0.4054,-0.11525 0.59571,-0.19141 0.18901,-0.0755 0.36479,-0.163 0.52929,-0.26172 0.1657,-0.0995 0.3216,-0.21271 0.46485,-0.33984 0.12928,-0.11465 0.24087,-0.23957 0.34179,-0.36524 0,2e-5 0.005,-0.005 0.006,-0.006 l 0.0215,-0.0215 0.0156,-0.0195 0.006,-0.008 0.002,-0.004 0.008,-0.008 0.008,-0.0137 c 4e-5,-7e-5 0.008,-0.016 0.0117,-0.0234 0.003,-0.004 0.009,-0.008 0.0117,-0.0117 -5.4e-4,7e-4 -0.007,0.003 -0.008,0.004 0.01,-0.0181 0.0172,-0.0306 0.0254,-0.0469 -0.006,0.0128 -0.01,0.0233 -0.0117,0.0273 0.095,-0.13149 0.18742,-0.26844 0.26562,-0.41992 0.0922,-0.17881 0.17175,-0.3686 0.24024,-0.56836 0.069,-0.20111 0.12594,-0.41283 0.17578,-0.63867 0.0501,-0.22709 0.0911,-0.46643 0.125,-0.71875 0.0307,-0.22912 0.0546,-0.4717 0.0742,-0.71875 l 0.002,-0.002 v -0.004 c -10e-4,0.0185 0.005,-0.009 0.01,-0.082 v -0.002 c 0.002,-0.0307 0.004,-0.0623 0,-0.006 v -0.002 -0.002 c 0.0411,-0.56466 0.0568,-1.18956 0.0586,-1.89062 v -0.004 -11.1875 c -0.007,-1.5618 -1.32097,-2.69049 -2.26758,-3.50391 l -0.01,-0.008 -0.002,-0.002 -6.71093,-6.47461 -0.008,-0.006 c -1.54333,-1.391 -2.79437,-2.15039 -4.97461,-2.15039 z"
-         id="path964-1-7-1"
-         inkscape:connector-curvature="0" />
+         d="m 247.78973,259.06168 -58.16888,-0.0674 V 51.54534 l 59.83429,-0.2166 c 10.39675,0.12515 15.59513,8.22114 15.59513,17.94884 v 170.99774 c 0.45245,10.68074 -6.60387,18.55532 -17.26054,18.78636 z"
+         fill="url(#a)"
+         id="path17"
+         style="fill:url(#a);stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.13511628;marker:none;enable-background:accumulate"
-         d="m 334.82422,134.58984 c -0.9565,0.006 -1.94374,0.13967 -2.86914,0.0449 h -0.17774 -0.12695 c -2.04449,0.15318 -4.20028,-0.32322 -6.11914,0.53906 -1.24349,0.92669 -0.67994,2.70613 -0.86328,4 -0.0369,6.59935 -0.18916,13.25502 0.082,19.80859 -0.17171,1.43522 1.18239,2.40622 2.5,2.38672 5.85305,0.12643 11.71895,0.17618 17.56836,-0.084 1.24609,0.0815 2.43752,-0.91538 2.31445,-2.22071 0.22226,-4.63848 0.23435,-9.29109 0.15821,-13.93359 -0.12185,-1.14821 -1.40667,-1.73493 -2.03516,-2.60547 -2.55012,-2.43536 -4.93774,-5.08 -7.75195,-7.2168 -0.79841,-0.6017 -1.72319,-0.72444 -2.67969,-0.71875 z"
-         id="rect4158-92-6-7-3"
-         inkscape:connector-curvature="0" />
+         d="m 155.74957,51.57903 79.47742,-7.451003 c 10.6326,-1.073368 15.27744,4.630407 15.35928,16.062023 l -0.67388,187.96466 C 249.71987,260.87149 244.03052,267.53311 232.81551,268 L 156.2694,259.06168 H 74.520105 c -10.44007,0 -21.04861,-8.50031 -21.10637,-21.74655 V 72.58914 c 0.3995,-15.23894 6.75308,-20.98123 21.99202,-21.2604 z"
+         fill="url(#b)"
+         id="path19"
+         style="fill:url(#b);stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.13511628;marker:none;enable-background:accumulate"
-         d="m 342.43453,133.5 c -0.0499,0 -0.0992,0.005 -0.14846,0.0114 -0.63275,0.19268 -0.84778,1.10823 -0.35998,1.53887 l 5.15449,4.82872 c 0.52901,0.47937 1.38249,0.0699 1.41036,-0.62634 v -1.36063 c 0.0226,-4.21424 0.33006,-4.29412 -3.66401,-4.38062 h -2.24263 c -0.0493,-0.007 -0.0999,-0.0114 -0.14977,-0.0114 z m -12.63559,0.0804 c -5.53701,-3.3e-4 -6.32794,0.58227 -6.29884,6.26467 v 8.19515 8.19514 c -0.0291,5.68242 1.00827,6.26467 6.54528,6.26467 h 11.7978 c 5.49726,0 6.52858,-0.57993 6.54266,-6.15295 v -11.14923 c -0.006,-1.25658 -1.15546,-2.31787 -2.08629,-3.11916 l -0.008,-0.006 -6.70166,-6.47491 c -1.50985,-1.36345 -2.55339,-2.01695 -4.61908,-2.01707 z m 7.22852,2.4196 8.97205,8.99977 V 158 c 0,0 -0.11213,1.17819 -0.44846,1.49951 -0.33633,0.32134 -1.56951,0.42847 -1.56951,0.42847 h -15.96407 c 0,0 -1.23318,-0.10713 -1.56951,-0.42847 C 326.11164,159.17819 325.99951,158 325.99951,158 l -0.018,-20.07203 c 0,0 0.11213,-1.17819 0.44845,-1.49951 C 326.76633,136.10713 327.99951,136 327.99951,136 Z"
-         id="rect4158-92-6-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 249.9124,248.15471 c -0.19253,12.71678 -5.88187,19.3784 -17.09688,19.84529 l -77.41251,-9.0394 V 51.61273 l 79.82398,-7.484703 c 10.6326,-1.073368 15.27745,4.630407 15.35928,16.062023 z"
+         fill-opacity="0.15"
+         id="path21"
+         style="stroke-width:4.81331" />
       <path
-         style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 323.49951,148 v 0.041 8.19531 c -0.0291,5.68242 1.00791,6.26367 6.54492,6.26367 h 11.79883 c 5.49726,0 6.52889,-0.57932 6.54297,-6.15234 V 148 Z"
-         id="rect4398"
-         inkscape:connector-curvature="0" />
+         d="m 363.44371,104.67587 -11.94539,-0.0138 V 62.060904 l 12.2874,-0.04448 c 2.13504,0.0257 3.20257,1.688269 3.20257,3.685924 v 35.115602 c 0.0929,2.19337 -1.35615,3.81047 -3.54458,3.85792 z"
+         fill="url(#a)"
+         id="path418"
+         style="fill:url(#linearGradient430);stroke-width:0.988448" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 353.50267,61.373185 c -0.13268,1.3e-4 -0.25604,0.01264 -0.36719,0.0293 l -0.0781,0.01172 -0.0762,0.02344 c -0.87574,0.279121 -1.39412,1.031903 -1.56445,1.792968 -0.1518,0.678132 0.0116,1.444638 0.51367,2.050782 l -0.36328,-0.363282 -0.01,-0.0078 -0.002,-0.0039 c 0,0 -0.002,0.0038 -0.002,0.0039 -0.28283,-0.267301 -0.55686,-0.524525 -0.83398,-0.767578 h -0.002 l -0.002,-0.0039 -0.002,-0.002 c 0,0 -0.006,-0.0019 -0.006,-0.002 -0.2711,-0.237536 -0.5406,-0.460957 -0.81055,-0.669923 0,0 -0.006,-0.0038 -0.006,-0.0039 -1.8e-4,-8.6e-5 -0.006,-0.0038 -0.006,-0.0039 -0.26922,-0.208011 -0.54257,-0.405967 -0.82617,-0.587891 h -0.002 l -0.002,-0.002 c 0,10e-7 -0.004,-0.0019 -0.004,-0.002 -0.27684,-0.177258 -0.55998,-0.341168 -0.85742,-0.488281 1e-5,0 -0.006,-0.0019 -0.006,-0.002 -0.29595,-0.146081 -0.60404,-0.275888 -0.92383,-0.386719 l -0.004,-0.002 h -0.002 -0.002 c -0.31787,-0.109783 -0.64897,-0.202793 -0.99414,-0.275391 0,-1e-6 -0.009,7.3e-5 -0.01,0 -0.34183,-0.07151 -0.69666,-0.126987 -1.07031,-0.162109 h -0.002 c -0.37669,-0.03533 -0.76878,-0.05072 -1.17774,-0.05078 h -0.002 -8.26738 c -4.1516,0 -6.86541,0.144562 -8.65234,1.832031 -0.89392,0.844181 -1.42053,2.015243 -1.71289,3.464843 -0.29235,1.449602 -0.3762,2.716182 -0.36524,4.956606 V 84.497515 97.24947 c -0.0108,2.23702 0.0732,4.00312 0.36524,5.45117 0.29236,1.44961 0.81896,2.62067 1.71289,3.46485 0.22046,0.20818 0.46372,0.3989 0.72656,0.5664 l 0.004,0.002 0.006,0.004 c 0,0 0.011,0.004 0.0117,0.004 0.24938,0.15738 0.51414,0.29744 0.79688,0.41797 l 0.006,0.002 c 10e-4,5.8e-4 0.003,0.003 0.004,0.004 h 0.002 c 0.001,2.9e-4 0.01,0.003 0.0117,0.004 0.28562,0.12045 0.58739,0.22665 0.90625,0.31446 h 0.002 0.002 c 0.31721,0.0872 0.65158,0.16192 1.00586,0.22265 h 0.004 0.002 0.002 c 0.35215,0.0602 0.71743,0.1063 1.10157,0.14453 2e-5,0 0.005,-1e-5 0.006,0 0.38435,0.0381 0.78775,0.0683 1.21289,0.0899 h 0.004 0.002 c 4.7e-4,1e-5 0.005,-1e-5 0.006,0 l 0.004,0.002 c 3.5e-4,1e-5 0.0746,-7e-5 0.0723,0 0.83602,0.0405 1.74479,0.0566 2.7539,0.0566 h 0.002 17.03691 c 4.12301,0 6.31689,-0.14175 8.10202,-1.80273 0.89298,-0.83017 1.42413,-1.9843 1.72461,-3.41016 0.30048,-1.42587 0.39703,-3.16132 0.40234,-5.35937 v -18.908211 -0.002 c -0.009,-1.901937 -1.18883,-3.38937 -2.32226,-4.541016 -0.37676,-0.382884 -0.75737,-0.733609 -1.10938,-1.050781 l -0.28515,-0.257813 h 0.0273 l -0.0117,-0.01172 h -0.002 l -0.0508,-0.05078 c 0.7203,0.562642 1.63962,0.613597 2.36523,0.31836 0.78035,-0.317514 1.50219,-1.045367 1.54102,-2.060547 v -0.01953 -2.13086 -0.0059 c 0.008,-1.627913 0.0362,-2.366723 -0.0274,-3.374573 -0.0638,-1.009375 -0.2058,-1.850441 -0.73633,-2.546875 -0.53053,-0.696434 -1.36221,-1.029213 -2.28515,-1.181641 -0.92293,-0.152428 -2.03533,-0.179157 -3.52344,-0.212891 h -0.0117 -2.84421 -0.002 c -0.073,-0.0069 -0.14393,-0.0174 -0.2207,-0.01758 z m -24.57206,43.876525 c 7.7e-4,4.2e-4 10e-4,0.002 0.002,0.002 -0.0334,0.003 -0.0689,0.006 -0.0684,0.006 5.2e-4,-8e-5 0.0335,-0.004 0.0664,-0.008 z m -0.0312,1.98438 c 0.005,2.6e-4 0.0335,0.004 0.0645,0.006 -0.0263,-10e-4 -0.0586,-0.004 -0.0586,-0.004 z"
-         id="path964-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccscccccccccccccccccccccccccccccccscsccccccccccccccccccsccccccccccccccc" />
+         d="m 344.54261,62.067822 16.32125,-1.530116 c 2.18348,-0.220424 3.13734,0.950887 3.15414,3.298451 l -0.13838,38.599883 c -0.0395,2.61148 -1.20789,3.9795 -3.51097,4.07538 l -15.71929,-1.83555 h -16.7878 c -2.14395,0 -4.32249,-1.7456 -4.33435,-4.46581 V 66.3824 c 0.082,-3.129426 1.3868,-4.308646 4.51622,-4.365975 z"
+         fill="url(#b)"
+         id="path420"
+         style="fill:url(#linearGradient428);stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6668);enable-background:accumulate"
-         d="M 102.92188 46 C 67.62515 46 64 49.625611 64 84.994141 L 64 156 L 64 158 L 64 229.00586 C 64 244.47959 64.693319 253.87799 68.429688 259.55469 C 68.963453 260.36564 69.559812 261.0997 70.224609 261.76562 C 75.542989 267.0931 85.27351 268 102.92188 268 L 201.07812 268 C 203.13276 268 205.06552 267.98518 206.91211 267.95508 C 207.57101 267.94428 208.1733 267.9199 208.80664 267.9043 C 209.95599 267.876 211.09853 267.8452 212.16602 267.79883 C 213.43596 267.74363 214.67536 267.67931 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.44517 267.45882 217.67424 267.44102 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67577 267.09975 221.31832 267.00362 221.94336 266.90039 C 222.16533 266.86369 222.37512 266.82019 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.01019 266.50659 224.24912 266.45017 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.69251 266.09626 225.94528 266.02572 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.98625 265.36467 228.26277 265.25859 228.53516 265.14844 C 228.73131 265.06914 228.92945 264.98988 229.11914 264.90625 C 229.3939 264.78514 229.6565 264.65577 229.91797 264.52539 C 230.0924 264.43839 230.27277 264.35491 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.02943 263.29518 232.41788 263.01413 232.78711 262.71484 C 233.12677 262.43952 233.44633 262.14559 233.75586 261.8418 C 233.83036 261.7687 233.90178 261.69201 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01257 256.99161 237.07571 256.85555 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.81286 254.90311 237.95901 254.4144 238.09961 253.91406 C 238.14041 253.7689 238.17961 253.62078 238.21875 253.47266 C 238.28325 253.22887 238.34214 252.97259 238.40234 252.7207 C 238.54618 252.11901 238.67815 251.49292 238.79883 250.84375 C 238.83073 250.67198 238.86618 250.50525 238.89648 250.33008 C 239.03717 249.51898 239.16395 248.67505 239.27344 247.78906 C 239.29544 247.61129 239.31328 247.41914 239.33398 247.23828 C 239.41648 246.52006 239.48974 245.77779 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78859 241.4566 239.80646 241.21235 239.81836 240.95312 C 239.82536 240.80563 239.82738 240.64128 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96989 235.43296 239.97567 235.00563 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 128.24023 C 239.956 118.50733 231.82093 110.28461 225.23828 104.07812 L 225.18945 104.02734 L 184.66602 61.619141 C 173.98913 51.057981 166.6082 46 152 46 L 102.92188 46 z M 199.9043 46.089844 C 197.73512 48.865721 197.51891 53.493389 200.11328 56.001953 L 228.60938 86.388672 C 232.33314 90.084594 239.72783 86.956935 239.99023 81.609375 C 239.9886 81.189355 239.99156 80.748144 239.98828 80.337891 C 239.98738 79.846541 239.97958 79.384529 239.97656 78.90625 C 239.61491 51.652251 235.0161 46.715732 208.63086 46.089844 L 199.9043 46.089844 z "
-         id="path5316-1" />
+         d="m 363.87962,102.43604 c -0.0395,2.61148 -1.20789,3.9795 -3.51097,4.07538 l -15.89721,-1.85631 V 62.074745 l 16.39242,-1.537037 c 2.18348,-0.220424 3.13734,0.950887 3.15414,3.298451 z"
+         fill-opacity="0.15"
+         id="path422"
+         style="stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6646);enable-background:accumulate"
-         d="M 102.92188 45 C 67.62515 45 64 48.625611 64 83.994141 L 64 156 L 64 157 L 64 229.00586 C 64 244.47959 64.693319 253.87799 68.429688 259.55469 C 68.963453 260.36564 69.559812 261.0997 70.224609 261.76562 C 75.542989 267.0931 85.27351 268 102.92188 268 L 201.07812 268 C 203.13276 268 205.06552 267.98518 206.91211 267.95508 C 207.57101 267.94428 208.1733 267.9199 208.80664 267.9043 C 209.95599 267.876 211.09853 267.8452 212.16602 267.79883 C 213.43596 267.74363 214.67536 267.67931 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.44517 267.45882 217.67424 267.44102 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67577 267.09975 221.31832 267.00362 221.94336 266.90039 C 222.16533 266.86369 222.37512 266.82019 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.01019 266.50659 224.24912 266.45017 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.69251 266.09626 225.94528 266.02572 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.98625 265.36467 228.26277 265.25859 228.53516 265.14844 C 228.73131 265.06914 228.92945 264.98988 229.11914 264.90625 C 229.3939 264.78514 229.6565 264.65577 229.91797 264.52539 C 230.0924 264.43839 230.27277 264.35491 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.02943 263.29518 232.41788 263.01413 232.78711 262.71484 C 233.12677 262.43952 233.44633 262.14559 233.75586 261.8418 C 233.83036 261.7687 233.90178 261.69201 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01257 256.99161 237.07571 256.85555 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.81286 254.90311 237.95901 254.4144 238.09961 253.91406 C 238.14041 253.7689 238.17961 253.62078 238.21875 253.47266 C 238.28325 253.22887 238.34214 252.97259 238.40234 252.7207 C 238.54618 252.11901 238.67815 251.49292 238.79883 250.84375 C 238.83073 250.67198 238.86618 250.50525 238.89648 250.33008 C 239.03717 249.51898 239.16395 248.67505 239.27344 247.78906 C 239.29544 247.61129 239.31328 247.41914 239.33398 247.23828 C 239.41648 246.52006 239.48974 245.77779 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78859 241.4566 239.80646 241.21235 239.81836 240.95312 C 239.82536 240.80563 239.82738 240.64128 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96989 235.43296 239.97567 235.00563 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 127.24023 C 239.956 117.50733 231.82093 109.28462 225.23828 103.07812 L 225.18945 103.02734 L 184.66602 60.619141 C 173.98913 50.057981 166.6082 45 152 45 L 102.92188 45 z M 200.89062 45.089844 C 197.85089 47.592149 197.17007 53.156086 200.11328 56.001953 L 228.60938 86.388672 C 232.33829 90.089704 239.75115 86.948987 239.99414 81.587891 C 239.99392 81.377038 239.99278 81.169387 239.99219 80.960938 C 239.99209 79.762634 239.97942 78.632386 239.9668 77.509766 C 239.56354 50.620533 234.88168 45.712543 208.63086 45.089844 L 200.89062 45.089844 z "
-         id="path5316-84" />
+         d="m 348.82897,161.8029 -7.79048,-0.009 v -27.78336 l 8.01353,-0.029 c 1.39241,0.0168 2.08863,1.10104 2.08863,2.40386 v 22.90148 c 0.0606,1.43045 -0.88445,2.48508 -2.31168,2.51603 z"
+         fill="url(#a)"
+         id="path432"
+         style="fill:url(#linearGradient444);stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="M 102.92188 44 C 100.74614 44 98.695529 44.014677 96.753906 44.048828 C 67.272036 44.576673 64.085938 49.836144 64.085938 82.994141 L 64.085938 156 L 64.085938 229.00586 C 64.085938 262.16386 67.272036 267.42333 96.753906 267.95117 C 98.695529 267.98532 100.74614 268 102.92188 268 C 102.95214 268.00001 102.9775 268 103.00781 268 L 201.07812 268 C 203.13276 268 205.06552 267.98518 206.91211 267.95508 C 207.57101 267.94428 208.1733 267.9199 208.80664 267.9043 C 209.95599 267.876 211.09853 267.8452 212.16602 267.79883 C 213.43596 267.74363 214.67536 267.67931 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.44517 267.45882 217.67424 267.44102 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67577 267.09975 221.31832 267.00362 221.94336 266.90039 C 222.16533 266.86369 222.37512 266.82019 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.01019 266.50659 224.24912 266.45017 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.69251 266.09626 225.94528 266.02572 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.98625 265.36467 228.26277 265.25859 228.53516 265.14844 C 228.73131 265.06914 228.92945 264.98988 229.11914 264.90625 C 229.3939 264.78514 229.6565 264.65577 229.91797 264.52539 C 230.0924 264.43839 230.27277 264.35491 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.02943 263.29518 232.41788 263.01413 232.78711 262.71484 C 233.12677 262.43952 233.44633 262.14559 233.75586 261.8418 C 233.83036 261.7687 233.90178 261.69201 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01257 256.99161 237.07571 256.85555 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.81286 254.90311 237.95901 254.4144 238.09961 253.91406 C 238.14041 253.7689 238.17961 253.62078 238.21875 253.47266 C 238.28325 253.22887 238.34214 252.97259 238.40234 252.7207 C 238.54618 252.11901 238.67815 251.49292 238.79883 250.84375 C 238.83073 250.67198 238.86618 250.50525 238.89648 250.33008 C 239.03717 249.51898 239.16395 248.67505 239.27344 247.78906 C 239.29544 247.61129 239.31328 247.41914 239.33398 247.23828 C 239.41648 246.52006 239.48974 245.77779 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78859 241.4566 239.80646 241.21235 239.81836 240.95312 C 239.82536 240.80563 239.82738 240.64128 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96989 235.43296 239.97567 235.00563 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 126.24023 C 239.956 116.50733 231.82093 108.28461 225.23828 102.07812 L 225.18945 102.02734 L 184.66602 59.619141 C 173.98918 49.057981 166.6082 44 152 44 L 102.92188 44 z M 202.6543 44.089844 C 198.17969 45.582244 196.66368 52.666443 200.11328 56.001953 L 228.60938 86.388672 C 232.34293 90.094303 239.77066 86.941636 239.99609 81.568359 C 240.04429 50.239345 236.44281 44.749576 208.63086 44.089844 L 202.6543 44.089844 z "
-         id="path5316-3" />
+         d="m 336.50216,134.01505 10.64429,-0.9979 c 1.424,-0.14376 2.04609,0.62014 2.05704,2.15116 l -0.0902,25.17383 c -0.0258,1.70314 -0.78776,2.59533 -2.28976,2.65786 l -10.25171,-1.1971 h -10.94856 c -1.39823,0 -2.81903,-1.13843 -2.82675,-2.91248 V 136.8289 c 0.0535,-2.04093 0.90443,-2.80998 2.94536,-2.84737 z"
+         fill="url(#b)"
+         id="path434"
+         style="fill:url(#linearGradient442);stroke-width:0.64464" />
       <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
+         d="m 349.11326,160.34214 c -0.0258,1.70314 -0.78776,2.59533 -2.28977,2.65786 l -10.36774,-1.21064 v -27.7698 l 10.69071,-1.00241 c 1.424,-0.14376 2.04609,0.62014 2.05704,2.15116 z"
+         fill-opacity="0.15"
+         id="path436"
+         style="stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188,44.000001 C 67.62516,44.000001 64,47.625611 64,82.994141 V 156 229.00586 C 64,264.37439 67.62516,268 102.92188,268 h 98.15625 C 236.37486,268 240.17299,264.37398 240,229.00586 V 126.24023 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 C 173.98919,49.057941 166.6082,44.000001 152,44.000001 Z"
-         id="path5316"
-         inkscape:connector-curvature="0" />
+         d="m 341.40788,210.12213 -5.71302,-0.007 v -20.37447 l 5.8766,-0.0213 c 1.02109,0.0123 1.53165,0.80743 1.53165,1.76283 v 16.79442 c 0.0444,1.04899 -0.64859,1.82239 -1.69522,1.84509 z"
+         fill="url(#a)"
+         id="path446"
+         style="fill:url(#linearGradient458);stroke-width:0.472736" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
+         d="m 332.36822,189.74437 7.80581,-0.73179 c 1.04427,-0.10543 1.50047,0.45477 1.5085,1.57751 l -0.0661,18.46081 c -0.0189,1.24897 -0.57769,1.90325 -1.67915,1.9491 l -7.51793,-0.87787 h -8.02893 c -1.02538,0 -2.0673,-0.83485 -2.07295,-2.13582 v -16.17845 c 0.0392,-1.49668 0.66325,-2.06065 2.15992,-2.08807 z"
+         fill="url(#b)"
+         id="path448"
+         style="fill:url(#linearGradient456);stroke-width:0.472736" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 337.2168,62.574219 c -2.7098,0.12547 -5.46999,-0.250541 -8.0918,0.568359 -2.08748,0.75242 -2.46235,3.243478 -2.36523,5.175781 -0.1807,10.955331 -0.23237,21.969994 0.0547,32.943361 -0.0101,1.80393 1.22123,3.61424 3.10352,3.82617 3.65661,0.63906 7.39397,0.27675 11.09961,0.39844 5.44724,-0.065 10.90764,0.10562 16.3457,-0.24219 1.58384,-0.18462 3.23299,-1.05524 3.57227,-2.74609 0.75568,-3.399533 0.43919,-6.897729 0.54687,-10.355472 -0.004,-4.974085 -0.0437,-9.947844 -0.0644,-14.921875 -1.49184,-2.396254 -3.72455,-4.200757 -5.60742,-6.251953 -2.61848,-2.514691 -5.07087,-5.249305 -7.97657,-7.435547 -2.0803,-1.380255 -4.71905,-0.79357 -7.06836,-0.958984 -1.18254,-0.0012 -2.36628,-0.0023 -3.54882,0 z"
-         id="path964"
-         inkscape:connector-curvature="0" />
+         d="m 341.61636,209.0509 c -0.0189,1.24897 -0.57769,1.90325 -1.67916,1.9491 l -7.60301,-0.8878 v -20.36452 l 7.83985,-0.7351 c 1.04427,-0.10543 1.50047,0.45477 1.5085,1.57751 z"
+         fill-opacity="0.15"
+         id="path450"
+         style="stroke-width:0.472736" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.20550393;marker:none;enable-background:accumulate"
-         d="m 353.5,61.375 c -0.0742,0 -0.1474,0.0066 -0.2207,0.01758 -0.94065,0.29981 -1.26034,1.724451 -0.53516,2.394531 l 7.51367,7.513672 c 0.78643,0.74591 2.35309,0.108771 2.39453,-0.974609 v -2.117188 c 0.0336,-6.55752 0.34204,-6.681806 -5.5957,-6.816406 h -3.33398 C 353.64936,61.381278 353.57418,61.375 353.5,61.375 Z M 335.23047,61.5 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 V 84 96.751953 c -0.0433,8.842037 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70563,-0.9024 9.72656,-9.574219 V 78.021484 c -0.009,-1.95527 -1.71775,-3.606675 -3.10156,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 C 348.62066,62.51706 347.069,61.5 343.99805,61.5 Z M 346.5,65 359,77.5 V 100 c 0,0 -0.1667,1.8333 -0.6667,2.3333 C 357.8333,102.8333 356,103 356,103 h -24 c 0,0 -1.8333,-0.1667 -2.3333,-0.6667 C 329.1667,101.8333 329,100 329,100 V 68 c 0,0 0.1667,-1.8333 0.6667,-2.3333 C 330.1667,65.1667 332,65 332,65 Z"
-         id="rect4158-92-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 333.98685,250.44136 -3.63555,-0.004 v -12.96557 l 3.73965,-0.0135 c 0.64979,0.008 0.97469,0.51382 0.97469,1.1218 v 10.68736 c 0.0283,0.66754 -0.41274,1.1597 -1.07878,1.17415 z"
+         fill="url(#a)"
+         id="path460"
+         style="fill:url(#linearGradient472);stroke-width:0.300832" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.90435,236.5 c 0.71048,0 1.27344,0.0154 1.75195,0.0957 0.47851,0.0803 0.89671,0.23728 1.20703,0.54688 0.31032,0.30959 0.46726,0.7261 0.54688,1.20508 0.0796,0.47897 0.0933,1.04352 0.0898,1.75586 V 244 v 3.89844 c 0.003,0.71121 -0.0103,1.27546 -0.0898,1.7539 -0.0796,0.47898 -0.23655,0.89549 -0.54688,1.20508 -0.31033,0.3096 -0.72851,0.46655 -1.20703,0.54688 -0.47852,0.0803 -1.04147,0.0957 -1.75195,0.0957 h -5.8086 c -0.71048,0 -1.27236,-0.0153 -1.75,-0.0957 -0.47763,-0.0804 -0.89584,-0.23713 -1.20508,-0.54688 -0.30921,-0.30975 -0.46469,-0.72681 -0.54492,-1.20508 -0.0802,-0.47826 -0.0957,-1.04201 -0.0957,-1.7539 V 244 240.10156 c 0,-0.71189 0.0155,-1.27564 0.0957,-1.7539 0.0802,-0.47827 0.2357,-0.89533 0.54492,-1.20508 0.30924,-0.30975 0.72745,-0.4665 1.20508,-0.54688 0.47764,-0.0804 1.03952,-0.0957 1.75,-0.0957 z"
-         id="path918"
-         inkscape:connector-curvature="0" />
+         d="m 328.23434,237.47369 4.96734,-0.46568 c 0.66453,-0.0671 0.95484,0.2894 0.95995,1.00387 l -0.0421,11.74779 c -0.012,0.7948 -0.36762,1.21116 -1.06855,1.24033 l -4.78414,-0.55864 h -5.10932 c -0.65251,0 -1.31555,-0.53127 -1.31915,-1.35916 v -10.29538 c 0.0249,-0.95243 0.42207,-1.31132 1.37449,-1.32877 z"
+         fill="url(#b)"
+         id="path462"
+         style="fill:url(#linearGradient470);stroke-width:0.300832" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 336.13453,188.5 c 1.11158,0 1.98683,0.0256 2.70703,0.14648 0.72019,0.1209 1.3105,0.34863 1.74218,0.7793 0.43169,0.43067 0.65954,1.01974 0.7793,1.74024 0.11977,0.72049 0.14217,1.59669 0.13672,2.71093 V 200 v 6.125 c 0.005,1.1131 -0.017,1.989 -0.13672,2.70898 -0.11976,0.72051 -0.3476,1.30957 -0.7793,1.74024 -0.43169,0.43067 -1.02199,0.6584 -1.74218,0.7793 -0.7202,0.12089 -1.59545,0.14648 -2.70703,0.14648 h -8.26954 c -1.11158,0 -1.98637,-0.0255 -2.70507,-0.14648 -0.7187,-0.12095 -1.30623,-0.34848 -1.73633,-0.7793 -0.4301,-0.43083 -0.6566,-1.01849 -0.77735,-1.73828 -0.12074,-0.71979 -0.14648,-1.59713 -0.14648,-2.71094 V 200 193.875 c 0,-1.11381 0.0257,-1.99115 0.14648,-2.71094 0.12075,-0.71979 0.34725,-1.30745 0.77735,-1.73828 0.4301,-0.43082 1.01763,-0.65835 1.73633,-0.7793 0.7187,-0.12094 1.59349,-0.14648 2.70507,-0.14648 z"
-         id="path914"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1309);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0962,238 c -0.6888,0 -1.1839,0.0205 -1.5039,0.0742 -0.30449,0.0511 -0.38369,0.11806 -0.39649,0.13086 -0.0131,0.0131 -0.0746,0.0855 -0.125,0.38867 -0.0529,0.31839 -0.0733,0.81274 -0.0703,1.50195 v 0.004 3.90039 3.90234 0.002 c -0.003,0.68916 0.0176,1.18495 0.0703,1.50195 0.0504,0.30317 0.1119,0.37557 0.125,0.38867 0.0128,0.0128 0.0918,0.0798 0.39649,0.13086 0.32002,0.0537 0.8151,0.0742 1.5039,0.0742 h 5.8086 c 0.68894,0 1.18348,-0.0206 1.50195,-0.0742 0.30433,-0.0512 0.38043,-0.1186 0.39063,-0.1289 0.0112,-0.0112 0.0774,-0.0858 0.1289,-0.39258 0.0536,-0.31974 0.0742,-0.81575 0.0742,-1.50586 V 244 241 l -3,-3 z"
-         id="path1291" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1311);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86573,190 c -1.08855,0 -1.90034,0.0312 -2.45898,0.125 -0.54887,0.0921 -0.79683,0.22878 -0.93164,0.36328 -0.13436,0.13404 -0.26642,0.37645 -0.35742,0.92383 -0.0925,0.55627 -0.12219,1.36674 -0.11719,2.45703 v 0.004 6.12695 6.12891 0.002 c -0.005,1.0898 0.0249,1.9019 0.11719,2.45703 0.091,0.5474 0.22306,0.78979 0.35742,0.92383 0.13484,0.13452 0.38277,0.27118 0.93164,0.36328 0.55862,0.0938 1.37043,0.125 2.45898,0.125 h 8.26954 c 1.08864,0 1.90078,-0.0314 2.45703,-0.125 0.54703,-0.0921 0.78777,-0.227 0.92187,-0.36133 0.13429,-0.13451 0.26913,-0.37646 0.36133,-0.92578 0.0936,-0.55811 0.125,-1.37233 0.125,-2.46303 V 200 197 L 333,190 Z"
-         id="path1293"
-         sodipodi:nodetypes="scccccccccccsscccscccs" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 323.0005,200 v 6.125 c -0.0217,4.42101 0.45314,4.875 4.86523,4.875 h 8.26954 c 4.41209,0 4.86523,-0.45393 4.86523,-4.875 V 200 Z"
-         id="path1007"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 322.0005,244 v 3.89844 C 321.9867,250.71181 322.28851,251 325.0962,251 h 5.8086 c 2.8077,0 3.0957,-0.28815 3.0957,-3.10156 V 244 Z"
-         id="path1016"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 325.50195,84 v 12.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 V 84 Z"
-         id="path964-0"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18820-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188 44 C 90.788624 44 82.396956 44.428807 76.609375 46.427734 C 74.505793 47.154326 72.745865 48.088818 71.275391 49.285156 C 71.274692 49.285724 71.274136 49.286541 71.273438 49.287109 C 70.171193 50.184574 69.229818 51.229668 68.429688 52.445312 C 68.174328 52.833282 67.936671 53.242531 67.708984 53.666016 C 67.651564 53.772798 67.598688 53.886993 67.542969 53.996094 C 67.382444 54.310441 67.226879 54.630866 67.080078 54.964844 C 67.006949 55.131203 66.93897 55.305225 66.869141 55.476562 C 66.748138 55.773462 66.628968 56.074579 66.517578 56.386719 C 66.446853 56.584913 66.379471 56.787726 66.3125 56.992188 C 66.212808 57.29649 66.117028 57.607335 66.025391 57.925781 C 65.965274 58.134707 65.90637 58.345421 65.849609 58.560547 C 65.756412 58.913766 65.668449 59.278191 65.583984 59.648438 C 65.536317 59.857386 65.488342 60.062875 65.443359 60.277344 C 65.362062 60.664875 65.287698 61.068729 65.214844 61.474609 C 65.176853 61.686319 65.133436 61.890634 65.097656 62.107422 C 64.994386 62.732944 64.90026 63.376169 64.814453 64.044922 C 64.814368 64.045582 64.814538 64.046215 64.814453 64.046875 C 64.730212 64.703594 64.654689 65.386182 64.585938 66.085938 C 64.558109 66.36935 64.535208 66.668359 64.509766 66.958984 C 64.471641 67.394278 64.435363 67.831478 64.402344 68.283203 C 64.320685 69.400176 64.258682 70.586022 64.205078 71.806641 C 64.154684 72.953182 64.119332 74.174143 64.089844 75.416016 C 64.07606 75.996757 64.054735 76.540389 64.044922 77.142578 C 64.014642 78.996321 64 80.929692 64 82.994141 L 64 156 L 64 229.00586 C 64 231.07031 64.014642 233.00368 64.044922 234.85742 C 64.054735 235.45961 64.07606 236.00324 64.089844 236.58398 C 64.119332 237.82586 64.154684 239.04682 64.205078 240.19336 C 64.258682 241.41398 64.320685 242.59982 64.402344 243.7168 C 64.435363 244.16852 64.471641 244.60572 64.509766 245.04102 C 64.535208 245.33164 64.558109 245.63065 64.585938 245.91406 C 64.654689 246.61382 64.730212 247.29641 64.814453 247.95312 C 64.814533 247.95375 64.814373 247.95445 64.814453 247.95508 C 64.90026 248.62383 64.994386 249.26706 65.097656 249.89258 C 65.133436 250.10937 65.176853 250.31368 65.214844 250.52539 C 65.287698 250.93127 65.362062 251.33512 65.443359 251.72266 C 65.488342 251.93713 65.536317 252.14261 65.583984 252.35156 C 65.668449 252.72181 65.756412 253.08623 65.849609 253.43945 C 65.90637 253.65458 65.965274 253.86529 66.025391 254.07422 C 66.117028 254.39267 66.212808 254.70351 66.3125 255.00781 C 66.379471 255.21227 66.446853 255.41509 66.517578 255.61328 C 66.628968 255.92542 66.748138 256.22654 66.869141 256.52344 C 66.93897 256.69478 67.006949 256.8688 67.080078 257.03516 C 67.226879 257.36913 67.382444 257.68956 67.542969 258.00391 C 67.598688 258.11301 67.651564 258.2272 67.708984 258.33398 C 67.936671 258.75747 68.174328 259.16672 68.429688 259.55469 C 68.963454 260.36564 69.559812 261.09969 70.224609 261.76562 C 70.557008 262.09859 70.905713 262.4136 71.273438 262.71289 C 71.274154 262.71347 71.274674 262.71426 71.275391 262.71484 C 72.745865 263.91118 74.505793 264.84567 76.609375 265.57227 C 82.396956 267.57119 90.788624 268 102.92188 268 L 201.07812 268 C 203.1354 268 205.06339 267.98528 206.91211 267.95508 C 206.92365 267.95489 206.93381 267.95528 206.94531 267.95508 C 207.59075 267.94401 208.18439 267.91962 208.80664 267.9043 C 209.2637 267.89304 209.69197 267.87615 210.14258 267.86328 C 210.81633 267.8421 211.52187 267.82684 212.16602 267.79883 C 212.17279 267.79853 212.17877 267.79717 212.18555 267.79688 C 213.43824 267.74231 214.66024 267.67979 215.80469 267.5957 C 215.81466 267.59497 215.82402 267.59449 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.23558 267.47754 217.24681 267.47753 217.25781 267.47656 C 217.46816 267.45801 217.685 267.43997 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67616 267.09973 221.31798 267.00366 221.94336 266.90039 C 221.94542 266.90005 221.94716 266.89878 221.94922 266.89844 C 222.16891 266.86195 222.37713 266.81983 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.00025 266.50867 224.22962 266.45386 224.46094 266.40039 C 224.47079 266.39813 224.4804 266.3968 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.68584 266.09801 225.93206 266.0296 226.17578 265.95898 C 226.18242 265.95706 226.18868 265.95505 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.85083 265.41318 227.99309 265.35464 228.13867 265.29883 C 228.27101 265.24829 228.40567 265.20081 228.53516 265.14844 C 228.5463 265.14393 228.55721 265.13927 228.56836 265.13477 C 228.75355 265.05996 228.94022 264.98513 229.11914 264.90625 C 229.28649 264.83249 229.44465 264.75208 229.60547 264.67383 C 229.70972 264.62427 229.81573 264.57638 229.91797 264.52539 C 229.92526 264.52175 229.93214 264.5173 229.93945 264.51367 C 230.10652 264.43083 230.2783 264.35078 230.43945 264.26367 C 230.43995 264.2634 230.44091 264.26394 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.40332 263.04924 233.10973 262.47581 233.75586 261.8418 C 233.75717 261.84051 233.75845 261.83918 233.75977 261.83789 C 233.83088 261.76789 233.8992 261.69466 233.96875 261.62305 C 233.97067 261.62108 233.97269 261.61916 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01198 256.99293 237.07424 256.85802 237.13281 256.71875 C 237.13336 256.71744 237.13422 256.71615 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.8128 254.90328 237.95906 254.41419 238.09961 253.91406 C 238.10016 253.9121 238.10101 253.91016 238.10156 253.9082 C 238.14177 253.76492 238.18014 253.61878 238.21875 253.47266 C 238.25475 253.33659 238.2866 253.19365 238.32031 253.05273 C 238.34775 252.94302 238.37574 252.832 238.40234 252.7207 C 238.40295 252.71818 238.40369 252.71542 238.4043 252.71289 C 238.54743 252.11352 238.67865 251.4902 238.79883 250.84375 C 238.82465 250.7047 238.8511 250.56733 238.87695 250.42773 C 238.88281 250.39444 238.89069 250.3635 238.89648 250.33008 C 238.89659 250.32947 238.89638 250.32874 238.89648 250.32812 C 239.03705 249.51759 239.16403 248.67439 239.27344 247.78906 C 239.27936 247.74118 239.28361 247.6901 239.28906 247.64062 C 239.30493 247.50972 239.31875 247.37085 239.33398 247.23828 C 239.3363 247.21815 239.33755 247.19595 239.33984 247.17578 C 239.41881 246.48269 239.49003 245.76862 239.55273 245.0293 C 239.55328 245.02286 239.55414 245.0162 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78349 241.55491 239.79357 241.40032 239.80273 241.24609 C 239.80753 241.14632 239.81376 241.05363 239.81836 240.95312 C 239.81877 240.94439 239.81798 240.93463 239.81836 240.92578 C 239.8239 240.79729 239.82694 240.65948 239.83203 240.5293 C 239.83253 240.51759 239.83349 240.5039 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96307 235.84067 239.96271 235.82927 239.96289 235.81836 C 239.96965 235.41022 239.97579 234.99445 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 126.24023 C 239.99175 124.41532 239.69913 122.64313 239.18555 120.92773 C 238.84316 119.78414 238.40271 118.66667 237.88281 117.57422 C 235.02338 111.56573 229.76385 106.34509 225.23828 102.07812 L 225.18945 102.02734 L 184.66602 59.619141 C 173.98907 49.058011 166.6082 44 152 44 L 102.92188 44 z M 202.6543 44.089844 C 198.17969 45.582244 196.66368 52.666443 200.11328 56.001953 L 228.60938 86.388672 C 232.34293 90.094303 239.77066 86.941636 239.99609 81.568359 C 239.99904 79.653502 239.98605 77.841831 239.95703 76.115234 C 239.95423 75.948427 239.94846 75.795955 239.94531 75.630859 C 239.91561 74.073736 239.87303 72.583034 239.80859 71.173828 C 239.76149 70.141731 239.70379 69.149343 239.63477 68.193359 C 238.48179 52.247696 234.0865 46.656477 219.97266 44.832031 C 218.6759 44.664404 217.29786 44.529298 215.83203 44.419922 C 215.12248 44.366977 214.38958 44.320376 213.63867 44.279297 C 213.63006 44.278828 213.61995 44.277811 213.61133 44.277344 C 212.04337 44.192346 210.38654 44.131491 208.63086 44.089844 L 202.6543 44.089844 z M 119.56641 55.945312 C 130.94041 55.949312 142.19691 55.986006 153.46484 56.191406 C 160.70267 55.806356 167.33104 59.645279 172.32031 64.599609 C 188.42569 80.562439 203.72801 97.313634 219.59766 113.50977 C 223.01384 117.3863 227.86068 121.27297 227.77148 126.91016 C 228.13347 156.76716 227.92575 186.62924 227.87695 216.48828 C 227.61216 226.73843 228.27253 237.18438 226.96875 247.45312 C 226.42181 249.81071 226.43599 253.48893 223.40625 254.10352 C 215.81737 255.95335 207.89537 255.57352 200.13867 255.80078 C 164.59267 255.97868 128.71027 256.09951 93.162109 255.66406 C 88.457189 255.24944 83.282319 255.67006 79.042969 253.2793 C 76.215659 249.46054 76.934056 244.27573 76.597656 239.79492 C 76.014926 191.14952 75.895482 142.48894 76.013672 93.822266 C 76.296742 83.105596 75.520041 72.053786 77.582031 61.384766 C 77.890341 58.111406 81.437525 57.376809 84.078125 56.974609 C 95.865617 55.846619 107.85901 56.107002 119.56641 55.945312 z "
-         id="rect4158-92-3" />
+         d="m 334.11952,249.75967 c -0.012,0.7948 -0.36762,1.21116 -1.06855,1.24033 l -4.83828,-0.56496 V 237.4758 l 4.98899,-0.46779 c 0.66454,-0.0671 0.95485,0.2894 0.95996,1.00387 z"
+         fill-opacity="0.15"
+         id="path464"
+         style="stroke-width:0.300832" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,156 v 73.00683 C 63.827405,264.37495 67.625545,268 102.92228,268 h 98.15624 c 35.29672,0 38.00361,-3.63655 38.92188,-38.99317 V 156 Z"
-         id="path4255"
-         sodipodi:nodetypes="ccssscc" />
+         d="m 195.44496,124.70769 c 0.27917,-0.77013 0.47652,-1.5547 0.47652,-2.3874 0,-10.20904 -22.05941,-15.71546 -42.82404,-15.71546 -20.74056,0 -42.79516,5.50642 -42.79516,15.71546 0,0.83752 0.19253,1.62209 0.4717,2.39222 l -0.1107,0.20697 c -0.94823,1.71835 -1.41512,3.45596 -1.41512,5.16468 v 12.63495 c 0,1.94458 0.61129,3.81214 1.69429,5.57863 l -0.13959,0.24548 c -1.03486,1.79536 -1.5547,3.60998 -1.5547,5.40535 v 12.63013 c 0,1.882 0.5776,3.69181 1.60284,5.41016 l -0.0529,0.11071 c -1.03486,1.79055 -1.5547,3.60998 -1.5547,5.40053 v 12.63495 c 0,11.22464 19.26288,20.01856 43.85408,20.01856 24.61528,0 43.87334,-8.79392 43.87334,-20.01856 V 177.5001 c 0,-1.79536 -0.51984,-3.61961 -1.56433,-5.40535 l -0.0433,-0.1107 c 1.0156,-1.71836 1.60764,-3.52816 1.60764,-5.41498 v -12.63013 c 0,-1.79537 -0.51984,-3.61961 -1.56432,-5.41016 l -0.13959,-0.24067 c 1.08781,-1.76649 1.70391,-3.62924 1.70391,-5.58344 v -12.63013 c 0,-1.70873 -0.47652,-3.45115 -1.41511,-5.17431 l -0.11552,-0.20216 z m -3.17197,65.37922 c 0,7.25367 -16.07647,15.32559 -39.17555,15.32559 -23.07502,0 -39.1563,-8.07192 -39.1563,-15.32559 v -11.87925 c 7.20072,6.59905 22.01609,10.80589 39.1563,10.80589 17.16427,0 31.97964,-4.21165 39.17555,-10.8107 z m 0,-23.51784 c 0,7.24885 -16.07647,15.32077 -39.17555,15.32077 -23.07502,0 -39.1563,-8.07192 -39.1563,-15.32077 V 154.685 c 7.20072,6.59424 22.01609,10.80589 39.1563,10.80589 17.16427,0 31.97964,-4.21165 39.17555,-10.8107 z m 0,-23.85959 c 0,7.24404 -16.07647,15.32077 -39.17555,15.32077 -23.07502,0 -39.1563,-8.07192 -39.1563,-15.32077 v -10.51227 c 7.03706,5.96369 23.35419,9.05865 39.1563,9.05865 15.82136,0 32.13367,-3.09496 39.17555,-9.05865 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path23"
+         style="display:inline;enable-background:new;fill:url(#c);stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,227.00586 v 2 C 63.827405,264.37398 67.625545,268 102.92228,268 h 98.15624 c 35.29672,0 38.00361,-3.63752 38.92188,-38.99414 v -2 C 239.08213,262.36248 236.37524,266 201.07852,266 h -98.15624 c -35.296735,0 -39.094875,-3.62602 -38.921885,-38.99414 z"
-         id="path945"
-         inkscape:connector-curvature="0" />
+         d="m 352.69434,77.085317 c 0.0573,-0.158152 0.0979,-0.31927 0.0979,-0.490272 0,-2.096498 -4.53006,-3.227282 -8.79422,-3.227282 -4.25922,0 -8.78829,1.130784 -8.78829,3.227282 0,0.171992 0.0395,0.333109 0.0969,0.49126 l -0.0227,0.0425 c -0.19473,0.352875 -0.29061,0.709706 -0.29061,1.060604 v 2.594677 c 0,0.399333 0.12553,0.78285 0.34794,1.145612 l -0.0287,0.05041 c -0.21252,0.36869 -0.31927,0.741336 -0.31927,1.110028 v 2.593687 c 0,0.386482 0.11861,0.75814 0.32915,1.111014 l -0.0109,0.02273 c -0.21251,0.367702 -0.31927,0.741336 -0.31927,1.109038 v 2.594677 c 0,2.30506 3.95577,4.110955 9.00575,4.110955 5.05493,0 9.00971,-1.805894 9.00971,-4.110955 v -2.594668 c 0,-0.36869 -0.10676,-0.743313 -0.32125,-1.110028 l -0.009,-0.02273 c 0.20856,-0.352879 0.33014,-0.724533 0.33014,-1.112004 v -2.593688 c 0,-0.368692 -0.10675,-0.743313 -0.32124,-1.111015 l -0.0287,-0.04942 c 0.22339,-0.362762 0.34991,-0.745291 0.34991,-1.146599 v -2.593688 c 0,-0.3509 -0.0979,-0.708718 -0.29061,-1.062581 l -0.0237,-0.04152 z m -0.65139,13.426089 c 0,1.489593 -3.30141,3.14722 -8.04498,3.14722 -4.73862,0 -8.04102,-1.657626 -8.04102,-3.14722 v -2.439489 c 1.47872,1.355162 4.52116,2.219067 8.04102,2.219067 3.52481,0 6.56725,-0.864893 8.04498,-2.220055 z m 0,-4.829556 c 0,1.488603 -3.30141,3.14623 -8.04498,3.14623 -4.73862,0 -8.04102,-1.657626 -8.04102,-3.14623 v -2.440478 c 1.47872,1.354174 4.52116,2.219066 8.04102,2.219066 3.52481,0 6.56725,-0.864892 8.04498,-2.220055 z m 0,-4.899738 c 0,1.487617 -3.30141,3.146231 -8.04498,3.146231 -4.73862,0 -8.04102,-1.657628 -8.04102,-3.146231 v -2.158768 c 1.44511,1.224685 4.79595,1.860257 8.04102,1.860257 3.24903,0 6.59888,-0.635572 8.04498,-1.860257 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path424"
+         style="display:inline;enable-background:new;fill:url(#linearGradient426);stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07999998;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:7.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 180.0004,268 60,-60 v 22.48388 C 239.9481,264.47969 236.19772,268 201.8263,268 Z"
-         id="path4254"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccsc" />
-      <g
-         id="g1289"
-         transform="matrix(0.93270191,0,0,0.93235082,23.15114,6.492631)"
-         style="display:inline;stroke-width:1.07235575;enable-background:new">
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccscccc"
-           id="path14085"
-           d="m 332.74163,90.1053 v 3.50254 c 0,0 0,0.33824 0,0.50036 0,1.93441 5.0402,3.50255 11.2577,3.50255 6.2174,0 11.2576,-1.56814 11.2576,-3.50255 V 93.60784 90.1053 Z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient19808);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.07235575;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-        <g
-           style="stroke-width:1.07235575;stroke-miterlimit:4;stroke-dasharray:none"
-           transform="translate(-927.00067,953.99307)"
-           id="g5748">
-          <path
-             sodipodi:nodetypes="cccscccc"
-             id="path14089"
-             d="m 1259.7423,-868.57233 v 3.50255 c 0,0 0,0.33824 0,0.50036 0,1.93441 5.0402,3.50254 11.2577,3.50254 6.2174,0 11.2576,-1.56813 11.2576,-3.50254 v -0.50036 -3.50255 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient19810);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.07235575;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-             inkscape:connector-curvature="0" />
-          <g
-             style="stroke-width:1.08344305;stroke-miterlimit:4;stroke-dasharray:none"
-             transform="matrix(0.97892669,0,0,1.0007266,878.4504,0.37753505)"
-             id="g14091">
-            <path
-               sodipodi:nodetypes="cccscccc"
-               id="path14093"
-               d="m 389.5,-872.95665 v 3.5 c 0,0 0,0.338 0,0.5 0,1.933 5.14873,3.5 11.5,3.5 6.35127,0 11.5,-1.567 11.5,-3.5 v -0.5 -3.5 z"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient19812);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.08344305;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-               inkscape:connector-curvature="0" />
-            <ellipse
-               ry="5.6875"
-               rx="22.4375"
-               cy="730.3125"
-               cx="519.6875"
-               transform="matrix(0.512535,0,0,0.615385,134.642,-1323.1872)"
-               id="path14095"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient19814);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.92917168;stroke-miterlimit:4;stroke-dasharray:none;marker:none" />
-          </g>
-        </g>
-      </g>
-      <g
-         style="display:inline;stroke-width:1.73539293;enable-background:new"
-         transform="matrix(0.57732782,0,0,0.57515103,137.3996,100.36002)"
-         id="g1387">
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1389);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.73539293;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-           d="m 332.74163,90.1053 v 3.50254 c 0,0 0,0.33824 0,0.50036 0,1.93441 5.0402,3.50255 11.2577,3.50255 6.2174,0 11.2576,-1.56814 11.2576,-3.50255 V 93.60784 90.1053 Z"
-           id="path1375"
-           sodipodi:nodetypes="cccscccc"
-           inkscape:connector-curvature="0" />
-        <g
-           id="g1385"
-           transform="translate(-927.00067,953.99307)"
-           style="stroke-width:1.73539293;stroke-miterlimit:4;stroke-dasharray:none">
-          <path
-             inkscape:connector-curvature="0"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1391);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.73539293;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-             d="m 1259.7423,-868.57233 v 3.50255 c 0,0 0,0.33824 0,0.50036 0,1.93441 5.0402,3.50254 11.2577,3.50254 6.2174,0 11.2576,-1.56813 11.2576,-3.50254 v -0.50036 -3.50255 z"
-             id="path1377"
-             sodipodi:nodetypes="cccscccc" />
-          <g
-             id="g1383"
-             transform="matrix(0.97892669,0,0,1.0007266,878.4504,0.37753505)"
-             style="stroke-width:1.75333548;stroke-miterlimit:4;stroke-dasharray:none">
-            <path
-               inkscape:connector-curvature="0"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1393);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.75333548;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-               d="m 389.5,-872.95665 v 3.5 c 0,0 0,0.338 0,0.5 0,1.933 5.14873,3.5 11.5,3.5 6.35127,0 11.5,-1.567 11.5,-3.5 v -0.5 -3.5 z"
-               id="path1379"
-               sodipodi:nodetypes="cccscccc" />
-            <ellipse
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1395);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:3.12197781;stroke-miterlimit:4;stroke-dasharray:none;marker:none"
-               id="ellipse1381"
-               transform="matrix(0.512535,0,0,0.615385,134.642,-1323.1872)"
-               cx="519.6875"
-               cy="730.3125"
-               rx="22.4375"
-               ry="5.6875" />
-          </g>
-        </g>
-      </g>
-      <g
-         id="g1357"
-         transform="matrix(0.73319609,0,0,0.73064287,85.645146,93.686514)"
-         style="display:inline;stroke-width:1.36627257;enable-background:new">
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccsccc"
-           id="path9344"
-           d="m 328.49952,148.50605 v 4 c 0,1.10457 3.3579,2 7.5,2 4.1421,0 7.5,-0.89543 7.5,-2 v -4 z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient9348);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.36627257;marker:none" />
-        <path
-           inkscape:connector-curvature="0"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient9339);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.36627257;marker:none"
-           d="m 328.49952,144.3085 v 4 c 0,1.10457 3.3579,2 7.5,2 4.1421,0 7.5,-0.89543 7.5,-2 v -4 z"
-           id="path9335"
-           sodipodi:nodetypes="ccsccc" />
-        <ellipse
-           ry="1.999998"
-           rx="7.5000038"
-           cy="144.05115"
-           cx="336.00131"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient9342);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.36627185;marker:none"
-           id="path9337" />
-      </g>
-      <g
-         style="display:inline;enable-background:new"
-         id="g1373"
-         transform="translate(0,0.4248)">
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccscccc"
-           id="rect6392"
-           d="m 324.5,243.0752 v 2 c 0,0 0,0.29921 0,0.5 0,0.82843 1.567,1.5 3.5,1.5 1.933,0 3.5,-0.67157 3.5,-1.5 v -0.5 -2 z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f2cbf8;fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0pt;stroke-opacity:1;marker:none" />
-        <ellipse
-           ry="1.4999985"
-           rx="3.5000031"
-           cy="242.57489"
-           cx="328.00052"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f2cbf8;fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;marker:none"
-           id="path6390" />
-      </g>
-      <g
-         id="g1289-6"
-         transform="matrix(4.5138357,0,0,4.4951112,-1400.7535,-217.1248)"
-         style="display:inline;stroke-width:1.07235575;enable-background:new">
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccscccc"
-           id="path14085-0"
-           d="m 332.74163,90.1053 v 3.50254 c 0,0 0,0.33824 0,0.50036 0,1.93441 5.0402,3.50255 11.2577,3.50255 6.2174,0 11.2576,-1.56814 11.2576,-3.50255 V 93.60784 90.1053 Z"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient19892);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.07235575;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-        <g
-           style="stroke-width:1.07235575;stroke-miterlimit:4;stroke-dasharray:none"
-           transform="translate(-927.00067,953.99307)"
-           id="g5748-2">
-          <path
-             sodipodi:nodetypes="cccscccc"
-             id="path14089-7"
-             d="m 1259.7423,-868.57233 v 3.50255 c 0,0 0,0.33824 0,0.50036 0,1.93441 5.0402,3.50254 11.2577,3.50254 6.2174,0 11.2576,-1.56813 11.2576,-3.50254 v -0.50036 -3.50255 z"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient19894);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.07235575;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-             inkscape:connector-curvature="0" />
-          <g
-             style="stroke-width:1.08344305;stroke-miterlimit:4;stroke-dasharray:none"
-             transform="matrix(0.97892669,0,0,1.0007266,878.4504,0.37753505)"
-             id="g14091-6">
-            <path
-               sodipodi:nodetypes="cccscccc"
-               id="path14093-1"
-               d="m 389.5,-872.95665 v 3.5 c 0,0 0,0.338 0,0.5 0,1.933 5.14873,3.5 11.5,3.5 6.35127,0 11.5,-1.567 11.5,-3.5 v -0.5 -3.5 z"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient19812-9);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.08344305;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-               inkscape:connector-curvature="0" />
-            <ellipse
-               ry="5.6875"
-               rx="22.4375"
-               cy="730.3125"
-               cx="519.6875"
-               transform="matrix(0.512535,0,0,0.615385,134.642,-1323.1872)"
-               id="path14095-3"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient19814-9);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1.92917168;stroke-miterlimit:4;stroke-dasharray:none;marker:none" />
-          </g>
-        </g>
-      </g>
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline">
+         d="m 341.81851,143.80906 c 0.0374,-0.10314 0.0639,-0.20822 0.0639,-0.31974 0,-1.36728 -2.95438,-2.10475 -5.73536,-2.10475 -2.77776,0 -5.7315,0.73747 -5.7315,2.10475 0,0.11217 0.0258,0.21725 0.0632,0.32039 l -0.0148,0.0277 c -0.127,0.23013 -0.18953,0.46285 -0.18953,0.6917 v 1.69218 c 0,0.26043 0.0819,0.51055 0.2269,0.74714 l -0.0187,0.0329 c -0.1386,0.24045 -0.20822,0.48348 -0.20822,0.72393 v 1.69153 c 0,0.25205 0.0774,0.49444 0.21466,0.72458 l -0.007,0.0148 c -0.13859,0.2398 -0.20822,0.48348 -0.20822,0.72328 v 1.69218 c 0,1.5033 2.57986,2.68106 5.87332,2.68106 3.29669,0 5.87589,-1.17776 5.87589,-2.68106 v -1.69217 c 0,-0.24045 -0.0696,-0.48477 -0.20951,-0.72393 l -0.006,-0.0148 c 0.13602,-0.23014 0.21531,-0.47253 0.21531,-0.72522 v -1.69155 c 0,-0.24045 -0.0696,-0.48477 -0.2095,-0.72457 l -0.0187,-0.0322 c 0.14569,-0.23659 0.2282,-0.48606 0.2282,-0.74778 v -1.69154 c 0,-0.22885 -0.0639,-0.46221 -0.18953,-0.69299 l -0.0154,-0.0271 z m -0.42483,8.75615 c 0,0.97147 -2.15309,2.05253 -5.24673,2.05253 -3.0904,0 -5.24414,-1.08106 -5.24414,-2.05253 v -1.59097 c 0.96438,0.8838 2.94858,1.44721 5.24414,1.44721 2.29879,0 4.28299,-0.56406 5.24673,-1.44786 z m 0,-3.14971 c 0,0.97083 -2.15309,2.05189 -5.24673,2.05189 -3.0904,0 -5.24414,-1.08106 -5.24414,-2.05189 v -1.59162 c 0.96438,0.88316 2.94858,1.44722 5.24414,1.44722 2.29879,0 4.28299,-0.56406 5.24673,-1.44786 z m 0,-3.19548 c 0,0.97018 -2.15309,2.05189 -5.24673,2.05189 -3.0904,0 -5.24414,-1.08107 -5.24414,-2.05189 v -1.4079 c 0.94246,0.79871 3.12779,1.21322 5.24414,1.21322 2.11894,0 4.30363,-0.41451 5.24673,-1.21322 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path438"
+         style="display:inline;enable-background:new;fill:url(#linearGradient440);stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23242,61.5 c -4.11577,0 -6.55968,0.226752 -7.96875,1.558594 -0.28725,0.271486 -0.52183,0.601863 -0.72851,0.972656 -0.0468,0.08393 -0.10154,0.156606 -0.14454,0.246094 -2.5e-4,5.28e-4 2.6e-4,0.0014 0,0.002 -0.11616,0.241982 -0.2184,0.50414 -0.30859,0.789062 -0.0904,0.285534 -0.16955,0.593694 -0.23633,0.925782 -0.0668,0.332095 -0.1223,0.688232 -0.16797,1.070312 -0.0913,0.764147 -0.1422,1.632501 -0.16406,2.617188 -0.0109,0.492345 -0.0144,1.013779 -0.0117,1.566406 V 84 96.751953 c -0.003,0.552627 8e-4,1.074061 0.0117,1.566406 0.0219,0.984686 0.0727,1.853041 0.16406,2.617191 0.0457,0.38208 0.1012,0.73821 0.16797,1.07031 0.13356,0.66417 0.31198,1.23197 0.54492,1.7168 0.23295,0.48482 0.52078,0.88581 0.87305,1.21875 0.17614,0.16648 0.36842,0.31556 0.57813,0.44921 0.41895,0.26701 0.90872,0.47238 1.47656,0.62891 6.2e-4,1.7e-4 0.001,-1.7e-4 0.002,0 1.42142,0.39113 3.3408,0.48047 5.91211,0.48047 h 17.53906 c 1.02156,0 1.93959,-0.015 2.76368,-0.0566 0.34097,-0.0172 0.65525,-0.0427 0.96484,-0.0703 0.0645,-0.006 0.13795,-0.007 0.20117,-0.0137 0.001,-1.4e-4 0.003,1.3e-4 0.004,0 0.73118,-0.0725 1.37505,-0.17995 1.93945,-0.33399 0.28273,-0.0772 0.54639,-0.16492 0.79102,-0.26758 0.24462,-0.10265 0.47066,-0.22006 0.67968,-0.35156 0.20903,-0.1315 0.40024,-0.27771 0.57618,-0.44141 0.15581,-0.14498 0.29602,-0.30775 0.42773,-0.48046 0.017,-0.0223 0.0381,-0.0397 0.0547,-0.0625 0.001,-0.002 0.003,-0.004 0.004,-0.006 0.14374,-0.19776 0.2725,-0.41443 0.38868,-0.6504 0.11725,-0.23815 0.22082,-0.49693 0.3125,-0.77734 0.0917,-0.28041 0.17164,-0.58218 0.24023,-0.9082 0.0686,-0.32602 0.12581,-0.6758 0.17383,-1.05078 0.0428,-0.33417 0.0752,-0.6967 0.10351,-1.072269 0.003,-0.04534 0.0104,-0.0849 0.0137,-0.130859 4.2e-4,-0.0061 -4.3e-4,-0.01341 0,-0.01953 0.059,-0.850021 0.0853,-1.80463 0.0879,-2.88086 V 78.021484 c -0.009,-1.95527 -1.71776,-3.606675 -3.10157,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 C 348.62263,62.517026 347.07095,61.5 344,61.5 Z"
-         id="path964-1"
-         inkscape:connector-curvature="0" />
+         d="m 336.26688,196.92665 c 0.0274,-0.0756 0.0469,-0.1527 0.0469,-0.23448 0,-1.00267 -2.16655,-1.54348 -4.20593,-1.54348 -2.03703,0 -4.2031,0.54081 -4.2031,1.54348 0,0.0823 0.0189,0.15932 0.0463,0.23495 l -0.0109,0.0203 c -0.0931,0.16876 -0.13899,0.33942 -0.13899,0.50724 v 1.24093 c 0,0.19099 0.0601,0.37441 0.16639,0.54791 l -0.0137,0.0241 c -0.10164,0.17633 -0.15269,0.35456 -0.15269,0.53089 v 1.24045 c 0,0.18484 0.0568,0.36259 0.15741,0.53136 l -0.005,0.0109 c -0.10163,0.17586 -0.15269,0.35456 -0.15269,0.53041 v 1.24093 c 0,1.10242 1.89189,1.96611 4.3071,1.96611 2.41757,0 4.30898,-0.86369 4.30898,-1.96611 v -1.24092 c 0,-0.17633 -0.051,-0.3555 -0.15364,-0.53089 l -0.004,-0.0109 c 0.0997,-0.16877 0.1579,-0.34652 0.1579,-0.53183 v -1.24047 c 0,-0.17633 -0.051,-0.3555 -0.15364,-0.53135 l -0.0137,-0.0236 c 0.10684,-0.1735 0.16735,-0.35645 0.16735,-0.54837 v -1.24047 c 0,-0.16782 -0.0469,-0.33895 -0.13899,-0.50819 l -0.0113,-0.0199 z m -0.31154,6.42117 c 0,0.71241 -1.57894,1.50519 -3.84761,1.50519 -2.26629,0 -3.8457,-0.79278 -3.8457,-1.50519 v -1.16671 c 0.70721,0.64812 2.16229,1.06129 3.8457,1.06129 1.68579,0 3.14086,-0.41365 3.84761,-1.06177 z m 0,-2.30979 c 0,0.71195 -1.57894,1.50472 -3.84761,1.50472 -2.26629,0 -3.8457,-0.79277 -3.8457,-1.50472 v -1.16718 c 0.70721,0.64765 2.16229,1.06129 3.8457,1.06129 1.68579,0 3.14086,-0.41364 3.84761,-1.06176 z m 0,-2.34335 c 0,0.71147 -1.57894,1.50472 -3.84761,1.50472 -2.26629,0 -3.8457,-0.79278 -3.8457,-1.50472 v -1.03246 c 0.69114,0.58572 2.29371,0.8897 3.8457,0.8897 1.5539,0 3.156,-0.30398 3.84761,-0.8897 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path452"
+         style="display:inline;enable-background:new;fill:url(#linearGradient454);stroke-width:0.472736" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -2.50815,0 -4.811706,0.02551 -7.011724,0.07227 -1.569123,0.03333 -3.085758,0.07665 -4.505859,0.142578 -0.892728,0.04133 -1.761123,0.08803 -2.597656,0.144531 -0.07361,0.005 -0.155337,0.0086 -0.228516,0.01367 -0.03977,0.0028 -0.07364,0.0069 -0.113281,0.0098 -1.116046,0.0793 -2.169724,0.179402 -3.1875,0.291016 -0.281404,0.03076 -0.565732,0.06033 -0.839844,0.09375 -0.275699,0.03373 -0.547991,0.06893 -0.816406,0.105469 -0.386448,0.05241 -0.763169,0.107586 -1.134766,0.166015 -0.245075,0.0387 -0.493706,0.07575 -0.732422,0.117188 -0.386715,0.06683 -0.756638,0.14255 -1.126953,0.216797 -0.50787,0.102283 -1.000729,0.211021 -1.478515,0.328125 -0.190937,0.04659 -0.386033,0.09158 -0.572266,0.140625 -0.3252,0.08602 -0.638123,0.17771 -0.949219,0.271484 -0.174107,0.05225 -0.347813,0.105409 -0.517578,0.160157 -0.32699,0.105899 -0.647816,0.216555 -0.958984,0.332031 -0.09794,0.0362 -0.19267,0.07416 -0.289063,0.111328 -1.533658,0.593687 -2.876219,1.308506 -4.044922,2.173828 -0.01464,0.01084 -0.03034,0.02036 -0.04492,0.03125 -4.841904,3.613548 -6.740009,9.796263 -7.419922,20.238281 -0.01716,0.264046 -0.02929,0.544903 -0.04492,0.814453 -0.06629,1.140594 -0.126494,2.305415 -0.167969,3.546875 -9.88e-4,0.02958 -9.78e-4,0.06216 -0.002,0.0918 -0.04738,1.439614 -0.07924,2.944486 -0.09961,4.525391 C 64.509576,49.175312 70.065023,46 102.92188,46 h 62.52929 c -0.85989,-0.295464 -1.74582,-0.553137 -2.65429,-0.783203 -0.15701,-0.03958 -0.31205,-0.08153 -0.47071,-0.119141 -0.38771,-0.0924 -0.78156,-0.17709 -1.17969,-0.257812 -0.28362,-0.0571 -0.57205,-0.108999 -0.86132,-0.160156 -0.33217,-0.05924 -0.66192,-0.122415 -1.00196,-0.173829 -0.61547,-0.09216 -1.24344,-0.171652 -1.88672,-0.238281 -0.25531,-0.02678 -0.51929,-0.04563 -0.77929,-0.06836 -0.49344,-0.04258 -0.99476,-0.07925 -1.50586,-0.107422 -0.26087,-0.01459 -0.52138,-0.03022 -0.78711,-0.04102 C 153.56684,44.020455 152.79888,44 152,44 Z"
-         id="path7772" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 202.6543,44.089844 C 201.58308,44.447123 200.68698,45.129921 199.98242,46 h 1.0957 c 34.15108,4e-6 38.64021,3.484765 38.89649,35.740234 0.003,-0.03712 0.0117,-0.07204 0.0137,-0.109375 -0.0536,-17.671398 -1.15787,-27.178174 -7.08008,-32.177734 -0.31691,-0.265045 -0.64554,-0.519153 -0.99023,-0.759766 -1.34338,-0.937742 -2.91268,-1.68853 -4.71875,-2.296875 -0.14212,-0.04772 -0.27668,-0.09862 -0.42188,-0.144531 -0.31902,-0.101184 -0.65609,-0.192499 -0.99023,-0.285156 -0.25795,-0.07131 -0.51412,-0.144507 -0.78125,-0.210938 -0.32384,-0.08078 -0.65655,-0.156631 -0.99414,-0.230468 -0.32254,-0.07033 -0.65294,-0.136909 -0.98828,-0.201172 -0.32063,-0.06164 -0.64012,-0.123397 -0.97266,-0.179688 -0.46228,-0.07802 -0.94194,-0.148582 -1.42773,-0.216797 -0.21622,-0.03046 -0.42163,-0.06516 -0.64258,-0.09375 -0.003,-3.28e-4 -0.005,-0.0016 -0.008,-0.002 -0.70741,-0.09114 -1.44413,-0.170948 -2.20118,-0.24414 -0.30752,-0.02983 -0.6294,-0.05499 -0.94531,-0.08203 -0.52075,-0.04445 -1.04787,-0.08768 -1.59179,-0.125 -0.34138,-0.02349 -0.68841,-0.04362 -1.03907,-0.06445 -0.36733,-0.02177 -0.74929,-0.04154 -1.12695,-0.06055 -1.40861,-0.07105 -2.86508,-0.128967 -4.42188,-0.166015 -0.006,-1.28e-4 -0.0105,5e-6 -0.0156,0 h -0.004 z"
-         id="path7770" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 64.011719,81.421875 C 64.009827,81.961067 64,82.439442 64,82.994141 v 2 c -0.0062,-1.260292 0.0066,-2.391311 0.01172,-3.572266 z"
-         id="path5316-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.005859,227.00586 v 2 c -0.0022,0.44238 0.0048,0.82141 0.0039,1.25391 0.0013,0.45945 0.007,0.88359 0.0098,1.33203 -0.01134,-1.48776 -0.02159,-2.96803 -0.01367,-4.58594 z M 240,227.75781 C 239.94446,262.39 236.11596,266 201.08398,266 h -98.15625 c -32.934263,0 -38.440959,-3.18029 -38.890621,-32.33398 0.304544,24.87428 3.489356,31.9654 22.175782,33.76562 0.0033,3.2e-4 0.0064,-3.2e-4 0.0098,0 0.761225,0.073 1.548247,0.13868 2.361328,0.19531 0.002,1.4e-4 0.0039,-1.4e-4 0.0059,0 0.814659,0.0567 1.655065,0.10648 2.523437,0.14844 6.7e-4,3e-5 0.0013,-3e-5 0.002,0 0.579873,0.028 1.24712,0.0365 1.851563,0.0586 1.208255,0.0442 2.391096,0.0937 3.701172,0.11719 0.0014,3e-5 0.0025,-2e-5 0.0039,0 1.964377,0.0351 4.045339,0.0488 6.250009,0.0488 0.002,0 0.004,0 0.006,0 h 98.15039 c 3.67649,0 6.93682,-0.0556 9.96094,-0.16602 2.42031,-0.0885 4.71577,-0.20623 6.75196,-0.40234 19.49586,-1.8777 22.12352,-9.49921 22.20507,-37.08398 -8.2e-4,-0.46208 0.006,-0.86842 0.004,-1.3418 z"
-         id="path5316-8"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 353.49905,61.375285 c -0.0742,0 -0.14719,0.007 -0.22049,0.018 -0.94065,0.29981 -1.25935,1.72298 -0.53417,2.39306 l 7.51333,7.51498 c 0.78643,0.74591 2.35311,0.10873 2.39455,-0.97465 v -2.118 c 0.0336,-6.55752 0.34308,-6.68079 -5.59466,-6.81539 H 353.722 c -0.0733,-0.0113 -0.14877,-0.018 -0.22295,-0.018 z"
-         id="rect4158-92-6-6"
-         sodipodi:nodetypes="scccccccs" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1004);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         clip-path="url(#clipPath994-5)"
-         d="m 335.23242,61.5 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 V 84 96.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 V 79.021813 C 362.49246,77.807802 361.8315,76.711812 361,75.756188 V 84 96.251953 c 0,2.193451 -0.0614,3.870697 -0.26562,5.087887 -0.20419,1.2172 -0.52867,1.92435 -0.99805,2.39454 -0.46938,0.47016 -1.17436,0.79564 -2.38867,1 -1.21432,0.20434 -2.8892,0.26562 -5.07813,0.26562 h -16.53906 c -2.18893,0 -3.86589,-0.0612 -5.08399,-0.26562 -1.21809,-0.20448 -1.92877,-0.5295 -2.40039,-1 -0.47161,-0.47052 -0.79596,-1.17682 -0.99804,-2.39258 -0.20209,-1.21576 -0.25879,-2.893414 -0.24805,-5.085941 v -0.002 V 84 71.746094 v -0.002 c -0.0107,-2.192528 0.046,-3.870175 0.24805,-5.085938 0.20209,-1.215763 0.52643,-1.922078 0.99804,-2.392578 0.47161,-0.4705 1.18426,-0.79553 2.40235,-1 C 331.86653,63.061202 333.54154,63 335.73047,63 H 348 c -1.40176,-1.001118 -3.79892,-1.5 -5.922,-1.5 z"
-         id="path990"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssccccscccsscccccccccscscss" />
-      <path
-         inkscape:connector-curvature="0"
-         style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04419417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 353.35547,61.876953 -0.14453,0.121094 c -0.28875,0.242959 -0.43321,0.748579 -0.31836,1.111328 0.007,0.0217 0.07,0.0936 0.11523,0.150391 0.056,-0.101219 0.12158,-0.193105 0.20313,-0.261719 l 0.14453,-0.121094 2.71875,0.02539 c 2.70745,0.02522 3.50936,0.05935 4.26562,0.185547 1.36683,0.228076 1.67801,0.658049 1.79102,2.474609 0.0245,0.393967 0.0317,1.552688 0.0352,2.636719 0.007,-1.466927 -5.4e-4,-3.080545 -0.0352,-3.636719 -0.11301,-1.81656 -0.42419,-2.246533 -1.79102,-2.474609 -0.75626,-0.126199 -1.55817,-0.160327 -4.26562,-0.185547 z"
-         id="path7025" />
-      <path
-         transform="translate(4.9980746e-4)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971-6)" />
-      <path
-         id="path1085"
-         d="m 327.86573,188.5 c -1.11158,0 -1.98683,0.0256 -2.70703,0.14648 -0.72019,0.1209 -1.3105,0.34863 -1.74218,0.7793 -0.43169,0.43067 -0.65954,1.01974 -0.7793,1.74024 -0.11977,0.72049 -0.14217,1.59669 -0.13672,2.71093 V 200 v 6.125 c -0.005,1.1131 0.017,1.989 0.13672,2.70898 0.11976,0.72051 0.3476,1.30957 0.7793,1.74024 0.43169,0.43067 1.02199,0.6584 1.74218,0.7793 0.7202,0.12089 1.59545,0.14648 2.70703,0.14648 h 8.26954 c 1.11158,0 1.98637,-0.0255 2.70507,-0.14648 0.7187,-0.12095 1.30623,-0.34848 1.73633,-0.7793 0.4301,-0.43083 0.6566,-1.01849 0.77735,-1.73828 0.12074,-0.71979 0.14648,-1.59713 0.14648,-2.71094 V 200 193.875 c 0,-1.11381 -0.0257,-1.99115 -0.14648,-2.71094 -0.12075,-0.71979 -0.34725,-1.30745 -0.77735,-1.73828 -0.4301,-0.43082 -1.01763,-0.65835 -1.73633,-0.7793 -0.7187,-0.12094 -1.59349,-0.14648 -2.70507,-0.14648 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path1087"
-         d="m 325.0962,236.5 c -0.71048,0 -1.27344,0.0154 -1.75195,0.0957 -0.47851,0.0803 -0.89671,0.23728 -1.20703,0.54688 -0.31032,0.30959 -0.46726,0.7261 -0.54688,1.20508 -0.0796,0.47897 -0.0933,1.04352 -0.0898,1.75586 V 244 v 3.89844 c -0.003,0.71121 0.0103,1.27546 0.0898,1.7539 0.0796,0.47898 0.23655,0.89549 0.54688,1.20508 0.31033,0.3096 0.72851,0.46655 1.20703,0.54688 0.47852,0.0803 1.04147,0.0957 1.75195,0.0957 h 5.8086 c 0.71048,0 1.27236,-0.0153 1.75,-0.0957 0.47763,-0.0804 0.89584,-0.23713 1.20508,-0.54688 0.30921,-0.30975 0.46469,-0.72681 0.54492,-1.20508 0.0802,-0.47826 0.0957,-1.04201 0.0957,-1.7539 V 244 240.10156 c 0,-0.71189 -0.0155,-1.27564 -0.0957,-1.7539 -0.0802,-0.47827 -0.2357,-0.89533 -0.54492,-1.20508 -0.30924,-0.30975 -0.72745,-0.4665 -1.20508,-0.54688 -0.47764,-0.0804 -1.03952,-0.0957 -1.75,-0.0957 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         transform="translate(4.9980746e-4)"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983-6)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99158418;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 342.28662,133.49219 c -0.0504,0 -0.10067,0.005 -0.15039,0.0117 -0.63831,0.19051 -0.85538,1.0957 -0.36328,1.52148 l 5.09961,4.77344 c 0.53367,0.47395 1.59687,0.0693 1.625,-0.61914 v -1.34571 c 0.0228,-4.16669 0.23241,-4.24454 -3.79688,-4.33007 h -2.26367 c -0.0498,-0.007 -0.10004,-0.0117 -0.15039,-0.0117 z m -12.21289,0.004 c -2.78209,0 -4.43425,0.14534 -5.38672,1.00391 -0.19416,0.175 -0.35249,0.38793 -0.49219,0.62695 -0.0316,0.054 -0.0686,0.10247 -0.0976,0.16016 -0.0785,0.156 -0.14802,0.3261 -0.20899,0.50977 -0.0611,0.18405 -0.11501,0.38162 -0.16015,0.5957 -0.0452,0.21409 -0.0824,0.44315 -0.11329,0.68945 -0.0617,0.49261 -0.0965,1.05274 -0.11132,1.6875 -0.007,0.31739 -0.01,0.65353 -0.008,1.00977 V 148 v 8.2207 c -0.002,0.35623 3.5e-4,0.69239 0.008,1.00977 0.0148,0.63477 0.0495,1.19491 0.11132,1.6875 0.0309,0.24631 0.0682,0.47537 0.11329,0.68945 0.0903,0.42816 0.21168,0.79292 0.36914,1.10547 0.15746,0.31252 0.35171,0.57249 0.58984,0.78711 0.11906,0.10732 0.24887,0.20291 0.39062,0.28906 0.28319,0.17212 0.61423,0.30534 0.99805,0.40625 0.96081,0.25213 2.25995,0.3086 3.99805,0.3086 h 11.85547 c 0.69054,0 1.31013,-0.0106 1.86719,-0.0371 0.23047,-0.0111 0.44308,-0.0272 0.65234,-0.0449 0.0436,-0.004 0.094,-0.004 0.13672,-0.008 h 0.002 c 0.49424,-0.0467 0.92903,-0.11749 1.31055,-0.21679 0.19111,-0.0498 0.36981,-0.10571 0.53515,-0.17188 0.16536,-0.0661 0.31771,-0.14178 0.45899,-0.22656 0.14129,-0.0848 0.2717,-0.17962 0.39062,-0.28516 0.10532,-0.0934 0.20005,-0.19727 0.28907,-0.30859 0.0115,-0.0144 0.0259,-0.0264 0.0371,-0.041 6.7e-4,-0.001 9.5e-4,-0.003 0.002,-0.004 0.0971,-0.12749 0.18514,-0.26586 0.26367,-0.41797 0.0792,-0.15352 0.14897,-0.32121 0.21094,-0.50196 0.062,-0.18077 0.11573,-0.37576 0.16211,-0.58593 0.0464,-0.21016 0.0847,-0.43601 0.11718,-0.67774 0.0289,-0.21541 0.0511,-0.44929 0.0703,-0.6914 0.002,-0.0292 0.008,-0.0543 0.01,-0.084 2.9e-4,-0.004 -2.9e-4,-0.008 0,-0.0117 0.0399,-0.54795 0.0568,-1.16365 0.0586,-1.85742 v -11.18578 c -0.006,-1.26044 -1.16032,-2.32513 -2.09571,-3.1289 l -0.008,-0.006 -6.72986,-6.49196 c -1.51744,-1.36767 -2.56676,-2.02344 -4.64258,-2.02344 z"
-         id="path964-1-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccccccccccccccccsscccccccccccccccccccccccss" />
-      <path
-         style="opacity:0.3;fill:url(#linearGradient4316);fill-opacity:1;stroke:none;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 343.16802,134.07487 c -0.99147,0.035 -1.02734,0.0465 -1.02734,0.33594 0,0.10178 0.15173,0.31016 0.45898,0.64648 h 2.87891 c 0.15931,0 0.30929,0.0306 0.45312,0.0762 0.32342,0.02 0.64497,0.0487 0.96485,0.10352 0.0264,0.32124 0.0306,0.64828 0.0371,0.97461 0.0263,0.11154 0.0449,0.2259 0.0449,0.3457 v 2.61719 c 0.25501,0.21272 0.45277,0.36813 0.49023,0.36914 0.45172,0.0121 0.5059,-0.28833 0.46289,-2.54883 -0.0534,-2.80528 0.043,-2.67754 -2.15624,-2.83984 -0.86922,-0.0642 -2.04216,-0.1 -2.60743,-0.0801 z m -10.83984,0.0371 c -5.16676,0.002 -5.89229,0.0632 -6.90234,0.57617 -0.60351,0.30649 -1.03843,1.06517 -1.2461,2.17187 -0.24355,1.30043 -0.239,21.42491 0.006,22.5 0.4115,1.80781 1.06039,2.3312 3.18555,2.56446 0.49142,0.054 4.63516,0.0862 9.20703,0.0723 7.44102,-0.0226 8.39113,-0.0477 9.0625,-0.24023 1.20765,-0.3464 1.67604,-0.80148 2.02539,-1.96289 0.17841,-0.59326 0.21211,-1.68489 0.25391,-8.28321 0.0479,-7.5564 0.0468,-6.60393 -0.21875,-7.15257 -0.0736,-0.15205 -0.33859,-0.46265 -0.72266,-0.875 v 4.07422 c 0,0.12416 -0.0206,0.24218 -0.0488,0.35742 0.0246,3.83198 -0.0428,6.67596 -0.12305,10.47289 0.094,0.98908 -0.26416,2.20979 -1.37304,2.42969 -4.17852,0.21246 -8.39772,0.16055 -12.60547,0.18945 -2.09316,-0.0712 -4.2187,0.13385 -6.29102,-0.20117 -1.20786,-0.09 -1.37139,-1.432 -1.46679,-2.37696 -0.1751,-6.57883 -0.13104,-13.28191 -0.041,-19.88867 0.0853,-1.09208 -0.0376,-2.65795 1.18164,-3.16406 2.366,-0.42229 4.785,-0.2218 7.17578,-0.3125 0.61114,0.0344 0.29054,0.0147 0.94202,0.0117 0.059,-0.007 0.11677,-0.0176 0.17773,-0.0176 h 3.5918 c -0.42688,-0.30915 -0.78914,-0.52782 -1.16797,-0.68359 -0.60974,-0.25114 0.12581,-0.26372 -4.60217,-0.26172 z"
-         id="path4296"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cscscccscccccccccccccccccsccccccccccscccc" />
+         d="m 330.71531,242.04423 c 0.0174,-0.0481 0.0298,-0.0972 0.0298,-0.14921 0,-0.63806 -1.37871,-0.98222 -2.6765,-0.98222 -1.29629,0 -2.6747,0.34416 -2.6747,0.98222 0,0.0524 0.012,0.10139 0.0295,0.14951 l -0.007,0.0129 c -0.0592,0.10739 -0.0884,0.216 -0.0884,0.32279 v 0.78968 c 0,0.12154 0.0383,0.23826 0.10589,0.34867 l -0.009,0.0153 c -0.0647,0.11221 -0.0972,0.22563 -0.0972,0.33784 v 0.78938 c 0,0.11762 0.0361,0.23074 0.10017,0.33813 l -0.003,0.007 c -0.0647,0.11191 -0.0972,0.22563 -0.0972,0.33753 v 0.78969 c 0,0.70154 1.20393,1.25116 2.74089,1.25116 1.53845,0 2.74207,-0.54962 2.74207,-1.25116 v -0.78968 c 0,-0.11221 -0.0324,-0.22623 -0.0978,-0.33784 l -0.003,-0.007 c 0.0634,-0.1074 0.10048,-0.22052 0.10048,-0.33844 v -0.78939 c 0,-0.11221 -0.0324,-0.22623 -0.0978,-0.33813 l -0.009,-0.015 c 0.068,-0.11041 0.1065,-0.22683 0.1065,-0.34896 v -0.78939 c 0,-0.1068 -0.0299,-0.2157 -0.0885,-0.3234 l -0.007,-0.0127 z m -0.19825,4.0862 c 0,0.45336 -1.00478,0.95785 -2.44848,0.95785 -1.44219,0 -2.44727,-0.50449 -2.44727,-0.95785 v -0.74245 c 0.45005,0.41244 1.37601,0.67537 2.44727,0.67537 1.07277,0 1.99873,-0.26323 2.44848,-0.67567 z m 0,-1.46986 c 0,0.45306 -1.00478,0.95755 -2.44848,0.95755 -1.44219,0 -2.44727,-0.50449 -2.44727,-0.95755 v -0.74275 c 0.45005,0.41214 1.37601,0.67536 2.44727,0.67536 1.07277,0 1.99873,-0.26322 2.44848,-0.67566 z m 0,-1.49123 c 0,0.45276 -1.00478,0.95755 -2.44848,0.95755 -1.44219,0 -2.44727,-0.50449 -2.44727,-0.95755 v -0.65702 c 0.43982,0.37274 1.45964,0.56618 2.44727,0.56618 0.98884,0 2.00836,-0.19344 2.44848,-0.56618 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path466"
+         style="display:inline;enable-background:new;fill:url(#linearGradient468);stroke-width:0.300832" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/libreoffice-calc.svg
+++ b/icons/src/fullcolor/default/apps/libreoffice-calc.svg
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="libreoffice-calc.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
      id="base"
-     pagecolor="#797979"
+     pagecolor="#ffffff"
      bordercolor="#000000"
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4142136"
-     inkscape:cx="84.145493"
-     inkscape:cy="139.2068"
-     inkscape:current-layer="layer6"
-     showgrid="true"
+     inkscape:cx="379.71634"
+     inkscape:cy="165.46299"
+     inkscape:current-layer="layer2"
+     showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -50,7 +50,7 @@
      gridtolerance="10000"
      inkscape:object-nodes="true"
      inkscape:snap-grids="true"
-     showguides="false"
+     showguides="true"
      inkscape:guide-bbox="true"
      inkscape:window-maximized="1"
      inkscape:bbox-paths="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,334 +93,89 @@
   <defs
      id="defs3">
     <linearGradient
-       id="linearGradient6430">
-      <stop
-         offset="0"
-         style="stop-color:#18a003;stop-opacity:1"
-         id="stop6426" />
-      <stop
-         offset="1"
-         style="stop-color:#2e851b;stop-opacity:1"
-         id="stop6428" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-5">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient3194"
-       x1="335.73108"
-       y1="62"
-       x2="352.26993"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="169.66859"
-       x2="4.4137931"
-       y1="386.30838"
-       x1="494.34482"
-       id="linearGradient4226-1"
-       xlink:href="#linearGradient4338"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.96286,268)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6646"
-       x="-0.01363613"
-       width="1.0272723"
-       y="-0.01071443"
-       height="1.0214289">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.0000135"
-         id="feGaussianBlur6648" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6668"
-       x="-0.054544518"
-       width="1.109089"
-       y="-0.042857721"
-       height="1.0857154">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.000054"
-         id="feGaussianBlur6670" />
-    </filter>
-    <linearGradient
-       id="linearGradient13214">
-      <stop
-         id="stop13216"
-         style="stop-color:#18a303;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop13218"
-         style="stop-color:#106802;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4338">
-      <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
-         offset="0"
-         id="stop4340" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="1"
-         id="stop4342" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7723"
-       id="linearGradient18935"
-       x1="335.23141"
-       y1="60.997517"
-       x2="352.77151"
-       y2="106.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983-6">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985-0"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971-6">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1311"
-       x1="327.99951"
-       y1="188"
-       x2="335.99951"
-       y2="212"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1309"
-       x1="332"
-       y1="236"
-       x2="324"
-       y2="252"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient13214"
-       id="linearGradient916"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05664062,-0.05663901,0,349.74506,214)"
-       x1="44.137936"
-       y1="240.29004"
-       x2="450.20694"
-       y2="386.30743" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient13214"
-       id="linearGradient920"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.03604403,-0.03604301,0,339.56482,252.90909)"
-       x1="25.221653"
-       y1="209.88313"
-       x2="469.12317"
-       y2="404.09555" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient7723"
-       id="linearGradient18935-0"
-       x1="335.27261"
-       y1="61.369068"
-       x2="352.89749"
-       y2="106.50614"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient4316"
-       x1="372"
-       y1="134"
-       x2="372"
-       y2="162"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-37.000489)" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient18935-0-8"
-       x1="336.64893"
-       y1="59.040947"
-       x2="348.54202"
-       y2="108.83411"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient15606-6">
-      <stop
-         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.588235;"
-         offset="0"
-         id="stop15608-8" />
-      <stop
-         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.862745;"
-         offset="1"
-         id="stop15610-7" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7723">
-      <stop
-         id="stop7721"
-         style="stop-color:#2e851b;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7715"
-         style="stop-color:#18a003;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(0,2e-6)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient6430"
-       id="linearGradient18820-3"
-       x1="201.07812"
-       y1="269.99988"
-       x2="102.92188"
-       y2="45.999878"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3976">
-      <stop
-         offset="0"
-         style="stop-color:#626262;stop-opacity:1"
-         id="stop3972" />
-      <stop
-         offset="1"
-         style="stop-color:#4e4e4e;stop-opacity:1"
-         id="stop3974" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear17"
-       x1="0"
-       y1="0"
+       id="b"
        x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,235,-235,0,106.005,28.0003)">
+       gradientTransform="matrix(0,-203.23056,203.23056,0,558.74892,255.27552)"
+       gradientUnits="userSpaceOnUse">
       <stop
+         stop-color="#16b72d"
          offset="0"
-         style="stop-color:rgb(24,163,3);stop-opacity:1"
-         id="stop427" />
+         id="stop287" />
       <stop
+         stop-color="#51ee84"
          offset="1"
-         style="stop-color:rgb(16,104,2);stop-opacity:1"
-         id="stop429" />
+         id="stop289" />
     </linearGradient>
     <linearGradient
-       id="_Linear9"
-       x1="0"
-       y1="0"
+       id="a"
        x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,46.9998,-46.9998,0,346,54.0002)">
+       gradientTransform="matrix(-0.00528208,-207.68287,207.68287,-0.00528208,232.4463,260.20339)"
+       gradientUnits="userSpaceOnUse">
       <stop
+         stop-color="#b7b4b4"
          offset="0"
-         style="stop-color:rgb(24,163,3);stop-opacity:1"
-         id="stop371" />
+         id="stop282" />
       <stop
+         stop-color="#f1f1f1"
          offset="1"
-         style="stop-color:rgb(16,104,2);stop-opacity:1"
-         id="stop373" />
+         id="stop284" />
     </linearGradient>
     <linearGradient
-       id="_Linear10"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient403"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,16.223,-16.223,0,338,228.912)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(24,163,3);stop-opacity:1"
-         id="stop376" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(16,104,2);stop-opacity:1"
-         id="stop378" />
-    </linearGradient>
+       gradientTransform="matrix(0,-41.734849,41.734849,0,427.5288,104.38694)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient405"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00108471,-42.649162,42.649162,-0.00108471,360.52022,105.39891)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient415"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-27.21838,27.21838,0,390.4753,161.29583)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient417"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-7.0741956e-4,-27.814671,27.814671,-7.0741956e-4,346.77405,161.95581)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient427"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-19.960147,19.960147,0,372.25958,209.63814)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient429"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.1877438e-4,-20.397427,20.397427,-5.1877438e-4,340.21199,210.12213)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient439"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-12.701914,12.701914,0,353.61975,250.13337)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient441"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.3012921e-4,-12.980183,12.980183,-3.3012921e-4,333.22583,250.44136)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -519,7 +275,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">libreoffice-calc</tspan></text>
+           id="tspan924">libreoffice-calc</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -554,656 +310,129 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.991584;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 342.28786,133.99591 c -0.0832,0 -0.1556,0.007 -0.2168,0.0156 l -0.0371,0.006 -0.0371,0.0117 c -1.02052,0.30458 -1.3544,1.66824 -0.54687,2.36914 0,0 0,0.002 0,0.002 l 5.08984,4.76563 0.006,0.004 c 0.44144,0.39204 1.03582,0.39851 1.50781,0.21874 0.47199,-0.17975 0.9171,-0.5946 0.94141,-1.18945 v -0.01 -1.35352 -0.002 c 0.006,-1.0363 0.0251,-1.82214 -0.0176,-2.45508 -0.0427,-0.63344 -0.14348,-1.14825 -0.47266,-1.55274 -0.32917,-0.40448 -0.82834,-0.59266 -1.42968,-0.68554 -0.60135,-0.0929 -1.35232,-0.1114 -2.36133,-0.13281 h -0.006 -2.26953 c -0.0478,-0.005 -0.0951,-0.0117 -0.15039,-0.0117 z m -7.25782,0.002 -4.95507,0.002 c -2.79936,0 -4.57517,0.10197 -5.71875,1.13282 -0.24259,0.21892 -0.43083,0.4754 -0.5879,0.74414 -0.0117,0.02 -0.0564,0.0782 -0.11132,0.1875 -0.0907,0.18027 -0.17065,0.37241 -0.23828,0.57617 -0.0671,0.20198 -0.12496,0.41859 -0.17383,0.65039 -0.0486,0.23023 -0.0869,0.47111 -0.11914,0.72851 v 0.002 c -0.0646,0.51578 -0.10015,1.09026 -0.11524,1.73633 -0.007,0.32198 -0.0116,0.66266 -0.01,1.02343 v 8.21875 8.22071 c -0.002,0.3594 0.002,0.69873 0.01,1.02148 0.0151,0.64603 0.0505,1.22236 0.11524,1.73828 0.0323,0.25754 0.0707,0.4986 0.11914,0.72852 0.0971,0.4603 0.23097,0.86702 0.41211,1.22656 0.18147,0.36018 0.41279,0.67544 0.69922,0.93359 0.14342,0.12929 0.30075,0.24284 0.46679,0.34375 0.33271,0.20222 0.70911,0.35057 1.12891,0.46094 v 0.002 c 1.04936,0.27537 2.37421,0.32422 4.12305,0.32422 h 11.85546 c 0.69562,0 1.32241,-0.0101 1.89063,-0.0371 h 0.002 c 0.23885,-0.0115 0.45772,-0.0289 0.66992,-0.0469 h 0.002 0.002 c 0.006,-5.4e-4 0.052,-0.004 0.0898,-0.006 h 0.0137 c 0.0155,-0.001 0.0141,-1.1e-4 0.0332,-0.002 h 0.002 c 0.51385,-0.0486 0.97388,-0.12251 1.38867,-0.23047 0.20576,-0.0536 0.4054,-0.11525 0.59571,-0.19141 0.18901,-0.0755 0.36479,-0.163 0.52929,-0.26172 0.1657,-0.0995 0.3216,-0.21271 0.46485,-0.33984 0.12928,-0.11465 0.24087,-0.23957 0.34179,-0.36524 0,2e-5 0.005,-0.005 0.006,-0.006 l 0.0215,-0.0215 0.0156,-0.0195 0.006,-0.008 0.002,-0.004 0.008,-0.008 0.008,-0.0137 c 4e-5,-7e-5 0.008,-0.016 0.0117,-0.0234 0.003,-0.004 0.009,-0.008 0.0117,-0.0117 -5.4e-4,7e-4 -0.007,0.003 -0.008,0.004 0.01,-0.0181 0.0172,-0.0306 0.0254,-0.0469 -0.006,0.0128 -0.01,0.0233 -0.0117,0.0273 0.095,-0.13149 0.18742,-0.26844 0.26562,-0.41992 0.0922,-0.17881 0.17175,-0.3686 0.24024,-0.56836 0.069,-0.20111 0.12594,-0.41283 0.17578,-0.63867 0.0501,-0.22709 0.0911,-0.46643 0.125,-0.71875 0.0307,-0.22912 0.0546,-0.4717 0.0742,-0.71875 l 0.002,-0.002 v -0.004 c -10e-4,0.0185 0.005,-0.009 0.01,-0.082 v -0.002 c 0.002,-0.0307 0.004,-0.0623 0,-0.006 v -0.002 -0.002 c 0.0411,-0.56466 0.0568,-1.18956 0.0586,-1.89062 v -0.004 -11.1875 c -0.007,-1.5618 -1.32097,-2.69049 -2.26758,-3.50391 l -0.01,-0.008 -0.002,-0.002 -6.71093,-6.47461 -0.008,-0.006 c -1.54333,-1.391 -2.79437,-2.15039 -4.97461,-2.15039 z"
-         id="path964-1-7-1"
-         inkscape:connector-curvature="0" />
+         d="m 244.62258,260.20339 -58.16893,-0.0674 V 52.687055 l 59.83434,-0.2166 c 10.39675,0.12515 15.59513,8.22114 15.59513,17.94884 V 241.41704 c 0.45245,10.68074 -6.60387,18.55531 -17.26054,18.78635 z"
+         fill="url(#a)"
+         id="path292"
+         style="display:inline;fill:url(#a);stroke-width:4.81331;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.135116;marker:none;enable-background:accumulate"
-         d="m 334.82227,134.66602 c -1.232,-0.0266 -2.52178,0.15451 -3.73047,0.0449 -0.29655,7.3e-4 -0.59212,9.5e-4 -0.88868,0.002 -1.6671,0.16913 -3.75817,-0.32886 -5.13476,0.81836 -0.75319,4.08167 -0.26144,8.28233 -0.41797,12.42773 0.12068,4.03553 -0.23881,8.12396 0.2832,12.12891 1.11174,1.89202 3.7025,1.01677 5.48243,1.27344 5.08011,-0.0559 10.19453,0.21822 15.2539,-0.24414 1.86137,-0.54694 1.27882,-2.8856 1.48438,-4.34766 0.087,-4.05402 0.0901,-8.17873 0.13867,-12.26172 -3.42529,-3.16466 -6.52114,-6.76535 -10.34375,-9.46093 -0.66889,-0.27404 -1.38776,-0.36491 -2.12695,-0.38086 z"
-         id="rect4158-92-6-7-3"
-         inkscape:connector-curvature="0" />
+         d="m 152.5824,52.720745 79.47739,-7.451003 c 10.6326,-1.073368 15.27745,4.630407 15.35928,16.062023 l -0.67382,187.964665 c -0.19253,12.71678 -5.88192,19.3784 -17.09688,19.84528 l -76.54613,-8.93832 H 71.352939 c -10.440074,0 -21.048614,-8.5003 -21.106374,-21.74654 V 73.730855 c 0.399505,-15.23894 6.753077,-20.98123 21.992024,-21.2604 z"
+         fill="url(#b)"
+         id="path294"
+         style="display:inline;fill:url(#b);stroke-width:4.81331;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.135116;marker:none;enable-background:accumulate"
-         d="m 342.43453,133.5 c -0.0499,0 -0.0992,0.005 -0.14846,0.0114 -0.63275,0.19268 -0.84778,1.10823 -0.35998,1.53887 l 5.15449,4.82872 c 0.52901,0.47937 1.38249,0.0699 1.41036,-0.62634 v -1.36063 c 0.0226,-4.21424 0.33006,-4.29412 -3.66401,-4.38062 h -2.24263 c -0.0493,-0.007 -0.0999,-0.0114 -0.14977,-0.0114 z m -12.63559,0.0804 c -5.53701,-3.3e-4 -6.32794,0.58227 -6.29884,6.26467 v 8.19515 8.19514 c -0.0291,5.68242 1.00827,6.26467 6.54528,6.26467 h 11.7978 c 5.49726,0 6.52858,-0.57993 6.54266,-6.15295 v -11.14923 c -0.006,-1.25658 -1.15546,-2.31787 -2.08629,-3.11916 l -0.008,-0.006 -6.70166,-6.47491 c -1.50985,-1.36345 -2.55339,-2.01695 -4.61908,-2.01707 z m 7.22852,2.4196 8.97205,8.99977 v 13.00023 c 0,0 -0.11213,1.17819 -0.44846,1.49951 -0.33633,0.32134 -1.56951,0.42847 -1.56951,0.42847 h -15.96407 c 0,0 -1.23318,-0.10713 -1.56951,-0.42847 -0.33632,-0.32132 -0.44845,-1.49951 -0.44845,-1.49951 l -0.018,-20.07203 c 0,0 0.11213,-1.17819 0.44845,-1.49951 0.33637,-0.32133 1.56955,-0.42846 1.56955,-0.42846 z"
-         id="rect4158-92-6-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 246.74525,249.29643 c -0.19253,12.71678 -5.88192,19.3784 -17.09688,19.84528 l -77.41253,-9.0394 V 52.754445 l 79.82395,-7.484703 c 10.6326,-1.073368 15.27745,4.630407 15.35928,16.062023 z"
+         fill-opacity="0.15"
+         id="path296"
+         style="display:inline;stroke-width:4.81331;enable-background:new" />
       <path
-         style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 323.49951,148 v 0.041 8.19531 c -0.0291,5.68242 1.00791,6.26367 6.54492,6.26367 h 11.79883 c 5.49726,0 6.52889,-0.57932 6.54297,-6.15234 v -8.34764 z"
-         id="rect4398"
-         inkscape:connector-curvature="0" />
+         d="m 363.02071,105.39891 -11.94541,-0.0138 V 62.783949 l 12.28741,-0.04448 c 2.13505,0.0257 3.20257,1.688269 3.20257,3.685922 V 101.541 c 0.0929,2.19337 -1.35615,3.81047 -3.54457,3.85791 z"
+         fill="url(#a)"
+         id="path395"
+         style="display:inline;fill:url(#linearGradient405);stroke-width:0.988448;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 353.50267,61.373185 c -0.13268,1.31e-4 -0.25604,0.01264 -0.36719,0.0293 l -0.0781,0.01172 -0.0762,0.02344 c -0.87574,0.279121 -1.39412,1.031903 -1.56445,1.792968 -0.1518,0.678132 0.0116,1.444638 0.51367,2.050782 l -0.36328,-0.363282 -0.01,-0.0078 -0.002,-0.0039 c 0,0 -0.002,0.0038 -0.002,0.0039 -0.28283,-0.2673 -0.55686,-0.524524 -0.83398,-0.767578 h -0.002 l -0.002,-0.0039 -0.002,-0.002 c 0,0 -0.006,-0.0019 -0.006,-0.002 -0.2711,-0.237536 -0.5406,-0.460957 -0.81055,-0.669922 0,0 -0.006,-0.0038 -0.006,-0.0039 -1.8e-4,-8.7e-5 -0.006,-0.0038 -0.006,-0.0039 -0.26922,-0.208011 -0.54257,-0.405967 -0.82617,-0.587891 h -0.002 l -0.002,-0.002 c 0,1e-6 -0.004,-0.0019 -0.004,-0.002 -0.27684,-0.177258 -0.55998,-0.341168 -0.85742,-0.488281 1e-5,0 -0.006,-0.0019 -0.006,-0.002 -0.29595,-0.146081 -0.60404,-0.275889 -0.92383,-0.386719 l -0.004,-0.002 h -0.002 -0.002 c -0.31787,-0.109783 -0.64897,-0.202793 -0.99414,-0.275391 0,-10e-7 -0.009,7.2e-5 -0.01,0 -0.34183,-0.07151 -0.69666,-0.126987 -1.07031,-0.162109 h -0.002 c -0.37669,-0.03533 -0.76878,-0.05072 -1.17774,-0.05078 h -0.002 -8.26738 c -4.1516,0 -6.86541,0.144563 -8.65234,1.832032 -0.89392,0.844181 -1.42053,2.015243 -1.71289,3.464842 -0.29235,1.449603 -0.3762,2.716182 -0.36524,4.956606 v 12.746093 12.751955 c -0.0108,2.23702 0.0732,4.00312 0.36524,5.45117 0.29236,1.44961 0.81896,2.62067 1.71289,3.46485 0.22046,0.20818 0.46372,0.3989 0.72656,0.5664 l 0.004,0.002 0.006,0.004 c 0,0 0.011,0.004 0.0117,0.004 0.24938,0.15738 0.51414,0.29744 0.79688,0.41797 l 0.006,0.002 c 10e-4,5.8e-4 0.003,0.003 0.004,0.004 h 0.002 c 0.001,2.9e-4 0.01,0.003 0.0117,0.004 0.28562,0.12045 0.58739,0.22665 0.90625,0.31446 h 0.002 0.002 c 0.31721,0.0872 0.65158,0.16192 1.00586,0.22265 h 0.004 0.002 0.002 c 0.35215,0.0602 0.71743,0.1063 1.10157,0.14453 2e-5,0 0.005,-1e-5 0.006,0 0.38435,0.0381 0.78775,0.0683 1.21289,0.0899 h 0.004 0.002 c 4.7e-4,1e-5 0.005,-1e-5 0.006,0 l 0.004,0.002 c 3.5e-4,1e-5 0.0746,-7e-5 0.0723,0 0.83602,0.0405 1.74479,0.0566 2.7539,0.0566 h 0.002 17.03691 c 4.12301,0 6.31689,-0.14175 8.10202,-1.80273 0.89298,-0.83017 1.42413,-1.9843 1.72461,-3.41016 0.30048,-1.42587 0.39703,-3.16132 0.40234,-5.35937 v -18.908211 -0.002 c -0.009,-1.901937 -1.18883,-3.38937 -2.32226,-4.541016 -0.37676,-0.382884 -0.75737,-0.733609 -1.10938,-1.050781 l -0.28515,-0.257813 h 0.0273 l -0.0117,-0.01172 h -0.002 l -0.0508,-0.05078 c 0.7203,0.562642 1.63962,0.613597 2.36523,0.31836 0.78035,-0.317514 1.50219,-1.045367 1.54102,-2.060547 v -0.01953 -2.13086 -0.0059 c 0.008,-1.627913 0.0362,-2.366723 -0.0274,-3.374573 -0.0638,-1.009375 -0.2058,-1.850441 -0.73633,-2.546875 -0.53053,-0.696434 -1.36221,-1.029213 -2.28515,-1.181641 -0.92293,-0.152428 -2.03533,-0.179157 -3.52344,-0.21289 h -0.0117 -2.84421 -0.002 c -0.073,-0.0069 -0.14393,-0.0174 -0.2207,-0.01758 z m -24.57206,43.876525 c 7.7e-4,4.2e-4 10e-4,0.002 0.002,0.002 -0.0334,0.003 -0.0689,0.006 -0.0684,0.006 5.2e-4,-8e-5 0.0335,-0.004 0.0664,-0.008 z m -0.0312,1.98438 c 0.005,2.6e-4 0.0335,0.004 0.0645,0.006 -0.0263,-10e-4 -0.0586,-0.004 -0.0586,-0.004 z"
-         id="path964-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccscccccccccccccccccccccccccccccccscsccccccccccccccccccsccccccccccccccc" />
+         d="m 344.1196,62.790867 16.32125,-1.530116 c 2.18348,-0.220424 3.13733,0.950887 3.15414,3.298451 l -0.13838,38.599888 c -0.0395,2.61148 -1.20789,3.97949 -3.51096,4.07537 l -15.7193,-1.83555 h -16.7878 c -2.14394,0 -4.32248,-1.7456 -4.33435,-4.46581 V 67.105444 c 0.082,-3.129426 1.3868,-4.308646 4.51622,-4.365975 z"
+         fill="url(#b)"
+         id="path397"
+         style="display:inline;fill:url(#linearGradient403);stroke-width:0.988448;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6668);enable-background:accumulate"
-         d="m 102.92188,46 c -35.29673,0 -38.92188,3.625611 -38.92188,38.994141 v 71.005859 2 71.00586 c 0,15.47373 0.693319,24.87213 4.429688,30.54883 0.533765,0.81095 1.130124,1.54501 1.794921,2.21093 5.31838,5.32748 15.048901,6.23438 32.697271,6.23438 h 98.15624 c 2.05464,0 3.9874,-0.0148 5.83399,-0.0449 0.6589,-0.0108 1.26119,-0.0352 1.89453,-0.0508 1.14935,-0.0283 2.29189,-0.0591 3.35938,-0.10547 1.26994,-0.0552 2.50934,-0.11952 3.66796,-0.20508 0.47389,-0.035 0.93478,-0.0745 1.39063,-0.11523 0.22056,-0.0197 0.44963,-0.0375 0.66601,-0.0586 0.72759,-0.0709 1.43573,-0.14684 2.11719,-0.23437 0.66796,-0.0858 1.31051,-0.18193 1.93555,-0.28516 0.22197,-0.0367 0.43176,-0.0802 0.64844,-0.11914 0.39648,-0.0713 0.79087,-0.14326 1.16992,-0.22266 0.24847,-0.052 0.4874,-0.10842 0.72851,-0.16406 0.31951,-0.0737 0.63656,-0.15017 0.94336,-0.23047 0.25892,-0.0678 0.51169,-0.13834 0.76172,-0.21094 0.28349,-0.0823 0.56172,-0.16909 0.83399,-0.25781 0.22709,-0.074 0.45245,-0.1499 0.67187,-0.22851 0.28508,-0.10213 0.5616,-0.20821 0.83399,-0.31836 0.19615,-0.0793 0.39429,-0.15856 0.58398,-0.24219 0.27476,-0.12111 0.53736,-0.25048 0.79883,-0.38086 0.17443,-0.087 0.3548,-0.17048 0.52344,-0.26172 0.40967,-0.22161 0.80523,-0.45357 1.18164,-0.70117 0.40638,-0.26732 0.79483,-0.54837 1.16406,-0.84766 0.33966,-0.27532 0.65922,-0.56925 0.96875,-0.87304 0.0745,-0.0731 0.14592,-0.14979 0.21875,-0.22461 0.22962,-0.23599 0.45095,-0.48113 0.66406,-0.73438 0.077,-0.0915 0.15554,-0.18158 0.23047,-0.27539 0.54111,-0.67772 1.02765,-1.41677 1.46484,-2.2207 0.0553,-0.10155 0.10843,-0.20689 0.16211,-0.31055 0.15861,-0.30642 0.3098,-0.62208 0.45508,-0.94726 0.0614,-0.1373 0.12454,-0.27336 0.1836,-0.41407 0.1819,-0.4336 0.35679,-0.8789 0.51757,-1.3457 0.16052,-0.46603 0.30667,-0.95474 0.44727,-1.45508 0.0408,-0.14516 0.08,-0.29328 0.11914,-0.4414 0.0645,-0.24379 0.12339,-0.50007 0.18359,-0.75196 0.14384,-0.60169 0.27581,-1.22778 0.39649,-1.87695 0.0319,-0.17177 0.0674,-0.3385 0.0976,-0.51367 0.14069,-0.8111 0.26747,-1.65503 0.37696,-2.54102 0.022,-0.17777 0.0398,-0.36992 0.0605,-0.55078 0.0825,-0.71822 0.15576,-1.46049 0.22071,-2.22851 0.0255,-0.30185 0.0493,-0.60826 0.0723,-0.91797 0.057,-0.7684 0.10605,-1.56297 0.14844,-2.38086 0.0132,-0.25434 0.0311,-0.49859 0.043,-0.75782 0.007,-0.14749 0.009,-0.31184 0.0156,-0.46093 0.0622,-1.46308 0.10249,-3.01983 0.12891,-4.64063 0.007,-0.4186 0.0128,-0.84593 0.0176,-1.27539 0.0196,-1.77364 0.0291,-3.60559 0.0195,-5.57031 v -100.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67689,-10.56116 -18.05782,-15.619141 -32.66602,-15.619141 z m 96.98242,0.08984 c -2.16918,2.775877 -2.38539,7.403545 0.20898,9.912109 l 28.4961,30.386719 c 3.72376,3.695922 11.11845,0.568263 11.38085,-4.779297 -0.002,-0.42002 0.001,-0.861231 -0.002,-1.271484 -9e-4,-0.49135 -0.009,-0.953362 -0.0117,-1.431641 -0.36165,-27.253999 -4.96046,-32.190518 -31.3457,-32.816406 z"
-         id="path5316-1" />
+         d="m 363.45661,103.15909 c -0.0395,2.61148 -1.20789,3.97949 -3.51096,4.07537 l -15.89722,-1.85631 V 62.797788 l 16.39242,-1.537037 c 2.18348,-0.220424 3.13733,0.950887 3.15414,3.298451 z"
+         fill-opacity="0.15"
+         id="path399"
+         style="display:inline;stroke-width:0.988448;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6646);enable-background:accumulate"
-         d="m 102.92188,45 c -35.29673,0 -38.92188,3.625611 -38.92188,38.994141 v 72.005859 1 72.00586 c 0,15.47373 0.693319,24.87213 4.429688,30.54883 0.533765,0.81095 1.130124,1.54501 1.794921,2.21093 5.31838,5.32748 15.048901,6.23438 32.697271,6.23438 h 98.15624 c 2.05464,0 3.9874,-0.0148 5.83399,-0.0449 0.6589,-0.0108 1.26119,-0.0352 1.89453,-0.0508 1.14935,-0.0283 2.29189,-0.0591 3.35938,-0.10547 1.26994,-0.0552 2.50934,-0.11952 3.66796,-0.20508 0.47389,-0.035 0.93478,-0.0745 1.39063,-0.11523 0.22056,-0.0197 0.44963,-0.0375 0.66601,-0.0586 0.72759,-0.0709 1.43573,-0.14684 2.11719,-0.23437 0.66796,-0.0858 1.31051,-0.18193 1.93555,-0.28516 0.22197,-0.0367 0.43176,-0.0802 0.64844,-0.11914 0.39648,-0.0713 0.79087,-0.14326 1.16992,-0.22266 0.24847,-0.052 0.4874,-0.10842 0.72851,-0.16406 0.31951,-0.0737 0.63656,-0.15017 0.94336,-0.23047 0.25892,-0.0678 0.51169,-0.13834 0.76172,-0.21094 0.28349,-0.0823 0.56172,-0.16909 0.83399,-0.25781 0.22709,-0.074 0.45245,-0.1499 0.67187,-0.22851 0.28508,-0.10213 0.5616,-0.20821 0.83399,-0.31836 0.19615,-0.0793 0.39429,-0.15856 0.58398,-0.24219 0.27476,-0.12111 0.53736,-0.25048 0.79883,-0.38086 0.17443,-0.087 0.3548,-0.17048 0.52344,-0.26172 0.40967,-0.22161 0.80523,-0.45357 1.18164,-0.70117 0.40638,-0.26732 0.79483,-0.54837 1.16406,-0.84766 0.33966,-0.27532 0.65922,-0.56925 0.96875,-0.87304 0.0745,-0.0731 0.14592,-0.14979 0.21875,-0.22461 0.22962,-0.23599 0.45095,-0.48113 0.66406,-0.73438 0.077,-0.0915 0.15554,-0.18158 0.23047,-0.27539 0.54111,-0.67772 1.02765,-1.41677 1.46484,-2.2207 0.0553,-0.10155 0.10843,-0.20689 0.16211,-0.31055 0.15861,-0.30642 0.3098,-0.62208 0.45508,-0.94726 0.0614,-0.1373 0.12454,-0.27336 0.1836,-0.41407 0.1819,-0.4336 0.35679,-0.8789 0.51757,-1.3457 0.16052,-0.46603 0.30667,-0.95474 0.44727,-1.45508 0.0408,-0.14516 0.08,-0.29328 0.11914,-0.4414 0.0645,-0.24379 0.12339,-0.50007 0.18359,-0.75196 0.14384,-0.60169 0.27581,-1.22778 0.39649,-1.87695 0.0319,-0.17177 0.0674,-0.3385 0.0976,-0.51367 0.14069,-0.8111 0.26747,-1.65503 0.37696,-2.54102 0.022,-0.17777 0.0398,-0.36992 0.0605,-0.55078 0.0825,-0.71822 0.15576,-1.46049 0.22071,-2.22851 0.0255,-0.30185 0.0493,-0.60826 0.0723,-0.91797 0.057,-0.7684 0.10605,-1.56297 0.14844,-2.38086 0.0132,-0.25434 0.0311,-0.49859 0.043,-0.75782 0.007,-0.14749 0.009,-0.31184 0.0156,-0.46093 0.0622,-1.46308 0.10249,-3.01983 0.12891,-4.64063 0.007,-0.4186 0.0128,-0.84593 0.0176,-1.27539 0.0196,-1.77364 0.0291,-3.60559 0.0195,-5.57031 v -101.76563 c -0.044,-9.7329 -8.17907,-17.95561 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67689,-10.56116 -18.05782,-15.619141 -32.66602,-15.619141 z m 97.96874,0.08984 c -3.03973,2.502305 -3.72055,8.066242 -0.77734,10.912109 l 28.4961,30.386719 c 3.72891,3.701032 11.14177,0.560315 11.38476,-4.800781 -2.2e-4,-0.210853 -10e-4,-0.418504 -0.002,-0.626953 -1e-4,-1.198304 -0.0128,-2.328552 -0.0254,-3.451172 -0.40326,-26.889233 -5.08512,-31.797223 -31.33594,-32.419922 z"
-         id="path5316-84" />
+         d="m 348.40481,161.95581 -7.79049,-0.009 v -27.78336 l 8.01353,-0.029 c 1.39242,0.0168 2.08863,1.10104 2.08863,2.40386 v 22.90148 c 0.0606,1.43046 -0.88444,2.48509 -2.31167,2.51603 z"
+         fill="url(#a)"
+         id="path407"
+         style="display:inline;fill:url(#linearGradient417);stroke-width:0.64464;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -2.17574,0 -4.226351,0.01468 -6.167974,0.04883 -29.48187,0.527845 -32.667968,5.787316 -32.667968,38.945313 v 73.005857 73.00586 c 0,33.158 3.186098,38.41747 32.667968,38.94531 1.941623,0.0342 3.992234,0.0488 6.167974,0.0488 0.0303,10e-6 0.0556,0 0.0859,0 h 98.07031 c 2.05464,0 3.9874,-0.0148 5.83399,-0.0449 0.6589,-0.0108 1.26119,-0.0352 1.89453,-0.0508 1.14935,-0.0283 2.29189,-0.0591 3.35938,-0.10547 1.26994,-0.0552 2.50934,-0.11952 3.66796,-0.20508 0.47389,-0.035 0.93478,-0.0745 1.39063,-0.11523 0.22056,-0.0197 0.44963,-0.0375 0.66601,-0.0586 0.72759,-0.0709 1.43573,-0.14684 2.11719,-0.23437 0.66796,-0.0858 1.31051,-0.18193 1.93555,-0.28516 0.22197,-0.0367 0.43176,-0.0802 0.64844,-0.11914 0.39648,-0.0713 0.79087,-0.14326 1.16992,-0.22266 0.24847,-0.052 0.4874,-0.10842 0.72851,-0.16406 0.31951,-0.0737 0.63656,-0.15017 0.94336,-0.23047 0.25892,-0.0678 0.51169,-0.13834 0.76172,-0.21094 0.28349,-0.0823 0.56172,-0.16909 0.83399,-0.25781 0.22709,-0.074 0.45245,-0.1499 0.67187,-0.22851 0.28508,-0.10213 0.5616,-0.20821 0.83399,-0.31836 0.19615,-0.0793 0.39429,-0.15856 0.58398,-0.24219 0.27476,-0.12111 0.53736,-0.25048 0.79883,-0.38086 0.17443,-0.087 0.3548,-0.17048 0.52344,-0.26172 0.40967,-0.22161 0.80523,-0.45357 1.18164,-0.70117 0.40638,-0.26732 0.79483,-0.54837 1.16406,-0.84766 0.33966,-0.27532 0.65922,-0.56925 0.96875,-0.87304 0.0745,-0.0731 0.14592,-0.14979 0.21875,-0.22461 0.22962,-0.23599 0.45095,-0.48113 0.66406,-0.73438 0.077,-0.0915 0.15554,-0.18158 0.23047,-0.27539 0.54111,-0.67772 1.02765,-1.41677 1.46484,-2.2207 0.0553,-0.10155 0.10843,-0.20689 0.16211,-0.31055 0.15861,-0.30642 0.3098,-0.62208 0.45508,-0.94726 0.0614,-0.1373 0.12454,-0.27336 0.1836,-0.41407 0.1819,-0.4336 0.35679,-0.8789 0.51757,-1.3457 0.16052,-0.46603 0.30667,-0.95474 0.44727,-1.45508 0.0408,-0.14516 0.08,-0.29328 0.11914,-0.4414 0.0645,-0.24379 0.12339,-0.50007 0.18359,-0.75196 0.14384,-0.60169 0.27581,-1.22778 0.39649,-1.87695 0.0319,-0.17177 0.0674,-0.3385 0.0976,-0.51367 0.14069,-0.8111 0.26747,-1.65503 0.37696,-2.54102 0.022,-0.17777 0.0398,-0.36992 0.0605,-0.55078 0.0825,-0.71822 0.15576,-1.46049 0.22071,-2.22851 0.0255,-0.30185 0.0493,-0.60826 0.0723,-0.91797 0.057,-0.7684 0.10605,-1.56297 0.14844,-2.38086 0.0132,-0.25434 0.0311,-0.49859 0.043,-0.75782 0.007,-0.14749 0.009,-0.31184 0.0156,-0.46093 0.0622,-1.46308 0.10249,-3.01983 0.12891,-4.64063 0.007,-0.4186 0.0128,-0.84593 0.0176,-1.27539 0.0196,-1.77364 0.0291,-3.60559 0.0195,-5.57031 v -102.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408197 c -10.67684,-10.56116 -18.05782,-15.619141 -32.66602,-15.619141 z m 99.73242,0.08984 c -4.47461,1.4924 -5.99062,8.576599 -2.54102,11.912109 l 28.4961,30.386719 c 3.73355,3.705631 11.16128,0.552964 11.38671,-4.820313 0.0482,-31.329014 -3.55328,-36.818783 -31.36523,-37.478515 z"
-         id="path5316-3" />
+         d="m 336.078,134.16796 10.64429,-0.9979 c 1.42401,-0.14376 2.04608,0.62014 2.05705,2.15116 l -0.0902,25.17384 c -0.0258,1.70314 -0.78776,2.59532 -2.28976,2.65785 l -10.25171,-1.1971 H 325.1991 c -1.39822,0 -2.81901,-1.13843 -2.82675,-2.91248 v -22.06152 c 0.0535,-2.04093 0.90443,-2.80998 2.94536,-2.84737 z"
+         fill="url(#b)"
+         id="path409"
+         style="display:inline;fill:url(#linearGradient415);stroke-width:0.64464;enable-background:new" />
       <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
+         d="m 348.68909,160.49506 c -0.0258,1.70314 -0.78776,2.59532 -2.28976,2.65785 l -10.36775,-1.21064 v -27.7698 l 10.69071,-1.00241 c 1.42401,-0.14376 2.04608,0.62014 2.05705,2.15116 z"
+         fill-opacity="0.15"
+         id="path411"
+         style="display:inline;stroke-width:0.64464;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44.000001 c -35.29672,0 -38.92188,3.62561 -38.92188,38.99414 v 73.005859 73.00586 c 0,35.36853 3.62516,38.99414 38.92188,38.99414 h 98.15625 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 v -102.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67686,-10.56118 -18.05785,-15.61912 -32.66605,-15.61912 z"
-         id="path5316"
-         inkscape:connector-curvature="0" />
+         d="m 341.40788,210.12213 -5.71302,-0.007 v -20.37447 l 5.87658,-0.0213 c 1.02111,0.0123 1.53167,0.80743 1.53167,1.76283 v 16.79442 c 0.0444,1.049 -0.64859,1.8224 -1.69523,1.84509 z"
+         fill="url(#a)"
+         id="path419"
+         style="display:inline;fill:url(#linearGradient429);stroke-width:0.472736;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 v 2.89258 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 0.0896,-0.53386 0.10352,-1.11551 0.10352,-1.83594 v -3.89844 -2.89844 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 -0.5334,-0.0898 -1.11494,-0.10352 -1.83398,-0.10352 z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
+         d="m 332.36822,189.74437 7.80581,-0.73179 c 1.04428,-0.10543 1.50046,0.45477 1.50851,1.57751 l -0.0661,18.46082 c -0.0189,1.24897 -0.57769,1.90324 -1.67916,1.94909 l -7.51792,-0.87787 h -8.02895 c -1.02536,0 -2.06727,-0.83485 -2.07295,-2.13582 v -16.17845 c 0.0392,-1.49668 0.66325,-2.06065 2.15993,-2.08807 z"
+         fill="url(#b)"
+         id="path421"
+         style="display:inline;fill:url(#linearGradient427);stroke-width:0.472736;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 338.04492,62.464844 c -3.30188,0.184179 -6.86204,-0.305851 -9.85351,1.287109 -1.97622,1.888857 -1.38183,4.995826 -1.58399,7.449219 -0.0344,10.068892 -0.14641,20.172417 0.23633,30.212888 -0.029,2.1336 1.84785,3.67138 3.86719,3.84375 8.70844,0.19443 17.43935,0.14344 26.15234,-0.0488 2.11454,0.21212 4.07818,-1.36195 4.26758,-3.49609 0.49435,-7.154994 0.29762,-14.368388 0.375,-21.554687 0.13662,-1.826153 -0.21889,-3.74064 -1.69336,-4.976562 -3.90212,-4.058118 -7.81355,-8.165811 -12.16016,-11.746094 -2.95707,-1.358369 -6.45049,-0.823446 -9.60742,-0.970703 z"
-         id="path964"
-         inkscape:connector-curvature="0" />
+         d="m 341.61635,209.05091 c -0.0189,1.24897 -0.57769,1.90324 -1.67915,1.94909 l -7.60302,-0.8878 v -20.36452 l 7.83985,-0.7351 c 1.04428,-0.10543 1.50046,0.45477 1.50851,1.57751 z"
+         fill-opacity="0.15"
+         id="path423"
+         style="display:inline;stroke-width:0.472736;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.205504;marker:none;enable-background:accumulate"
-         d="m 353.5,61.375 c -0.0742,0 -0.1474,0.0066 -0.2207,0.01758 -0.94065,0.29981 -1.26034,1.724451 -0.53516,2.394531 l 7.51367,7.513672 c 0.78643,0.74591 2.35309,0.108771 2.39453,-0.974609 v -2.117188 c 0.0336,-6.55752 0.34204,-6.681806 -5.5957,-6.816406 h -3.33398 c -0.0733,-0.0113 -0.14848,-0.01758 -0.22266,-0.01758 z m -18.26953,0.125 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 v 12.751953 12.751953 c -0.0433,8.842037 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70563,-0.9024 9.72656,-9.574219 v -18.904297 c -0.009,-1.95527 -1.71775,-3.606675 -3.10156,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 c -2.24459,-2.121578 -3.79625,-3.138638 -6.8672,-3.138638 z m 11.26953,3.5 12.5,12.5 v 22.5 c 0,0 -0.1667,1.8333 -0.6667,2.3333 -0.5,0.5 -2.3333,0.6667 -2.3333,0.6667 h -24 c 0,0 -1.8333,-0.1667 -2.3333,-0.6667 -0.5,-0.5 -0.6667,-2.3333 -0.6667,-2.3333 v -32 c 0,0 0.1667,-1.8333 0.6667,-2.3333 0.5,-0.5 2.3333,-0.6667 2.3333,-0.6667 z"
-         id="rect4158-92-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 333.98685,250.44136 -3.63556,-0.004 v -12.96557 l 3.73964,-0.0135 c 0.64981,0.008 0.9747,0.51382 0.9747,1.1218 v 10.68736 c 0.0283,0.66754 -0.41273,1.15971 -1.07878,1.17415 z"
+         fill="url(#a)"
+         id="path431"
+         style="display:inline;fill:url(#linearGradient441);stroke-width:0.300832;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.90435,236.5 c 0.71048,0 1.27344,0.0154 1.75195,0.0957 0.47851,0.0803 0.89671,0.23728 1.20703,0.54688 0.31032,0.30959 0.46726,0.7261 0.54688,1.20508 0.0796,0.47897 0.0933,1.04352 0.0898,1.75586 v 3.89648 3.89844 c 0.003,0.71121 -0.0103,1.27546 -0.0898,1.7539 -0.0796,0.47898 -0.23655,0.89549 -0.54688,1.20508 -0.31033,0.3096 -0.72851,0.46655 -1.20703,0.54688 -0.47852,0.0803 -1.04147,0.0957 -1.75195,0.0957 h -5.8086 c -0.71048,0 -1.27236,-0.0153 -1.75,-0.0957 -0.47763,-0.0804 -0.89584,-0.23713 -1.20508,-0.54688 -0.30921,-0.30975 -0.46469,-0.72681 -0.54492,-1.20508 -0.0802,-0.47826 -0.0957,-1.04201 -0.0957,-1.7539 v -3.89844 -3.89844 c 0,-0.71189 0.0155,-1.27564 0.0957,-1.7539 0.0802,-0.47827 0.2357,-0.89533 0.54492,-1.20508 0.30924,-0.30975 0.72745,-0.4665 1.20508,-0.54688 0.47764,-0.0804 1.03952,-0.0957 1.75,-0.0957 z"
-         id="path918"
-         inkscape:connector-curvature="0" />
+         d="m 328.23434,237.47369 4.96733,-0.46568 c 0.66455,-0.0671 0.95484,0.2894 0.95996,1.00387 l -0.0421,11.74779 c -0.012,0.7948 -0.36762,1.21116 -1.06856,1.24033 l -4.78413,-0.55864 h -5.10933 c -0.65249,0 -1.31554,-0.53127 -1.31915,-1.35916 v -10.29538 c 0.0249,-0.95243 0.42208,-1.31132 1.37451,-1.32877 z"
+         fill="url(#b)"
+         id="path433"
+         style="display:inline;fill:url(#linearGradient439);stroke-width:0.300832;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 336.13453,188.5 c 1.11158,0 1.98683,0.0256 2.70703,0.14648 0.72019,0.1209 1.3105,0.34863 1.74218,0.7793 0.43169,0.43067 0.65954,1.01974 0.7793,1.74024 0.11977,0.72049 0.14217,1.59669 0.13672,2.71093 v 6.12305 6.125 c 0.005,1.1131 -0.017,1.989 -0.13672,2.70898 -0.11976,0.72051 -0.3476,1.30957 -0.7793,1.74024 -0.43169,0.43067 -1.02199,0.6584 -1.74218,0.7793 -0.7202,0.12089 -1.59545,0.14648 -2.70703,0.14648 h -8.26954 c -1.11158,0 -1.98637,-0.0255 -2.70507,-0.14648 -0.7187,-0.12095 -1.30623,-0.34848 -1.73633,-0.7793 -0.4301,-0.43083 -0.6566,-1.01849 -0.77735,-1.73828 -0.12074,-0.71979 -0.14648,-1.59713 -0.14648,-2.71094 v -6.125 -6.125 c 0,-1.11381 0.0257,-1.99115 0.14648,-2.71094 0.12075,-0.71979 0.34725,-1.30745 0.77735,-1.73828 0.4301,-0.43082 1.01763,-0.65835 1.73633,-0.7793 0.7187,-0.12094 1.59349,-0.14648 2.70507,-0.14648 z"
-         id="path914"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1309);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0962,238 c -0.6888,0 -1.1839,0.0205 -1.5039,0.0742 -0.30449,0.0511 -0.38369,0.11806 -0.39649,0.13086 -0.0131,0.0131 -0.0746,0.0855 -0.125,0.38867 -0.0529,0.31839 -0.0733,0.81274 -0.0703,1.50195 v 0.004 3.90039 3.90234 0.002 c -0.003,0.68916 0.0176,1.18495 0.0703,1.50195 0.0504,0.30317 0.1119,0.37557 0.125,0.38867 0.0128,0.0128 0.0918,0.0798 0.39649,0.13086 0.32002,0.0537 0.8151,0.0742 1.5039,0.0742 h 5.8086 c 0.68894,0 1.18348,-0.0206 1.50195,-0.0742 0.30433,-0.0512 0.38043,-0.1186 0.39063,-0.1289 0.0112,-0.0112 0.0774,-0.0858 0.1289,-0.39258 0.0536,-0.31974 0.0742,-0.81575 0.0742,-1.50586 v -3.89855 -3 l -3,-3 z"
-         id="path1291" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1311);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86573,190 c -1.08855,0 -1.90034,0.0312 -2.45898,0.125 -0.54887,0.0921 -0.79683,0.22878 -0.93164,0.36328 -0.13436,0.13404 -0.26642,0.37645 -0.35742,0.92383 -0.0925,0.55627 -0.12219,1.36674 -0.11719,2.45703 v 0.004 6.12695 6.12891 0.002 c -0.005,1.0898 0.0249,1.9019 0.11719,2.45703 0.091,0.5474 0.22306,0.78979 0.35742,0.92383 0.13484,0.13452 0.38277,0.27118 0.93164,0.36328 0.55862,0.0938 1.37043,0.125 2.45898,0.125 h 8.26954 c 1.08864,0 1.90078,-0.0314 2.45703,-0.125 0.54703,-0.0921 0.78777,-0.227 0.92187,-0.36133 0.13429,-0.13451 0.26913,-0.37646 0.36133,-0.92578 0.0936,-0.55811 0.125,-1.37233 0.125,-2.46303 v -6.125 -3 l -7.0005,-7 z"
-         id="path1293"
-         sodipodi:nodetypes="scccccccccccsscccscccs" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 323.0005,200 v 6.125 c -0.0217,4.42101 0.45314,4.875 4.86523,4.875 h 8.26954 c 4.41209,0 4.86523,-0.45393 4.86523,-4.875 v -6.125 z"
-         id="path1007"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 322.0005,244 v 3.89844 c -0.0138,2.81337 0.28801,3.10156 3.0957,3.10156 h 5.8086 c 2.8077,0 3.0957,-0.28815 3.0957,-3.10156 v -3.89844 z"
-         id="path1016"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 325.50195,84 v 12.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 v -12.925781 z"
-         id="path964-0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18820-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -12.133256,0 -20.524924,0.428807 -26.312505,2.427734 -2.103582,0.726592 -3.86351,1.661084 -5.333984,2.857422 -6.99e-4,5.68e-4 -0.0013,0.0014 -0.002,0.002 -1.102245,0.897465 -2.04362,1.942559 -2.84375,3.158203 -0.25536,0.38797 -0.493017,0.797219 -0.720704,1.220704 -0.05742,0.106782 -0.110296,0.220977 -0.166015,0.330078 -0.160525,0.314347 -0.31609,0.634772 -0.462891,0.96875 -0.07313,0.166359 -0.141108,0.340381 -0.210937,0.511718 -0.121003,0.2969 -0.240173,0.598017 -0.351563,0.910157 -0.07072,0.198194 -0.138107,0.401007 -0.205078,0.605469 -0.09969,0.304302 -0.195472,0.615147 -0.287109,0.933593 -0.06012,0.208926 -0.119021,0.41964 -0.175782,0.634766 -0.0932,0.353219 -0.18116,0.717644 -0.265625,1.087891 -0.04767,0.208948 -0.09564,0.414437 -0.140625,0.628906 -0.0813,0.387531 -0.155661,0.791385 -0.228515,1.197265 -0.03799,0.21171 -0.08141,0.416025 -0.117188,0.632813 -0.10327,0.625522 -0.197396,1.268747 -0.283203,1.9375 -8.5e-5,6.6e-4 8.5e-5,0.0013 0,0.002 -0.08424,0.656719 -0.159764,1.339307 -0.228515,2.039063 -0.02783,0.283412 -0.05073,0.582421 -0.07617,0.873046 -0.03812,0.435294 -0.0744,0.872494 -0.107422,1.324219 -0.08166,1.116973 -0.143662,2.302819 -0.197266,3.523438 -0.05039,1.146541 -0.08575,2.367502 -0.115234,3.609375 -0.01378,0.580741 -0.03511,1.124373 -0.04492,1.726562 -0.03028,1.853743 -0.04492,3.787114 -0.04492,5.851563 v 73.005855 73.00586 c 0,2.06445 0.01464,3.99782 0.04492,5.85156 0.0098,0.60219 0.03114,1.14582 0.04492,1.72656 0.02949,1.24188 0.06484,2.46284 0.115234,3.60938 0.0536,1.22062 0.115607,2.40646 0.197266,3.52344 0.03302,0.45172 0.0693,0.88892 0.107422,1.32422 0.02544,0.29062 0.04834,0.58963 0.07617,0.87304 0.06875,0.69976 0.144274,1.38235 0.228515,2.03906 8e-5,6.3e-4 -8e-5,10e-4 0,0.002 0.08581,0.66875 0.179933,1.31198 0.283203,1.9375 0.03578,0.21679 0.0792,0.4211 0.117188,0.63281 0.07285,0.40588 0.147218,0.80973 0.228515,1.19727 0.04498,0.21447 0.09296,0.41995 0.140625,0.6289 0.08446,0.37025 0.172428,0.73467 0.265625,1.08789 0.05676,0.21513 0.115665,0.42584 0.175782,0.63477 0.09164,0.31845 0.187417,0.62929 0.287109,0.93359 0.06697,0.20446 0.134353,0.40728 0.205078,0.60547 0.11139,0.31214 0.23056,0.61326 0.351563,0.91016 0.06983,0.17134 0.137808,0.34536 0.210937,0.51172 0.146801,0.33397 0.302366,0.6544 0.462891,0.96875 0.05572,0.1091 0.108595,0.22329 0.166015,0.33007 0.227687,0.42349 0.465344,0.83274 0.720704,1.22071 0.533766,0.81095 1.130124,1.545 1.794921,2.21093 0.332399,0.33297 0.681104,0.64798 1.048829,0.94727 7.16e-4,5.8e-4 0.0012,0.001 0.002,0.002 1.470474,1.19634 3.230402,2.13083 5.333984,2.85743 5.787581,1.99892 14.179249,2.42773 26.312505,2.42773 h 98.15624 c 2.05728,0 3.98527,-0.0147 5.83399,-0.0449 0.0115,-1.9e-4 0.0217,2e-4 0.0332,0 0.64544,-0.0111 1.23908,-0.0355 1.86133,-0.0508 0.45706,-0.0113 0.88533,-0.0281 1.33594,-0.041 0.67375,-0.0212 1.37929,-0.0364 2.02344,-0.0644 0.007,-3e-4 0.0127,-0.002 0.0195,-0.002 1.25269,-0.0546 2.47469,-0.11709 3.61914,-0.20118 0.01,-7.3e-4 0.0193,-10e-4 0.0293,-0.002 0.47389,-0.035 0.93478,-0.0745 1.39063,-0.11523 0.011,-9.8e-4 0.0222,-9.9e-4 0.0332,-0.002 0.21035,-0.0186 0.42719,-0.0366 0.63281,-0.0566 0.72759,-0.0709 1.43573,-0.14684 2.11719,-0.23437 0.66835,-0.0858 1.31017,-0.18189 1.93555,-0.28516 0.002,-3.4e-4 0.004,-0.002 0.006,-0.002 0.21969,-0.0365 0.42791,-0.0786 0.64258,-0.11719 0.39648,-0.0713 0.79087,-0.14326 1.16992,-0.22266 0.23853,-0.0499 0.4679,-0.10473 0.69922,-0.1582 0.01,-0.002 0.0195,-0.004 0.0293,-0.006 0.31951,-0.0737 0.63656,-0.15017 0.94336,-0.23047 0.25225,-0.0661 0.49847,-0.13446 0.74219,-0.20508 0.007,-0.002 0.0129,-0.004 0.0195,-0.006 0.28349,-0.0823 0.56172,-0.16909 0.83399,-0.25781 0.22709,-0.074 0.45245,-0.1499 0.67187,-0.22851 0.14966,-0.0536 0.29192,-0.11216 0.4375,-0.16797 0.13234,-0.0505 0.267,-0.098 0.39649,-0.15039 0.0111,-0.005 0.0221,-0.009 0.0332,-0.0137 0.18519,-0.0748 0.37186,-0.14964 0.55078,-0.22852 0.16735,-0.0738 0.32551,-0.15417 0.48633,-0.23242 0.10425,-0.0496 0.21026,-0.0975 0.3125,-0.14844 0.007,-0.004 0.0142,-0.008 0.0215,-0.0117 0.16707,-0.0828 0.33885,-0.16289 0.5,-0.25 5e-4,-2.7e-4 0.001,2.7e-4 0.002,0 0.40967,-0.22161 0.80523,-0.45357 1.18164,-0.70117 0.78027,-0.51326 1.48668,-1.08669 2.13281,-1.7207 0.001,-10e-4 0.003,-0.003 0.004,-0.004 0.0711,-0.07 0.13943,-0.14323 0.20898,-0.21484 0.002,-0.002 0.004,-0.004 0.006,-0.006 0.22962,-0.23599 0.45095,-0.48113 0.66406,-0.73438 0.077,-0.0915 0.15554,-0.18158 0.23047,-0.27539 0.54111,-0.67772 1.02765,-1.41677 1.46484,-2.2207 0.0553,-0.10155 0.10843,-0.20689 0.16211,-0.31055 0.15861,-0.30642 0.3098,-0.62208 0.45508,-0.94726 0.0608,-0.13598 0.12307,-0.27089 0.18164,-0.41016 5.5e-4,-10e-4 0.001,-0.003 0.002,-0.004 0.1819,-0.4336 0.35679,-0.8789 0.51757,-1.3457 0.16046,-0.46586 0.30672,-0.95495 0.44727,-1.45508 5.5e-4,-0.002 0.001,-0.004 0.002,-0.006 0.0402,-0.14328 0.0786,-0.28942 0.11719,-0.43554 0.036,-0.13607 0.0678,-0.27901 0.10156,-0.41993 0.0274,-0.10971 0.0554,-0.22073 0.082,-0.33203 6.1e-4,-0.003 10e-4,-0.005 0.002,-0.008 0.14313,-0.59937 0.27435,-1.22269 0.39453,-1.86914 0.0258,-0.13905 0.0523,-0.27642 0.0781,-0.41602 0.006,-0.0333 0.0137,-0.0642 0.0195,-0.0976 1.1e-4,-6.1e-4 -1e-4,-10e-4 0,-0.002 0.14057,-0.81053 0.26755,-1.65373 0.37696,-2.53906 0.006,-0.0479 0.0102,-0.099 0.0156,-0.14844 0.0159,-0.1309 0.0297,-0.26977 0.0449,-0.40234 0.002,-0.0201 0.004,-0.0423 0.006,-0.0625 0.079,-0.69309 0.15019,-1.40716 0.21289,-2.14648 5.5e-4,-0.006 0.001,-0.0131 0.002,-0.0195 0.0255,-0.30185 0.0493,-0.60826 0.0723,-0.91797 0.057,-0.7684 0.10605,-1.56297 0.14844,-2.38086 0.008,-0.15603 0.0182,-0.31062 0.0273,-0.46485 0.005,-0.0998 0.011,-0.19246 0.0156,-0.29297 4.1e-4,-0.009 -3.8e-4,-0.0185 0,-0.0273 0.006,-0.12849 0.009,-0.2663 0.0137,-0.39648 5e-4,-0.0117 0.001,-0.0254 0.002,-0.0371 0.0622,-1.46308 0.10249,-3.01983 0.12891,-4.64063 1.8e-4,-0.0109 -1.8e-4,-0.0223 0,-0.0332 0.007,-0.40814 0.0129,-0.82391 0.0176,-1.24219 0.0196,-1.77364 0.0291,-3.60559 0.0195,-5.57031 v -102.76563 c -0.008,-1.82491 -0.30087,-3.5971 -0.81445,-5.3125 -0.34239,-1.14359 -0.78284,-2.26106 -1.30274,-3.35351 -2.85943,-6.00849 -8.11896,-11.22913 -12.64453,-15.4961 l -0.0488,-0.0508 -40.52343,-42.408195 c -10.67695,-10.56113 -18.05782,-15.619141 -32.66602,-15.619141 z m 99.73242,0.08984 c -4.47461,1.4924 -5.99062,8.576599 -2.54102,11.912109 l 28.4961,30.386719 c 3.73355,3.705631 11.16128,0.552964 11.38671,-4.820313 0.003,-1.914857 -0.01,-3.726528 -0.0391,-5.453125 -0.003,-0.166807 -0.009,-0.319279 -0.0117,-0.484375 -0.0297,-1.557123 -0.0723,-3.047825 -0.13672,-4.457031 -0.0471,-1.032097 -0.1048,-2.024485 -0.17382,-2.980469 -1.15298,-15.945663 -5.54827,-21.536882 -19.66211,-23.361328 -1.29676,-0.167627 -2.6748,-0.302733 -4.14063,-0.412109 -0.70955,-0.05295 -1.44245,-0.09955 -2.19336,-0.140625 -0.009,-4.69e-4 -0.0187,-0.0015 -0.0273,-0.002 -1.56796,-0.085 -3.22479,-0.145853 -4.98047,-0.1875 z m -83.08789,11.855468 c 11.374,0.004 22.6305,0.04069 33.89843,0.246094 7.23783,-0.38505 13.8662,3.453873 18.85547,8.408203 16.10538,15.96283 31.4077,32.714027 47.27735,48.910165 3.41618,3.87653 8.26302,7.7632 8.17382,13.40039 0.36199,29.857 0.15427,59.71908 0.10547,89.57812 -0.26479,10.25015 0.39558,20.69609 -0.9082,30.96484 -0.54694,2.35759 -0.53276,6.03581 -3.5625,6.6504 -7.58888,1.84983 -15.51088,1.47 -23.26758,1.69726 -35.546,0.1779 -71.4284,0.29873 -106.976561,-0.13672 -4.70492,-0.41462 -9.87979,0.006 -14.11914,-2.38476 -2.82731,-3.81876 -2.108913,-9.00357 -2.445313,-13.48438 -0.58273,-48.6454 -0.702174,-97.30598 -0.583984,-145.972658 0.28307,-10.716668 -0.493631,-21.76848 1.568359,-32.4375 0.30831,-3.27336 3.855494,-4.007957 6.496094,-4.410157 11.78749,-1.12799 23.780885,-0.867606 35.488285,-1.029297 z"
-         id="rect4158-92-3" />
+         d="m 334.11951,249.75967 c -0.012,0.7948 -0.36762,1.21116 -1.06855,1.24033 l -4.83828,-0.56496 V 237.4758 l 4.98899,-0.46779 c 0.66455,-0.0671 0.95484,0.2894 0.95996,1.00387 z"
+         fill-opacity="0.15"
+         id="path435"
+         style="display:inline;stroke-width:0.300832;enable-background:new" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,156 v 73.00683 c -0.17299,35.36812 3.62515,38.99317 38.921885,38.99317 h 98.15624 c 35.29672,0 38.00361,-3.63655 38.92188,-38.99317 v -73.00683 z"
-         id="path4255"
-         sodipodi:nodetypes="ccssscc" />
+         d="m 177.59716,203.35818 h 35.25756 c 0.5439,0 0.9771,0.73643 0.9771,1.64615 v 8.48586 c -5e-5,0.90972 -0.4332,1.64616 -0.97715,1.64616 h -35.25751 c -0.53909,0 -0.97229,-0.73644 -0.97229,-1.64616 v -8.48587 c 0,-0.90971 0.4332,-1.64615 0.97229,-1.64614 z m -7.9708,11.77817 h -35.25272 c -0.54391,0 -0.9771,-0.73644 -0.9771,-1.64616 v -8.48587 c 0,-0.90971 0.43319,-1.64615 0.9771,-1.64615 h 35.25267 c 0.54391,0 0.97711,0.73644 0.97711,1.64615 v 8.48587 c 0,0.90972 -0.4332,1.64616 -0.97706,1.64616 z m -43.22357,0 H 91.14047 c -0.53909,0 -0.97229,-0.73644 -0.97229,-1.64616 v -8.48587 c 0,-0.90971 0.4332,-1.64615 0.97229,-1.64615 h 35.26232 c 0.53428,0 0.96748,0.73644 0.96748,1.64615 v 8.48587 c 0,0.90972 -0.4332,1.64616 -0.96748,1.64616 z m 51.19437,-37.68824 h 35.25751 c 0.5439,0 0.9771,0.73162 0.9771,1.64615 v 8.48106 c 0,0.91453 -0.4332,1.65097 -0.9771,1.65097 h -35.25751 c -0.53909,0 -0.97229,-0.73644 -0.97229,-1.65097 v -8.48106 c 0,-0.91453 0.4332,-1.64615 0.97229,-1.64615 z m -7.9708,11.77818 h -35.25272 c -0.54391,0 -0.9771,-0.73644 -0.9771,-1.65097 v -8.48106 c 0,-0.91453 0.43319,-1.64615 0.9771,-1.64615 h 35.25267 c 0.54391,0 0.97711,0.73162 0.97711,1.64615 v 8.48106 c 0,0.91453 -0.4332,1.65097 -0.97706,1.65097 z m -43.22357,0 H 91.14047 c -0.53909,0 -0.97229,-0.73644 -0.97229,-1.65097 v -8.48106 c 0,-0.91453 0.4332,-1.64615 0.97229,-1.64615 h 35.26232 c 0.53428,0 0.96748,0.73162 0.96748,1.64615 v 8.48106 c 0,0.91453 -0.4332,1.65097 -0.96748,1.65097 z m 51.19437,-37.69305 h 35.25751 c 0.5439,0 0.9771,0.73643 0.9771,1.65096 v 8.48106 c 0,0.91454 -0.4332,1.64615 -0.9771,1.64615 h -35.25751 c -0.53909,0 -0.97229,-0.73161 -0.97229,-1.64615 v -8.48106 c 0,-0.91453 0.4332,-1.65096 0.97229,-1.65096 z m -7.9708,11.77817 h -35.25272 c -0.54391,0 -0.9771,-0.73162 -0.9771,-1.64615 v -8.48106 c 0,-0.91453 0.43319,-1.65096 0.9771,-1.65096 h 35.25267 c 0.54391,0 0.97711,0.73643 0.97711,1.65096 v 8.48106 c 0,0.91454 -0.4332,1.64615 -0.97706,1.64615 z m -43.22357,0 H 91.14047 c -0.53909,0 -0.97229,-0.73162 -0.97229,-1.64615 v -8.48106 c 0,-0.91453 0.4332,-1.65096 0.97229,-1.65096 h 35.26232 c 0.53428,0 0.96748,0.73643 0.96748,1.65096 v 8.48106 c 0,0.91454 -0.4332,1.64615 -0.96748,1.64615 z m 18.78155,-66.447765 c 1.00598,0 1.81943,0.71718 1.81943,1.61727 v 37.587155 c 0,0.89527 -0.81345,1.61727 -1.81943,1.61727 H 92.17533 c -1.00598,0 -1.81462,-0.722 -1.81462,-1.61727 V 98.480915 c 0,-0.90009 0.80864,-1.61727 1.81462,-1.61727 z m 24.44202,40.537705 h -11.47977 c -0.53909,0 -0.97711,-0.73643 -0.97711,-1.64615 v -8.48587 c 0,-0.90972 0.43802,-1.64615 0.97711,-1.64615 h 11.47972 c 0.54391,0 0.97711,0.73643 0.97711,1.64615 v 8.48587 c 0,0.90972 -0.4332,1.64615 -0.97706,1.64615 z m 7.9708,-11.77816 h 35.25751 c 0.5439,0 0.9771,0.73643 0.9771,1.64615 v 8.48587 c 0,0.90971 -0.4332,1.64615 -0.9771,1.64615 h -35.25751 c -0.53909,0 -0.97229,-0.73644 -0.97229,-1.64615 v -8.48587 c 0,-0.90972 0.4332,-1.64615 0.97229,-1.64615 z M 116.136,101.53256 c -0.77976,0 -1.41512,0.56797 -1.41512,1.25627 l -0.0289,29.34676 c -0.005,0.70274 0.62573,1.26109 1.41512,1.26109 h 5.76153 c 0.78457,0 1.41512,-0.56797 1.41993,-1.25628 l 0.0289,-29.34676 c 0,-0.69311 -0.63054,-1.26108 -1.41511,-1.26108 z m 12.98631,16.53854 c -0.78457,0 -1.41511,0.56797 -1.41511,1.26109 l -0.0241,12.79859 c -0.005,0.69311 0.62573,1.25627 1.40549,1.26108 h 5.77116 c 0.77976,0 1.4103,-0.56315 1.41512,-1.26108 l 0.0289,-12.79859 c 0,-0.69312 -0.63055,-1.26109 -1.41512,-1.26109 z m -25.74159,-8.33184 h 5.76635 c 0.78457,0 1.41511,0.55834 1.41511,1.26108 l -0.0289,21.07268 c 0,0.69311 -0.63536,1.26108 -1.41511,1.26108 l -5.76635,-0.005 c -0.78457,0 -1.41511,-0.55834 -1.41511,-1.26109 l 0.0289,-21.07267 c 0,-0.69794 0.63535,-1.25627 1.41511,-1.25627 z m 66.24564,-0.60648 h -11.47977 c -0.53909,0 -0.97711,-0.73162 -0.97711,-1.64615 v -8.481065 c 0,-0.91453 0.43802,-1.65097 0.97711,-1.65097 h 11.47977 c 0.54391,0 0.9771,0.73644 0.9771,1.65097 v 8.481065 c 0,0.91453 -0.43319,1.64615 -0.9771,1.64615 z m 7.9708,-11.778185 h 35.25756 c 0.5439,0 0.9771,0.73644 0.9771,1.65097 v 8.481065 c 0,0.91453 -0.4332,1.64615 -0.9771,1.64615 h -35.25751 c -0.53914,0 -0.97234,-0.73162 -0.97234,-1.64615 v -8.481065 c 0,-0.91453 0.4332,-1.65097 0.97229,-1.65097 z"
+         fill="#f3f3f3"
+         fill-rule="nonzero"
+         id="path298"
+         style="display:inline;stroke-width:4.81331;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,227.00586 v 2 c -0.17299,35.36812 3.62515,38.99414 38.921885,38.99414 h 98.15624 c 35.29672,0 38.00361,-3.63752 38.92188,-38.99414 v -2 c -0.91827,35.35662 -3.62516,38.99414 -38.92188,38.99414 h -98.15624 c -35.296735,0 -39.094875,-3.62602 -38.921885,-38.99414 z"
-         id="path945"
-         inkscape:connector-curvature="0" />
+         d="m 349.25656,93.725341 h 7.24039 c 0.1117,0 0.20066,0.151232 0.20066,0.338049 v 1.742632 c -10e-6,0.186818 -0.089,0.338051 -0.20067,0.338051 h -7.24038 c -0.11071,0 -0.19967,-0.151233 -0.19967,-0.338051 v -1.742634 c 0,-0.186815 0.089,-0.338049 0.19967,-0.338047 z m -1.63686,2.418732 h -7.2394 c -0.11169,0 -0.20065,-0.151233 -0.20065,-0.338051 v -1.742634 c 0,-0.186815 0.089,-0.338049 0.20065,-0.338049 h 7.23939 c 0.1117,0 0.20066,0.151234 0.20066,0.338049 v 1.742634 c 0,0.186818 -0.089,0.338051 -0.20065,0.338051 z m -8.87627,0 h -7.24137 c -0.1107,0 -0.19967,-0.151233 -0.19967,-0.338051 v -1.742634 c 0,-0.186815 0.089,-0.338049 0.19967,-0.338049 h 7.24137 c 0.10972,0 0.19868,0.151234 0.19868,0.338049 v 1.742634 c 0,0.186818 -0.089,0.338051 -0.19868,0.338051 z m 10.51313,-7.73955 h 7.24038 c 0.1117,0 0.20066,0.150244 0.20066,0.338049 v 1.741646 c 0,0.187806 -0.089,0.339039 -0.20066,0.339039 h -7.24038 c -0.11071,0 -0.19967,-0.151233 -0.19967,-0.339039 v -1.741646 c 0,-0.187805 0.089,-0.338049 0.19967,-0.338049 z m -1.63686,2.418734 h -7.2394 c -0.11169,0 -0.20065,-0.151233 -0.20065,-0.339039 v -1.741646 c 0,-0.187805 0.089,-0.338049 0.20065,-0.338049 h 7.23939 c 0.1117,0 0.20066,0.150244 0.20066,0.338049 v 1.741646 c 0,0.187806 -0.089,0.339039 -0.20065,0.339039 z m -8.87627,0 h -7.24137 c -0.1107,0 -0.19967,-0.151233 -0.19967,-0.339039 v -1.741646 c 0,-0.187805 0.089,-0.338049 0.19967,-0.338049 h 7.24137 c 0.10972,0 0.19868,0.150244 0.19868,0.338049 v 1.741646 c 0,0.187806 -0.089,0.339039 -0.19868,0.339039 z m 10.51313,-7.740537 h 7.24038 c 0.1117,0 0.20066,0.151231 0.20066,0.339036 v 1.741646 c 0,0.187808 -0.089,0.338049 -0.20066,0.338049 h -7.24038 c -0.11071,0 -0.19967,-0.150241 -0.19967,-0.338049 v -1.741646 c 0,-0.187805 0.089,-0.339036 0.19967,-0.339036 z m -1.63686,2.418731 h -7.2394 c -0.11169,0 -0.20065,-0.150243 -0.20065,-0.338049 v -1.741646 c 0,-0.187805 0.089,-0.339036 0.20065,-0.339036 h 7.23939 c 0.1117,0 0.20066,0.151231 0.20066,0.339036 v 1.741646 c 0,0.187808 -0.089,0.338049 -0.20065,0.338049 z m -8.87627,0 h -7.24137 c -0.1107,0 -0.19967,-0.150243 -0.19967,-0.338049 v -1.741646 c 0,-0.187805 0.089,-0.339036 0.19967,-0.339036 h 7.24137 c 0.10972,0 0.19868,0.151231 0.19868,0.339036 v 1.741646 c 0,0.187808 -0.089,0.338049 -0.19868,0.338049 z m 3.85693,-13.645524 c 0.20658,0 0.37363,0.147279 0.37363,0.332118 v 7.718791 c 0,0.18385 -0.16705,0.332118 -0.37363,0.332118 h -10.88578 c -0.20659,0 -0.37265,-0.148268 -0.37265,-0.332118 v -7.718791 c 0,-0.184839 0.16606,-0.332118 0.37265,-0.332118 z m 5.01934,8.324708 h -2.35745 c -0.11071,0 -0.20066,-0.151231 -0.20066,-0.338049 v -1.742634 c 0,-0.186817 0.0899,-0.338048 0.20066,-0.338048 h 2.35744 c 0.1117,0 0.20066,0.151231 0.20066,0.338048 v 1.742634 c 0,0.186818 -0.089,0.338049 -0.20065,0.338049 z m 1.63686,-2.418729 h 7.24038 c 0.1117,0 0.20066,0.151231 0.20066,0.338048 v 1.742634 c 0,0.186816 -0.089,0.338049 -0.20066,0.338049 h -7.24038 c -0.11071,0 -0.19967,-0.151233 -0.19967,-0.338049 v -1.742634 c 0,-0.186817 0.089,-0.338048 0.19967,-0.338048 z m -12.62149,-4.947183 c -0.16013,0 -0.2906,0.116636 -0.2906,0.257984 l -0.006,6.026566 c -10e-4,0.144313 0.12849,0.258974 0.2906,0.258974 h 1.18317 c 0.16112,0 0.29061,-0.116636 0.29159,-0.257986 l 0.006,-6.026567 c 0,-0.142335 -0.12948,-0.258971 -0.2906,-0.258971 z m 2.66683,3.396307 c -0.16111,0 -0.2906,0.116637 -0.2906,0.258974 l -0.005,2.628282 c -0.001,0.142335 0.1285,0.257984 0.28863,0.258972 h 1.18515 c 0.16013,0 0.28961,-0.115647 0.2906,-0.258972 l 0.006,-2.628282 c 0,-0.142337 -0.12949,-0.258974 -0.2906,-0.258974 z m -5.28622,-1.711003 h 1.18416 c 0.16112,0 0.29061,0.114659 0.29061,0.258972 l -0.006,4.327425 c 0,0.142335 -0.13048,0.258972 -0.29061,0.258972 l -1.18416,-10e-4 c -0.16111,0 -0.2906,-0.114659 -0.2906,-0.258974 l 0.006,-4.327423 c 0,-0.143327 0.13047,-0.257984 0.2906,-0.257984 z m 13.60402,-0.124545 h -2.35745 c -0.11071,0 -0.20066,-0.150243 -0.20066,-0.338049 v -1.741647 c 0,-0.187805 0.0899,-0.339038 0.20066,-0.339038 h 2.35745 c 0.1117,0 0.20065,0.151233 0.20065,0.339038 v 1.741647 c 0,0.187806 -0.089,0.338049 -0.20065,0.338049 z m 1.63686,-2.418734 h 7.24039 c 0.1117,0 0.20066,0.151233 0.20066,0.339038 v 1.741647 c 0,0.187806 -0.089,0.338049 -0.20066,0.338049 h -7.24038 c -0.11072,0 -0.19968,-0.150243 -0.19968,-0.338049 v -1.741647 c 0,-0.187805 0.089,-0.339038 0.19967,-0.339038 z"
+         fill="#f3f3f3"
+         fill-rule="nonzero"
+         id="path401"
+         style="display:inline;stroke-width:0.988448;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.08;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 180.0004,268 60,-60 v 22.48388 c -0.0523,33.99581 -3.80268,37.51612 -38.1741,37.51612 z"
-         id="path4254"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccsc" />
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g64"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 349,191 h -8 c -0.552,0 -1,0.448 -1,1 v 1 c 0,0.552 0.448,1 1,1 h 8 c 0.552,0 1,-0.448 1,-1 v -1 c 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:#92e285;fill-rule:nonzero"
-           id="path62" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g68"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 356,138 h -12 c -1.105,0 -2,0.896 -2,2 v 9 c 0,1.105 0.895,2 2,2 h 12 c 1.105,0 2,-0.895 2,-2 v -9 c 0,-1.104 -0.895,-2 -2,-2 z"
-           style="fill:#ccf4c6;fill-rule:nonzero"
-           id="path66" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g72"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 356,138 h -12 c -1.105,0 -2,0.896 -2,2 0,1.105 0.895,2 2,2 h 12 c 1.105,0 2,-0.895 2,-2 0,-1.104 -0.895,-2 -2,-2 z"
-           style="fill:#92e285;fill-rule:nonzero"
-           id="path70" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g76"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 344,138 c -1.105,0 -2,0.896 -2,2 v 9 c 0,1.105 0.895,2 2,2 h 12 c 1.105,0 2,-0.895 2,-2 v -9 c 0,-1.104 -0.895,-2 -2,-2 z m -1,2 c 0,-0.552 0.448,-1 1,-1 h 3 v 2 h -4 z m 5,-1 h 4 v 2 h -4 z m 5,0 h 3 c 0.552,0 1,0.448 1,1 v 1 h -4 z m -10,3 h 4 v 2 h -4 z m 5,0 h 4 v 2 h -4 z m 5,0 h 4 v 2 h -4 z m -10,3 h 4 v 2 h -4 z m 5,0 h 4 v 2 h -4 z m 5,0 h 4 v 2 h -4 z m -10,3 h 4 v 2 h -3 c -0.552,0 -1,-0.447 -1,-1 z m 5,0 h 4 v 2 h -4 z m 5,0 h 4 v 1 c 0,0.553 -0.448,1 -1,1 h -3 z"
-           style="fill:#148203;fill-rule:nonzero"
-           id="path74" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g80"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 358,144 h -6 c -0.552,0 -1,0.448 -1,1 v 6 c 0,0.552 0.448,1 1,1 h 6 c 0.552,0 1,-0.448 1,-1 v -6 c 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:#148403;fill-rule:nonzero"
-           id="path78" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g84"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 357.5,145 h -5 c -0.276,0 -0.5,0.224 -0.5,0.5 v 5 c 0,0.276 0.224,0.5 0.5,0.5 h 5 c 0.276,0 0.5,-0.224 0.5,-0.5 v -5 c 0,-0.276 -0.224,-0.5 -0.5,-0.5 z"
-           style="fill:#cccccc;fill-rule:nonzero"
-           id="path82" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g88"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 357.5,145 h -5 c -0.276,0 -0.5,0.224 -0.5,0.5 v 5 c 0,0.276 0.224,0.5 0.5,0.5 h 5 c 0.276,0 0.5,-0.224 0.5,-0.5 v -5 c 0,-0.276 -0.224,-0.5 -0.5,-0.5 z"
-           style="fill:#ccf4c6;fill-rule:nonzero"
-           id="path86" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g92"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 355,148 h -1 c -0.552,0 -1,0.448 -1,1 v 2 h 2 z"
-           style="fill:#41b02f;fill-rule:nonzero"
-           id="path90" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g96"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 357,151 v -4 c 0,-0.552 -0.448,-1 -1,-1 -0.552,0 -1,0.448 -1,1 v 4 z"
-           style="fill:#148503;fill-rule:nonzero"
-           id="path94" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g100"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="354"
-           y="148"
-           width="1"
-           height="2"
-           style="fill:#92e285;fill-rule:nonzero"
-           id="rect98" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g104"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 357,150 v -3 c 0,-0.552 -0.448,-1 -1,-1 v 4 z"
-           style="fill:#41b02f;fill-rule:nonzero"
-           id="path102" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g108"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 367,72 h -18 c -1.105,0 -2,0.896 -2,2 v 17 c 0,1.105 0.895,2 2,2 h 18 c 1.105,0 2,-0.895 2,-2 v -17 c 0,-1.104 -0.895,-2 -2,-2 z"
-           style="fill:#ccf4c6;fill-rule:nonzero"
-           id="path106" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g112"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 367,72 h -18 c -1.105,0 -2,0.896 -2,2 v 1 c 0,1.105 0.895,2 2,2 h 18 c 1.105,0 2,-0.895 2,-2 v -1 c 0,-1.104 -0.895,-2 -2,-2 z"
-           style="fill:#92e285;fill-rule:nonzero"
-           id="path110" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g116"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 349,72 c -1.105,0 -2,0.895 -2,2 v 16.998 c 0,1.105 0.895,2 2,2 l 20,0.002 v -19.002 c 0,-1.104 -0.896,-2 -2,-2 z m -1,1.998 c 0,-0.552 0.448,-1 1,-1 h 5 v 3 h -6 z m 7,-1 h 6 v 3 h -6 z m 7,0 h 5 c 0.552,0 1,0.448 1,1 v 2 h -6 z m -14,4 h 6 v 3 h -6 z m 7,0 h 6 v 3 h -6 z m 7,0 h 6 v 3 h -6 z m -14,4 h 6 v 3 h -6 z m 7,0 h 6 v 3 h -6 z m 7,0 h 6 v 3 h -6 z m -14,4 h 6 v 3 h -6 z m 7,0 h 6 v 3 h -6 z m 7,0 h 6 v 3 h -6 z m -14,4 h 6 v 3 h -5 c -0.552,0 -1,-0.448 -1,-1 z m 7,0 h 6 v 3 h -6 z m 7,0 h 6 v 2 c 0,0.552 -0.448,1 -1,1 h -5 z"
-           style="fill:url(#_Linear9);fill-rule:nonzero"
-           id="path114" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g120"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 369,83 h -7 c -1.105,0 -2,0.895 -2,2 v 7 c 0,1.105 0.895,2 2,2 h 7 c 1.105,0 2,-0.895 2,-2 v -7 c 0,-1.105 -0.895,-2 -2,-2 z"
-           style="fill:#148103;fill-rule:nonzero"
-           id="path118" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g124"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 369,84 h -7 c -0.552,0 -1,0.448 -1,1 v 7 c 0,0.552 0.448,1 1,1 h 7 c 0.552,0 1,-0.448 1,-1 v -7 c 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:#cccccc;fill-rule:nonzero"
-           id="path122" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g128"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 369,84 h -7 c -0.552,0 -1,0.448 -1,1 v 7 c 0,0.553 0.448,1 1,1 h 7 c 0.552,0 1,-0.447 1,-1 v -7 c 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:#ccf4c6;fill-rule:nonzero"
-           id="path126" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g132"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 364,93 v -3.5 c 0,-0.828 -0.672,-1.5 -1.5,-1.5 -0.828,0 -1.5,0.672 -1.5,1.5 v 2.5 c 0,0.553 0.448,1 1,1 z"
-           style="fill:#41b02f;fill-rule:nonzero"
-           id="path130" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g136"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 367,93 v -6.5 c 0,-0.828 -0.672,-1.5 -1.5,-1.5 -0.828,0 -1.5,0.672 -1.5,1.5 v 6.5 z"
-           style="fill:#239310;fill-rule:nonzero"
-           id="path134" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g140"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 370,92 v -0.5 c 0,-0.828 -0.672,-1.5 -1.5,-1.5 -0.828,0 -1.5,0.672 -1.5,1.5 v 1.5 h 2 c 0.552,0 1,-0.447 1,-1 z"
-           style="fill:#41b02f;fill-rule:nonzero"
-           id="path138" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g144"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="362"
-           y="89"
-           width="1"
-           height="4"
-           style="fill:#92e285;fill-rule:nonzero"
-           id="rect142" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g148"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="365"
-           y="86"
-           width="1"
-           height="7"
-           style="fill:#41b02f;fill-rule:nonzero"
-           id="rect146" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g152"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="368"
-           y="91"
-           width="1"
-           height="2"
-           style="fill:#92e285;fill-rule:nonzero"
-           id="rect150" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g156"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 344,235 h -5 c -0.552,0 -1,0.448 -1,1 v 5 c 0,0.552 0.448,1 1,1 h 5 c 0.552,0 1,-0.448 1,-1 v -5 c 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:#ccf4c6;fill-rule:nonzero"
-           id="path154" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g160"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 339,235 c -0.552,0 -1,0.448 -1,1 v 5 c 0,0.552 0.448,1 1,1 h 6 c 0.552,0 1,-0.448 1,-1 v -5 c 0,-0.552 -0.448,-1 -1,-1 z m 0,1.5 c 0,-0.276 0.224,-0.5 0.5,-0.5 h 1.5 v 1 h -2 z m 3,-0.5 h 2.5 c 0.276,0 0.5,0.224 0.5,0.5 v 0.5 h -3 z m -3,2 h 2 v 1 h -2 z m 3,0 h 3 v 1 h -3 z m -3,2 h 2 v 1 h -1.5 c -0.276,0 -0.5,-0.224 -0.5,-0.5 z m 3,0 h 3 v 0.5 c 0,0.276 -0.224,0.5 -0.5,0.5 h -2.5 z"
-           style="fill:url(#_Linear10);fill-rule:nonzero"
-           id="path158" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g164"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 350,194 h -10 v 5 c 0,0.552 0.448,1 1,1 h 8 c 0.552,0 1,-0.448 1,-1 z"
-           style="fill:#ccf4c6;fill-rule:nonzero"
-           id="path162" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g168"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 341,191 c -0.552,0 -1,0.448 -1,1 v 7 c 0,0.552 0.448,1 1,1 h 8 c 0.552,0 1,-0.448 1,-1 v -7 c 0,-0.552 -0.448,-1 -1,-1 z m 0,1 h 2 v 1 h -2 z m 3,0 h 2 v 1 h -2 z m 3,0 h 2 v 1 h -2 z m -6,2 h 2 v 1 h -2 z m 3,0 h 2 v 1 h -2 z m 3,0 h 2 v 1 h -2 z m -6,2 h 2 v 1 h -2 z m 3,0 h 2 v 1 h -2 z m 3,0 h 2 v 1 h -2 z m -6,2 h 2 v 1 h -2 z m 3,0 h 2 v 1 h -2 z m 3,0 h 2 v 1 h -2 z"
-           style="fill:#148003;fill-rule:nonzero"
-           id="path166" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g172"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 351,195 h -5 c -0.552,0 -1,0.448 -1,1 v 5 c 0,0.552 0.448,1 1,1 h 5 c 0.552,0 1,-0.448 1,-1 v -5 c 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:#148003;fill-rule:nonzero"
-           id="path170" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g176"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="346"
-           y="196"
-           width="5"
-           height="5"
-           style="fill:#cccccc;fill-rule:nonzero"
-           id="rect174" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g180"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="346"
-           y="196"
-           width="5"
-           height="5"
-           style="fill:#ccf4c6;fill-rule:nonzero"
-           id="rect178" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g184"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 348,201 v -2.5 c 0,-0.276 -0.224,-0.5 -0.5,-0.5 -0.276,0 -0.5,0.224 -0.5,0.5 v 2.5 z"
-           style="fill:#41b02f;fill-rule:nonzero"
-           id="path182" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g188"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 349,201 v -3.5 c 0,-0.276 -0.224,-0.5 -0.5,-0.5 -0.276,0 -0.5,0.224 -0.5,0.5 v 3.5 z"
-           style="fill:#239310;fill-rule:nonzero"
-           id="path186" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g192"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 350,201 v -1.5 c 0,-0.276 -0.224,-0.5 -0.5,-0.5 -0.276,0 -0.5,0.224 -0.5,0.5 v 1.5 z"
-           style="fill:#41b02f;fill-rule:nonzero"
-           id="path190" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g268"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 200.005,118 h -68 c -11.598,0 -21,9.403 -21,21 v 63 c 0,11.598 9.402,21 21,21 h 68 c 11.598,0 21,-9.402 21,-21 v -63 c 0,-11.597 -9.402,-21 -21,-21 z"
-           style="fill:#ccf4c6;fill-rule:nonzero"
-           id="path266" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g272"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 196.005,118 h -60 c -13.807,0 -25,11.194 -25,25.001 h 110 c 0,-13.807 -11.193,-25.001 -25,-25.001 z"
-           style="fill:#92e285;fill-rule:nonzero"
-           id="path270" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g276"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 128.005,117.99 c -9.389,0 -17,7.611 -17,17 v 71 c 0,9.389 7.611,17 17,17 h 76 c 9.389,0 17,-7.611 17,-17 v -71 c 0,-9.389 -7.611,-17 -17,-17 z m -12,17 c 0,-6.628 5.373,-12 12,-12 h 18 v 15 h -30 z m 35,-12 h 30 v 15 h -30 z m 35,0 h 18 c 6.627,0 12,5.372 12,12 v 3 h -30 z m -70,20 h 30 v 15 h -30 z m 35,0 h 30 v 15 h -30 z m 35,0 h 30 v 15 h -30 z m -70,20 h 30 v 15 h -30 z m 35,0 h 30 v 15 h -30 z m 35,0 h 30 v 15 h -30 z m -70,20 h 30 v 15 h -30 z m 35,0 h 30 v 15 h -30 z m 35,0 h 30 v 15 h -30 z m -70,20 h 30 v 15 h -18 c -6.627,0 -12,-5.373 -12,-12 z m 35,0 h 30 v 15 h -30 z m 35,0 h 30 v 3 c 0,6.627 -5.373,12 -12,12 h -18 z"
-           style="fill:url(#_Linear17);fill-rule:nonzero"
-           id="path274" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g280"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 221.005,173 h -35 c -5.523,0 -10,4.477 -10,10 v 35 c 0,5.523 4.477,10 10,10 h 35 c 5.523,0 10,-4.477 10,-10 v -35 c 0,-5.523 -4.477,-10 -10,-10 z"
-           style="fill:#148103;fill-rule:nonzero"
-           id="path278" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g284"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 219.005,178 h -31 c -3.866,0 -7,3.134 -7,7 v 31 c 0,3.866 3.134,7 7,7 h 31 c 3.866,0 7,-3.134 7,-7 v -31 c 0,-3.866 -3.134,-7 -7,-7 z"
-           style="fill:#cccccc;fill-rule:nonzero"
-           id="path282" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g288"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 219.005,178 h -31 c -3.866,0 -7,3.134 -7,7 v 31 c 0,3.866 3.134,7 7,7 h 31 c 3.866,0 7,-3.134 7,-7 v -31 c 0,-3.866 -3.134,-7 -7,-7 z"
-           style="fill:#ccf4c6;fill-rule:nonzero"
-           id="path286" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g292"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 196,223 v -21.5 c 0,-4.142 -3.358,-7.5 -7.5,-7.5 -4.142,0 -7.5,3.358 -7.5,7.5 v 14.519 c 0,3.855 3.126,6.981 6.981,6.981 z"
-           style="fill:#41b02f;fill-rule:nonzero"
-           id="path290" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g296"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 211.005,223 v -32.5 c 0,-4.142 -3.358,-7.5 -7.5,-7.5 -4.142,0 -7.5,3.358 -7.5,7.5 v 32.5 z"
-           style="fill:#239310;fill-rule:nonzero"
-           id="path294" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g300"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 226,216.022 v -5.522 c 0,-4.142 -3.358,-7.5 -7.5,-7.5 -4.142,0 -7.5,3.358 -7.5,7.5 v 12.5 h 8.022 c 3.854,0 6.978,-3.124 6.978,-6.978 z"
-           style="fill:#41b02f;fill-rule:nonzero"
-           id="path298" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g304"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 191,217.5 v -17 c 0,-1.381 -1.119,-2.5 -2.5,-2.5 -1.381,0 -2.5,1.119 -2.5,2.5 v 17 c 0,1.381 1.119,2.5 2.5,2.5 1.381,0 2.5,-1.119 2.5,-2.5 z"
-           style="fill:#92e285;fill-rule:nonzero"
-           id="path302" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g308"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 206,217.5 v -28 c 0,-1.381 -1.119,-2.5 -2.5,-2.5 -1.381,0 -2.5,1.119 -2.5,2.5 v 28 c 0,1.381 1.119,2.5 2.5,2.5 1.381,0 2.5,-1.119 2.5,-2.5 z"
-           style="fill:#41b02f;fill-rule:nonzero"
-           id="path306" />
-      </g>
-      <g
-         transform="translate(-14.005,6.002)"
-         id="g312"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 221,217.5 v -8 c 0,-1.381 -1.119,-2.5 -2.5,-2.5 -1.381,0 -2.5,1.119 -2.5,2.5 v 8 c 0,1.381 1.119,2.5 2.5,2.5 1.381,0 2.5,-1.119 2.5,-2.5 z"
-           style="fill:#92e285;fill-rule:nonzero"
-           id="path310" />
-      </g>
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline">
+         d="m 339.42819,154.34262 h 4.72199 c 0.0729,0 0.13087,0.0986 0.13087,0.22046 v 1.1365 c -10e-6,0.12184 -0.058,0.22047 -0.13088,0.22047 h -4.72198 c -0.0722,0 -0.13022,-0.0986 -0.13022,-0.22047 v -1.1365 c 0,-0.12184 0.058,-0.22047 0.13022,-0.22046 z m -1.06752,1.57743 h -4.72135 c -0.0728,0 -0.13086,-0.0986 -0.13086,-0.22047 v -1.1365 c 0,-0.12184 0.058,-0.22047 0.13086,-0.22047 h 4.72134 c 0.0729,0 0.13087,0.0986 0.13087,0.22047 v 1.1365 c 0,0.12184 -0.058,0.22047 -0.13086,0.22047 z m -5.78887,0 h -4.72263 c -0.0722,0 -0.13022,-0.0986 -0.13022,-0.22047 v -1.1365 c 0,-0.12184 0.058,-0.22047 0.13022,-0.22047 h 4.72263 c 0.0716,0 0.12957,0.0986 0.12957,0.22047 v 1.1365 c 0,0.12184 -0.058,0.22047 -0.12957,0.22047 z m 6.85639,-5.04753 h 4.72198 c 0.0729,0 0.13087,0.098 0.13087,0.22046 v 1.13586 c 0,0.12248 -0.058,0.22111 -0.13087,0.22111 h -4.72198 c -0.0722,0 -0.13022,-0.0986 -0.13022,-0.22111 v -1.13586 c 0,-0.12248 0.058,-0.22046 0.13022,-0.22046 z m -1.06752,1.57743 h -4.72135 c -0.0728,0 -0.13086,-0.0986 -0.13086,-0.22111 v -1.13586 c 0,-0.12248 0.058,-0.22046 0.13086,-0.22046 h 4.72134 c 0.0729,0 0.13087,0.098 0.13087,0.22046 v 1.13586 c 0,0.12248 -0.058,0.22111 -0.13086,0.22111 z m -5.78887,0 h -4.72263 c -0.0722,0 -0.13022,-0.0986 -0.13022,-0.22111 v -1.13586 c 0,-0.12248 0.058,-0.22046 0.13022,-0.22046 h 4.72263 c 0.0716,0 0.12957,0.098 0.12957,0.22046 v 1.13586 c 0,0.12248 -0.058,0.22111 -0.12957,0.22111 z m 6.85639,-5.04817 h 4.72198 c 0.0729,0 0.13087,0.0986 0.13087,0.22111 v 1.13585 c 0,0.12249 -0.058,0.22047 -0.13087,0.22047 h -4.72198 c -0.0722,0 -0.13022,-0.098 -0.13022,-0.22047 v -1.13585 c 0,-0.12249 0.058,-0.22111 0.13022,-0.22111 z m -1.06752,1.57743 h -4.72135 c -0.0728,0 -0.13086,-0.098 -0.13086,-0.22047 v -1.13585 c 0,-0.12249 0.058,-0.22111 0.13086,-0.22111 h 4.72134 c 0.0729,0 0.13087,0.0986 0.13087,0.22111 v 1.13585 c 0,0.12249 -0.058,0.22047 -0.13086,0.22047 z m -5.78887,0 h -4.72263 c -0.0722,0 -0.13022,-0.098 -0.13022,-0.22047 v -1.13585 c 0,-0.12249 0.058,-0.22111 0.13022,-0.22111 h 4.72263 c 0.0716,0 0.12957,0.0986 0.12957,0.22111 v 1.13585 c 0,0.12249 -0.058,0.22047 -0.12957,0.22047 z m 2.51539,-8.89926 c 0.13472,0 0.24367,0.0961 0.24367,0.2166 v 5.034 c 0,0.1199 -0.10895,0.2166 -0.24367,0.2166 h -7.09942 c -0.13474,0 -0.24304,-0.0967 -0.24304,-0.2166 v -5.034 c 0,-0.12054 0.1083,-0.2166 0.24304,-0.2166 z m 3.27348,5.42916 h -1.53747 c -0.0722,0 -0.13086,-0.0986 -0.13086,-0.22047 v -1.1365 c 0,-0.12183 0.0586,-0.22046 0.13086,-0.22046 h 1.53746 c 0.0729,0 0.13087,0.0986 0.13087,0.22046 v 1.1365 c 0,0.12184 -0.058,0.22047 -0.13086,0.22047 z m 1.06752,-1.57743 h 4.72198 c 0.0729,0 0.13087,0.0986 0.13087,0.22047 v 1.1365 c 0,0.12183 -0.058,0.22046 -0.13087,0.22046 h -4.72198 c -0.0722,0 -0.13022,-0.0986 -0.13022,-0.22046 v -1.1365 c 0,-0.12184 0.058,-0.22047 0.13022,-0.22047 z m -8.23141,-3.22642 c -0.10443,0 -0.18952,0.0761 -0.18952,0.16825 l -0.004,3.93037 c -6.6e-4,0.0941 0.0838,0.16889 0.18952,0.16889 h 0.77163 c 0.10508,0 0.18953,-0.0761 0.19017,-0.16825 l 0.004,-3.93037 c 0,-0.0928 -0.0844,-0.16889 -0.18952,-0.16889 z m 1.73924,2.21498 c -0.10507,0 -0.18952,0.0761 -0.18952,0.16889 l -0.003,1.7141 c -6.5e-4,0.0928 0.0838,0.16825 0.18824,0.1689 h 0.77293 c 0.10443,0 0.18887,-0.0754 0.18952,-0.1689 l 0.004,-1.7141 c 0,-0.0928 -0.0845,-0.16889 -0.18952,-0.16889 z m -3.44754,-1.11587 h 0.77228 c 0.10508,0 0.18953,0.0748 0.18953,0.16889 l -0.004,2.82224 c 0,0.0928 -0.0851,0.16889 -0.18953,0.16889 l -0.77228,-6.5e-4 c -0.10507,0 -0.18952,-0.0748 -0.18952,-0.1689 l 0.004,-2.82223 c 0,-0.0935 0.0851,-0.16825 0.18952,-0.16825 z m 8.87219,-0.0812 h -1.53747 c -0.0722,0 -0.13086,-0.098 -0.13086,-0.22047 v -1.13586 c 0,-0.12248 0.0586,-0.22111 0.13086,-0.22111 h 1.53747 c 0.0728,0 0.13086,0.0986 0.13086,0.22111 v 1.13586 c 0,0.12248 -0.058,0.22047 -0.13086,0.22047 z m 1.06752,-1.57744 h 4.72199 c 0.0729,0 0.13087,0.0986 0.13087,0.22111 v 1.13586 c 0,0.12248 -0.058,0.22047 -0.13087,0.22047 h -4.72199 c -0.0722,0 -0.13022,-0.098 -0.13022,-0.22047 v -1.13586 c 0,-0.12248 0.058,-0.22111 0.13022,-0.22111 z"
+         fill="#f3f3f3"
+         fill-rule="nonzero"
+         id="path413"
+         style="display:inline;stroke-width:0.64464;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23242,61.5 c -4.11577,0 -6.55968,0.226752 -7.96875,1.558594 -0.28725,0.271486 -0.52183,0.601863 -0.72851,0.972656 -0.0468,0.08393 -0.10154,0.156606 -0.14454,0.246094 -2.5e-4,5.28e-4 2.6e-4,0.0014 0,0.002 -0.11616,0.241982 -0.2184,0.50414 -0.30859,0.789062 -0.0904,0.285534 -0.16955,0.593694 -0.23633,0.925782 -0.0668,0.332095 -0.1223,0.688232 -0.16797,1.070312 -0.0913,0.764147 -0.1422,1.632501 -0.16406,2.617188 -0.0109,0.492345 -0.0144,1.013779 -0.0117,1.566406 v 12.751906 12.751953 c -0.003,0.552627 8e-4,1.074061 0.0117,1.566406 0.0219,0.984686 0.0727,1.853041 0.16406,2.617191 0.0457,0.38208 0.1012,0.73821 0.16797,1.07031 0.13356,0.66417 0.31198,1.23197 0.54492,1.7168 0.23295,0.48482 0.52078,0.88581 0.87305,1.21875 0.17614,0.16648 0.36842,0.31556 0.57813,0.44921 0.41895,0.26701 0.90872,0.47238 1.47656,0.62891 6.2e-4,1.7e-4 0.001,-1.7e-4 0.002,0 1.42142,0.39113 3.3408,0.48047 5.91211,0.48047 h 17.53906 c 1.02156,0 1.93959,-0.015 2.76368,-0.0566 0.34097,-0.0172 0.65525,-0.0427 0.96484,-0.0703 0.0645,-0.006 0.13795,-0.007 0.20117,-0.0137 0.001,-1.4e-4 0.003,1.3e-4 0.004,0 0.73118,-0.0725 1.37505,-0.17995 1.93945,-0.33399 0.28273,-0.0772 0.54639,-0.16492 0.79102,-0.26758 0.24462,-0.10265 0.47066,-0.22006 0.67968,-0.35156 0.20903,-0.1315 0.40024,-0.27771 0.57618,-0.44141 0.15581,-0.14498 0.29602,-0.30775 0.42773,-0.48046 0.017,-0.0223 0.0381,-0.0397 0.0547,-0.0625 0.001,-0.002 0.003,-0.004 0.004,-0.006 0.14374,-0.19776 0.2725,-0.41443 0.38868,-0.6504 0.11725,-0.23815 0.22082,-0.49693 0.3125,-0.77734 0.0917,-0.28041 0.17164,-0.58218 0.24023,-0.9082 0.0686,-0.32602 0.12581,-0.6758 0.17383,-1.05078 0.0428,-0.33417 0.0752,-0.6967 0.10351,-1.072269 0.003,-0.04534 0.0104,-0.0849 0.0137,-0.130859 4.2e-4,-0.0061 -4.3e-4,-0.01341 0,-0.01953 0.059,-0.850021 0.0853,-1.80463 0.0879,-2.88086 v -18.904178 c -0.009,-1.95527 -1.71776,-3.606675 -3.10157,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 c -2.24485,-2.121612 -3.79653,-3.138638 -6.86748,-3.138638 z"
-         id="path964-1"
-         inkscape:connector-curvature="0" />
+         d="m 334.82503,204.53912 h 3.46279 c 0.0535,0 0.096,0.0723 0.096,0.16167 v 0.83344 c -1e-5,0.0893 -0.0425,0.16167 -0.096,0.16167 h -3.46278 c -0.053,0 -0.0955,-0.0723 -0.0955,-0.16167 v -0.83344 c 0,-0.0893 0.0425,-0.16167 0.0955,-0.16167 z m -0.78285,1.15678 h -3.46232 c -0.0534,0 -0.096,-0.0723 -0.096,-0.16167 v -0.83344 c 0,-0.0893 0.0425,-0.16167 0.096,-0.16167 h 3.46231 c 0.0535,0 0.096,0.0723 0.096,0.16167 v 0.83344 c 0,0.0893 -0.0425,0.16167 -0.096,0.16167 z m -4.24517,0 h -3.46327 c -0.0529,0 -0.0955,-0.0723 -0.0955,-0.16167 v -0.83344 c 0,-0.0893 0.0425,-0.16167 0.0955,-0.16167 h 3.46327 c 0.0525,0 0.095,0.0723 0.095,0.16167 v 0.83344 c 0,0.0893 -0.0425,0.16167 -0.095,0.16167 z m 5.02802,-3.70152 h 3.46278 c 0.0535,0 0.096,0.0719 0.096,0.16167 v 0.83297 c 0,0.0898 -0.0425,0.16214 -0.096,0.16214 h -3.46278 c -0.053,0 -0.0955,-0.0723 -0.0955,-0.16214 v -0.83297 c 0,-0.0898 0.0425,-0.16167 0.0955,-0.16167 z m -0.78285,1.15678 h -3.46232 c -0.0534,0 -0.096,-0.0723 -0.096,-0.16214 v -0.83297 c 0,-0.0898 0.0425,-0.16167 0.096,-0.16167 h 3.46231 c 0.0535,0 0.096,0.0719 0.096,0.16167 v 0.83297 c 0,0.0898 -0.0425,0.16214 -0.096,0.16214 z m -4.24517,0 h -3.46327 c -0.0529,0 -0.0955,-0.0723 -0.0955,-0.16214 v -0.83297 c 0,-0.0898 0.0425,-0.16167 0.0955,-0.16167 h 3.46327 c 0.0525,0 0.095,0.0719 0.095,0.16167 v 0.83297 c 0,0.0898 -0.0425,0.16214 -0.095,0.16214 z m 5.02802,-3.70199 h 3.46278 c 0.0535,0 0.096,0.0723 0.096,0.16215 v 0.83296 c 0,0.0898 -0.0425,0.16167 -0.096,0.16167 h -3.46278 c -0.053,0 -0.0955,-0.0719 -0.0955,-0.16167 v -0.83296 c 0,-0.0898 0.0425,-0.16215 0.0955,-0.16215 z m -0.78285,1.15678 h -3.46232 c -0.0534,0 -0.096,-0.0719 -0.096,-0.16167 v -0.83296 c 0,-0.0898 0.0425,-0.16215 0.096,-0.16215 h 3.46231 c 0.0535,0 0.096,0.0723 0.096,0.16215 v 0.83296 c 0,0.0898 -0.0425,0.16167 -0.096,0.16167 z m -4.24517,0 h -3.46327 c -0.0529,0 -0.0955,-0.0719 -0.0955,-0.16167 v -0.83296 c 0,-0.0898 0.0425,-0.16215 0.0955,-0.16215 h 3.46327 c 0.0525,0 0.095,0.0723 0.095,0.16215 v 0.83296 c 0,0.0898 -0.0425,0.16167 -0.095,0.16167 z m 1.84462,-6.52612 c 0.0988,0 0.17869,0.0705 0.17869,0.15884 v 3.6916 c 0,0.0879 -0.0799,0.15884 -0.17869,0.15884 h -5.20624 c -0.0988,0 -0.17823,-0.0709 -0.17823,-0.15884 v -3.6916 c 0,-0.0884 0.0794,-0.15884 0.17823,-0.15884 z m 2.40055,3.98138 h -1.12748 c -0.053,0 -0.096,-0.0723 -0.096,-0.16167 v -0.83344 c 0,-0.0893 0.043,-0.16167 0.096,-0.16167 h 1.12747 c 0.0535,0 0.096,0.0723 0.096,0.16167 v 0.83344 c 0,0.0893 -0.0425,0.16167 -0.096,0.16167 z m 0.78285,-1.15678 h 3.46278 c 0.0535,0 0.096,0.0723 0.096,0.16168 v 0.83343 c 0,0.0893 -0.0425,0.16167 -0.096,0.16167 h -3.46278 c -0.053,0 -0.0955,-0.0723 -0.0955,-0.16167 v -0.83343 c 0,-0.0893 0.0425,-0.16168 0.0955,-0.16168 z m -6.03637,-2.36604 c -0.0766,0 -0.13898,0.0558 -0.13898,0.12338 l -0.003,2.88228 c -4.8e-4,0.069 0.0615,0.12385 0.13899,0.12385 h 0.56586 c 0.0771,0 0.13899,-0.0558 0.13946,-0.12338 l 0.003,-2.88228 c 0,-0.068 -0.0619,-0.12385 -0.13898,-0.12385 z m 1.27544,1.62432 c -0.077,0 -0.13898,0.0558 -0.13898,0.12385 l -0.002,1.25701 c -4.8e-4,0.068 0.0614,0.12338 0.13804,0.12386 h 0.56682 c 0.0766,0 0.1385,-0.0553 0.13898,-0.12386 l 0.003,-1.25701 c 0,-0.068 -0.062,-0.12385 -0.13898,-0.12385 z m -2.52819,-0.8183 h 0.56633 c 0.0771,0 0.13899,0.0548 0.13899,0.12385 l -0.003,2.06964 c 0,0.068 -0.0624,0.12385 -0.13899,0.12385 l -0.56634,-4.7e-4 c -0.0771,0 -0.13898,-0.0549 -0.13898,-0.12386 l 0.003,-2.06964 c 0,-0.0686 0.0624,-0.12338 0.13899,-0.12338 z m 6.50627,-0.0596 h -1.12748 c -0.053,0 -0.096,-0.0719 -0.096,-0.16168 v -0.83296 c 0,-0.0898 0.043,-0.16215 0.096,-0.16215 h 1.12748 c 0.0534,0 0.096,0.0723 0.096,0.16215 v 0.83296 c 0,0.0898 -0.0425,0.16168 -0.096,0.16168 z m 0.78285,-1.15679 h 3.46279 c 0.0535,0 0.096,0.0723 0.096,0.16215 v 0.83296 c 0,0.0898 -0.0425,0.16168 -0.096,0.16168 h -3.46279 c -0.053,0 -0.0955,-0.0719 -0.0955,-0.16168 v -0.83296 c 0,-0.0898 0.0425,-0.16215 0.0955,-0.16215 z"
+         fill="#f3f3f3"
+         fill-rule="nonzero"
+         id="path425"
+         style="display:inline;stroke-width:0.472736;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -2.50815,0 -4.811706,0.02551 -7.011724,0.07227 -1.569123,0.03333 -3.085758,0.07665 -4.505859,0.142578 -0.892728,0.04133 -1.761123,0.08803 -2.597656,0.144531 -0.07361,0.005 -0.155337,0.0086 -0.228516,0.01367 -0.03977,0.0028 -0.07364,0.0069 -0.113281,0.0098 -1.116046,0.0793 -2.169724,0.179402 -3.1875,0.291016 -0.281404,0.03076 -0.565732,0.06033 -0.839844,0.09375 -0.275699,0.03373 -0.547991,0.06893 -0.816406,0.105469 -0.386448,0.05241 -0.763169,0.107586 -1.134766,0.166015 -0.245075,0.0387 -0.493706,0.07575 -0.732422,0.117188 -0.386715,0.06683 -0.756638,0.14255 -1.126953,0.216797 -0.50787,0.102283 -1.000729,0.211021 -1.478515,0.328125 -0.190937,0.04659 -0.386033,0.09158 -0.572266,0.140625 -0.3252,0.08602 -0.638123,0.17771 -0.949219,0.271484 -0.174107,0.05225 -0.347813,0.105409 -0.517578,0.160157 -0.32699,0.105899 -0.647816,0.216555 -0.958984,0.332031 -0.09794,0.0362 -0.19267,0.07416 -0.289063,0.111328 -1.533658,0.593687 -2.876219,1.308506 -4.044922,2.173828 -0.01464,0.01084 -0.03034,0.02036 -0.04492,0.03125 -4.841904,3.613548 -6.740009,9.796263 -7.419922,20.238281 -0.01716,0.264046 -0.02929,0.544903 -0.04492,0.814453 -0.06629,1.140594 -0.126494,2.305415 -0.167969,3.546875 -9.88e-4,0.02958 -9.78e-4,0.06216 -0.002,0.0918 -0.04738,1.439614 -0.07924,2.944486 -0.09961,4.525391 0.472511,-28.9634 6.027958,-32.138712 38.884815,-32.138712 h 62.52929 c -0.85989,-0.295464 -1.74582,-0.553137 -2.65429,-0.783203 -0.15701,-0.03958 -0.31205,-0.08153 -0.47071,-0.119141 -0.38771,-0.0924 -0.78156,-0.17709 -1.17969,-0.257812 -0.28362,-0.0571 -0.57205,-0.108999 -0.86132,-0.160156 -0.33217,-0.05924 -0.66192,-0.122415 -1.00196,-0.173829 -0.61547,-0.09216 -1.24344,-0.171652 -1.88672,-0.238281 -0.25531,-0.02678 -0.51929,-0.04563 -0.77929,-0.06836 -0.49344,-0.04258 -0.99476,-0.07925 -1.50586,-0.107422 -0.26087,-0.01459 -0.52138,-0.03022 -0.78711,-0.04102 -0.75738,-0.03032 -1.52534,-0.05078 -2.32422,-0.05078 z"
-         id="path7778" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 202.6543,44.089844 c -1.07122,0.357279 -1.96732,1.040077 -2.67188,1.910156 h 1.0957 c 34.15108,4e-6 38.64021,3.484765 38.89649,35.740234 0.003,-0.03712 0.0117,-0.07204 0.0137,-0.109375 -0.0536,-17.671398 -1.15787,-27.178174 -7.08008,-32.177734 -0.31691,-0.265045 -0.64554,-0.519153 -0.99023,-0.759766 -1.34338,-0.937742 -2.91268,-1.68853 -4.71875,-2.296875 -0.14212,-0.04772 -0.27668,-0.09862 -0.42188,-0.144531 -0.31902,-0.101184 -0.65609,-0.192499 -0.99023,-0.285156 -0.25795,-0.07131 -0.51412,-0.144507 -0.78125,-0.210938 -0.32384,-0.08078 -0.65655,-0.156631 -0.99414,-0.230468 -0.32254,-0.07033 -0.65294,-0.136909 -0.98828,-0.201172 -0.32063,-0.06164 -0.64012,-0.123397 -0.97266,-0.179688 -0.46228,-0.07802 -0.94194,-0.148582 -1.42773,-0.216797 -0.21622,-0.03046 -0.42163,-0.06516 -0.64258,-0.09375 -0.003,-3.28e-4 -0.005,-0.0016 -0.008,-0.002 -0.70741,-0.09114 -1.44413,-0.170948 -2.20118,-0.24414 -0.30752,-0.02983 -0.6294,-0.05499 -0.94531,-0.08203 -0.52075,-0.04445 -1.04787,-0.08768 -1.59179,-0.125 -0.34138,-0.02349 -0.68841,-0.04362 -1.03907,-0.06445 -0.36733,-0.02177 -0.74929,-0.04154 -1.12695,-0.06055 -1.40861,-0.07105 -2.86508,-0.128967 -4.42188,-0.166015 -0.006,-1.28e-4 -0.0105,5e-6 -0.0156,0 h -0.004 z"
-         id="path7776" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.011719,81.421875 c -0.0019,0.539192 -0.01172,1.017567 -0.01172,1.572266 v 2 c -0.0062,-1.260292 0.0066,-2.391311 0.01172,-3.572266 z"
-         id="path5316-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.005859,227.00586 v 2 c -0.0022,0.44238 0.0048,0.82141 0.0039,1.25391 0.0013,0.45945 0.007,0.88359 0.0098,1.33203 -0.01134,-1.48776 -0.02159,-2.96803 -0.01367,-4.58594 z m 175.994141,0.75195 c -0.0555,34.63219 -3.88404,38.24219 -38.91602,38.24219 h -98.15625 c -32.934263,0 -38.440959,-3.18029 -38.890621,-32.33398 0.304544,24.87428 3.489356,31.9654 22.175782,33.76562 0.0033,3.2e-4 0.0064,-3.2e-4 0.0098,0 0.761225,0.073 1.548247,0.13868 2.361328,0.19531 0.002,1.4e-4 0.0039,-1.4e-4 0.0059,0 0.814659,0.0567 1.655065,0.10648 2.523437,0.14844 6.7e-4,3e-5 0.0013,-3e-5 0.002,0 0.579873,0.028 1.24712,0.0365 1.851563,0.0586 1.208255,0.0442 2.391096,0.0937 3.701172,0.11719 0.0014,3e-5 0.0025,-2e-5 0.0039,0 1.964377,0.0351 4.045339,0.0488 6.250009,0.0488 0.002,0 0.004,0 0.006,0 h 98.15039 c 3.67649,0 6.93682,-0.0556 9.96094,-0.16602 2.42031,-0.0885 4.71577,-0.20623 6.75196,-0.40234 19.49586,-1.8777 22.12352,-9.49921 22.20507,-37.08398 -8.2e-4,-0.46208 0.006,-0.86842 0.004,-1.3418 z"
-         id="path5316-8"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 353.49905,61.375285 c -0.0742,0 -0.14719,0.007 -0.22049,0.018 -0.94065,0.29981 -1.25935,1.72298 -0.53417,2.39306 l 7.51333,7.51498 c 0.78643,0.74591 2.35311,0.10873 2.39455,-0.97465 v -2.118 c 0.0336,-6.55752 0.34308,-6.68079 -5.59466,-6.81539 h -3.33561 c -0.0733,-0.0113 -0.14877,-0.018 -0.22295,-0.018 z"
-         id="rect4158-92-6-6"
-         sodipodi:nodetypes="scccccccs" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1004);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         clip-path="url(#clipPath994-5)"
-         d="m 335.23242,61.5 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 v 12.751953 12.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 v -17.903968 c -0.006,-1.214011 -0.66655,-2.310001 -1.49805,-3.265625 v 8.243812 12.251953 c 0,2.193451 -0.0614,3.870697 -0.26562,5.087887 -0.20419,1.2172 -0.52867,1.92435 -0.99805,2.39454 -0.46938,0.47016 -1.17436,0.79564 -2.38867,1 -1.21432,0.20434 -2.8892,0.26562 -5.07813,0.26562 h -16.53906 c -2.18893,0 -3.86589,-0.0612 -5.08399,-0.26562 -1.21809,-0.20448 -1.92877,-0.5295 -2.40039,-1 -0.47161,-0.47052 -0.79596,-1.17682 -0.99804,-2.39258 -0.20209,-1.21576 -0.25879,-2.893414 -0.24805,-5.085941 v -0.002 -12.253859 -12.253906 -0.002 c -0.0107,-2.192528 0.046,-3.870175 0.24805,-5.085938 0.20209,-1.215763 0.52643,-1.922078 0.99804,-2.392578 0.47161,-0.4705 1.18426,-0.79553 2.40235,-1 1.21809,-0.204376 2.8931,-0.265578 5.08203,-0.265578 h 12.26953 c -1.40176,-1.001118 -3.79892,-1.5 -5.922,-1.5 z"
-         id="path990"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssccccscccsscccccccccscscss" />
-      <path
-         inkscape:connector-curvature="0"
-         style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0441942;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 353.35547,61.876953 -0.14453,0.121094 c -0.28875,0.242959 -0.43321,0.748579 -0.31836,1.111328 0.007,0.0217 0.07,0.0936 0.11523,0.150391 0.056,-0.101219 0.12158,-0.193105 0.20313,-0.261719 l 0.14453,-0.121094 2.71875,0.02539 c 2.70745,0.02522 3.50936,0.05935 4.26562,0.185547 1.36683,0.228076 1.67801,0.658049 1.79102,2.474609 0.0245,0.393967 0.0317,1.552688 0.0352,2.636719 0.007,-1.466927 -5.4e-4,-3.080545 -0.0352,-3.636719 -0.11301,-1.81656 -0.42419,-2.246533 -1.79102,-2.474609 -0.75626,-0.126199 -1.55817,-0.160327 -4.26562,-0.185547 z"
-         id="path7025" />
-      <path
-         transform="translate(4.9980746e-4)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 v 6.12581 6.12581 c -0.0217,4.42101 0.45311,4.87419 4.8652,4.87419 h 8.2696 c 4.41209,0 4.8652,-0.45312 4.8652,-4.87419 v -6.12581 -6.12581 c 0,-4.42106 -0.45312,-4.87419 -4.86521,-4.87419 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971-6)" />
-      <path
-         id="path1085"
-         d="m 327.86573,188.5 c -1.11158,0 -1.98683,0.0256 -2.70703,0.14648 -0.72019,0.1209 -1.3105,0.34863 -1.74218,0.7793 -0.43169,0.43067 -0.65954,1.01974 -0.7793,1.74024 -0.11977,0.72049 -0.14217,1.59669 -0.13672,2.71093 v 6.12305 6.125 c -0.005,1.1131 0.017,1.989 0.13672,2.70898 0.11976,0.72051 0.3476,1.30957 0.7793,1.74024 0.43169,0.43067 1.02199,0.6584 1.74218,0.7793 0.7202,0.12089 1.59545,0.14648 2.70703,0.14648 h 8.26954 c 1.11158,0 1.98637,-0.0255 2.70507,-0.14648 0.7187,-0.12095 1.30623,-0.34848 1.73633,-0.7793 0.4301,-0.43083 0.6566,-1.01849 0.77735,-1.73828 0.12074,-0.71979 0.14648,-1.59713 0.14648,-2.71094 v -6.125 -6.125 c 0,-1.11381 -0.0257,-1.99115 -0.14648,-2.71094 -0.12075,-0.71979 -0.34725,-1.30745 -0.77735,-1.73828 -0.4301,-0.43082 -1.01763,-0.65835 -1.73633,-0.7793 -0.7187,-0.12094 -1.59349,-0.14648 -2.70507,-0.14648 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path1087"
-         d="m 325.0962,236.5 c -0.71048,0 -1.27344,0.0154 -1.75195,0.0957 -0.47851,0.0803 -0.89671,0.23728 -1.20703,0.54688 -0.31032,0.30959 -0.46726,0.7261 -0.54688,1.20508 -0.0796,0.47897 -0.0933,1.04352 -0.0898,1.75586 v 3.89648 3.89844 c -0.003,0.71121 0.0103,1.27546 0.0898,1.7539 0.0796,0.47898 0.23655,0.89549 0.54688,1.20508 0.31033,0.3096 0.72851,0.46655 1.20703,0.54688 0.47852,0.0803 1.04147,0.0957 1.75195,0.0957 h 5.8086 c 0.71048,0 1.27236,-0.0153 1.75,-0.0957 0.47763,-0.0804 0.89584,-0.23713 1.20508,-0.54688 0.30921,-0.30975 0.46469,-0.72681 0.54492,-1.20508 0.0802,-0.47826 0.0957,-1.04201 0.0957,-1.7539 v -3.89844 -3.89844 c 0,-0.71189 -0.0155,-1.27564 -0.0957,-1.7539 -0.0802,-0.47827 -0.2357,-0.89533 -0.54492,-1.20508 -0.30924,-0.30975 -0.72745,-0.4665 -1.20508,-0.54688 -0.47764,-0.0804 -1.03952,-0.0957 -1.75,-0.0957 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         transform="translate(4.9980746e-4)"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 v 3.89824 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 c 2.8077,0 3.09604,-0.28835 3.09604,-3.10176 v -3.89824 -3.89824 c 0,-2.8134 -0.28835,-3.10176 -3.09604,-3.10176 z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983-6)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.991584;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 342.28662,133.49219 c -0.0504,0 -0.10067,0.005 -0.15039,0.0117 -0.63831,0.19051 -0.85538,1.0957 -0.36328,1.52148 l 5.09961,4.77344 c 0.53367,0.47395 1.59687,0.0693 1.625,-0.61914 v -1.34571 c 0.0228,-4.16669 0.23241,-4.24454 -3.79688,-4.33007 h -2.26367 c -0.0498,-0.007 -0.10004,-0.0117 -0.15039,-0.0117 z m -12.21289,0.004 c -2.78209,0 -4.43425,0.14534 -5.38672,1.00391 -0.19416,0.175 -0.35249,0.38793 -0.49219,0.62695 -0.0316,0.054 -0.0686,0.10247 -0.0976,0.16016 -0.0785,0.156 -0.14802,0.3261 -0.20899,0.50977 -0.0611,0.18405 -0.11501,0.38162 -0.16015,0.5957 -0.0452,0.21409 -0.0824,0.44315 -0.11329,0.68945 -0.0617,0.49261 -0.0965,1.05274 -0.11132,1.6875 -0.007,0.31739 -0.01,0.65353 -0.008,1.00977 v 8.2206 8.2207 c -0.002,0.35623 3.5e-4,0.69239 0.008,1.00977 0.0148,0.63477 0.0495,1.19491 0.11132,1.6875 0.0309,0.24631 0.0682,0.47537 0.11329,0.68945 0.0903,0.42816 0.21168,0.79292 0.36914,1.10547 0.15746,0.31252 0.35171,0.57249 0.58984,0.78711 0.11906,0.10732 0.24887,0.20291 0.39062,0.28906 0.28319,0.17212 0.61423,0.30534 0.99805,0.40625 0.96081,0.25213 2.25995,0.3086 3.99805,0.3086 h 11.85547 c 0.69054,0 1.31013,-0.0106 1.86719,-0.0371 0.23047,-0.0111 0.44308,-0.0272 0.65234,-0.0449 0.0436,-0.004 0.094,-0.004 0.13672,-0.008 h 0.002 c 0.49424,-0.0467 0.92903,-0.11749 1.31055,-0.21679 0.19111,-0.0498 0.36981,-0.10571 0.53515,-0.17188 0.16536,-0.0661 0.31771,-0.14178 0.45899,-0.22656 0.14129,-0.0848 0.2717,-0.17962 0.39062,-0.28516 0.10532,-0.0934 0.20005,-0.19727 0.28907,-0.30859 0.0115,-0.0144 0.0259,-0.0264 0.0371,-0.041 6.7e-4,-0.001 9.5e-4,-0.003 0.002,-0.004 0.0971,-0.12749 0.18514,-0.26586 0.26367,-0.41797 0.0792,-0.15352 0.14897,-0.32121 0.21094,-0.50196 0.062,-0.18077 0.11573,-0.37576 0.16211,-0.58593 0.0464,-0.21016 0.0847,-0.43601 0.11718,-0.67774 0.0289,-0.21541 0.0511,-0.44929 0.0703,-0.6914 0.002,-0.0292 0.008,-0.0543 0.01,-0.084 2.9e-4,-0.004 -2.9e-4,-0.008 0,-0.0117 0.0399,-0.54795 0.0568,-1.16365 0.0586,-1.85742 v -11.18578 c -0.006,-1.26044 -1.16032,-2.32513 -2.09571,-3.1289 l -0.008,-0.006 -6.72986,-6.49196 c -1.51744,-1.36767 -2.56676,-2.02344 -4.64258,-2.02344 z"
-         id="path964-1-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccccccccccccccccsscccccccccccccccccccccccss" />
-      <path
-         style="opacity:0.3;fill:url(#linearGradient4316);fill-opacity:1;stroke:none;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 343.16802,134.07487 c -0.99147,0.035 -1.02734,0.0465 -1.02734,0.33594 0,0.10178 0.15173,0.31016 0.45898,0.64648 h 2.87891 c 0.15931,0 0.30929,0.0306 0.45312,0.0762 0.32342,0.02 0.64497,0.0487 0.96485,0.10352 0.0264,0.32124 0.0306,0.64828 0.0371,0.97461 0.0263,0.11154 0.0449,0.2259 0.0449,0.3457 v 2.61719 c 0.25501,0.21272 0.45277,0.36813 0.49023,0.36914 0.45172,0.0121 0.5059,-0.28833 0.46289,-2.54883 -0.0534,-2.80528 0.043,-2.67754 -2.15624,-2.83984 -0.86922,-0.0642 -2.04216,-0.1 -2.60743,-0.0801 z m -10.83984,0.0371 c -5.16676,0.002 -5.89229,0.0632 -6.90234,0.57617 -0.60351,0.30649 -1.03843,1.06517 -1.2461,2.17187 -0.24355,1.30043 -0.239,21.42491 0.006,22.5 0.4115,1.80781 1.06039,2.3312 3.18555,2.56446 0.49142,0.054 4.63516,0.0862 9.20703,0.0723 7.44102,-0.0226 8.39113,-0.0477 9.0625,-0.24023 1.20765,-0.3464 1.67604,-0.80148 2.02539,-1.96289 0.17841,-0.59326 0.21211,-1.68489 0.25391,-8.28321 0.0479,-7.5564 0.0468,-6.60393 -0.21875,-7.15257 -0.0736,-0.15205 -0.33859,-0.46265 -0.72266,-0.875 v 4.07422 c 0,0.12416 -0.0206,0.24218 -0.0488,0.35742 0.0246,3.83198 -0.0428,6.67596 -0.12305,10.47289 0.094,0.98908 -0.26416,2.20979 -1.37304,2.42969 -4.17852,0.21246 -8.39772,0.16055 -12.60547,0.18945 -2.09316,-0.0712 -4.2187,0.13385 -6.29102,-0.20117 -1.20786,-0.09 -1.37139,-1.432 -1.46679,-2.37696 -0.1751,-6.57883 -0.13104,-13.28191 -0.041,-19.88867 0.0853,-1.09208 -0.0376,-2.65795 1.18164,-3.16406 2.366,-0.42229 4.785,-0.2218 7.17578,-0.3125 0.61114,0.0344 0.29054,0.0147 0.94202,0.0117 0.059,-0.007 0.11677,-0.0176 0.17773,-0.0176 h 3.5918 c -0.42688,-0.30915 -0.78914,-0.52782 -1.16797,-0.68359 -0.60974,-0.25114 0.12581,-0.26372 -4.60217,-0.26172 z"
-         id="path4296"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cscscccscccccccccccccccccsccccccccccscccc" />
+         d="m 329.79776,246.88853 h 2.2036 c 0.034,0 0.0611,0.046 0.0611,0.10289 v 0.53037 c -10e-6,0.0568 -0.0271,0.10288 -0.0611,0.10288 h -2.20359 c -0.0337,0 -0.0608,-0.046 -0.0608,-0.10288 v -0.53037 c 0,-0.0568 0.027,-0.10289 0.0608,-0.10289 z m -0.49817,0.73614 h -2.2033 c -0.034,0 -0.0611,-0.046 -0.0611,-0.10288 v -0.53037 c 0,-0.0568 0.0271,-0.10289 0.0611,-0.10289 h 2.20329 c 0.034,0 0.0611,0.046 0.0611,0.10289 v 0.53037 c 0,0.0568 -0.027,0.10288 -0.0611,0.10288 z m -2.70148,0 h -2.20389 c -0.0337,0 -0.0608,-0.046 -0.0608,-0.10288 v -0.53037 c 0,-0.0568 0.027,-0.10289 0.0608,-0.10289 h 2.20389 c 0.0334,0 0.0605,0.046 0.0605,0.10289 v 0.53037 c 0,0.0568 -0.027,0.10288 -0.0605,0.10288 z m 3.19965,-2.35552 h 2.20359 c 0.034,0 0.0611,0.0458 0.0611,0.10288 v 0.53008 c 0,0.0571 -0.027,0.10318 -0.0611,0.10318 h -2.20359 c -0.0337,0 -0.0608,-0.046 -0.0608,-0.10318 v -0.53008 c 0,-0.0571 0.0271,-0.10288 0.0608,-0.10288 z m -0.49817,0.73614 h -2.2033 c -0.034,0 -0.0611,-0.046 -0.0611,-0.10318 v -0.53008 c 0,-0.0571 0.0271,-0.10288 0.0611,-0.10288 h 2.20329 c 0.034,0 0.0611,0.0458 0.0611,0.10288 v 0.53008 c 0,0.0571 -0.027,0.10318 -0.0611,0.10318 z m -2.70148,0 h -2.20389 c -0.0337,0 -0.0608,-0.046 -0.0608,-0.10318 v -0.53008 c 0,-0.0571 0.027,-0.10288 0.0608,-0.10288 h 2.20389 c 0.0334,0 0.0605,0.0458 0.0605,0.10288 v 0.53008 c 0,0.0571 -0.027,0.10318 -0.0605,0.10318 z m 3.19965,-2.35582 h 2.20359 c 0.034,0 0.0611,0.046 0.0611,0.10319 v 0.53007 c 0,0.0571 -0.027,0.10288 -0.0611,0.10288 h -2.20359 c -0.0337,0 -0.0608,-0.0458 -0.0608,-0.10288 v -0.53007 c 0,-0.0571 0.0271,-0.10319 0.0608,-0.10319 z m -0.49817,0.73614 h -2.2033 c -0.034,0 -0.0611,-0.0458 -0.0611,-0.10288 v -0.53007 c 0,-0.0571 0.0271,-0.10319 0.0611,-0.10319 h 2.20329 c 0.034,0 0.0611,0.046 0.0611,0.10319 v 0.53007 c 0,0.0571 -0.027,0.10288 -0.0611,0.10288 z m -2.70148,0 h -2.20389 c -0.0337,0 -0.0608,-0.0458 -0.0608,-0.10288 v -0.53007 c 0,-0.0571 0.027,-0.10319 0.0608,-0.10319 h 2.20389 c 0.0334,0 0.0605,0.046 0.0605,0.10319 v 0.53007 c 0,0.0571 -0.027,0.10288 -0.0605,0.10288 z m 1.17385,-4.15299 c 0.0629,0 0.11372,0.0449 0.11372,0.10108 v 2.3492 c 0,0.0559 -0.0508,0.10108 -0.11372,0.10108 h -3.31306 c -0.0629,0 -0.11342,-0.0451 -0.11342,-0.10108 v -2.3492 c 0,-0.0563 0.0505,-0.10108 0.11342,-0.10108 z m 1.52763,2.53361 h -0.71749 c -0.0337,0 -0.0611,-0.046 -0.0611,-0.10288 v -0.53037 c 0,-0.0568 0.0274,-0.10289 0.0611,-0.10289 h 0.71748 c 0.034,0 0.0611,0.046 0.0611,0.10289 v 0.53037 c 0,0.0568 -0.027,0.10288 -0.0611,0.10288 z m 0.49817,-0.73614 h 2.20359 c 0.034,0 0.0611,0.046 0.0611,0.10289 v 0.53037 c 0,0.0568 -0.027,0.10288 -0.0611,0.10288 h -2.20359 c -0.0337,0 -0.0608,-0.046 -0.0608,-0.10288 v -0.53037 c 0,-0.0568 0.0271,-0.10289 0.0608,-0.10289 z m -3.84132,-1.50566 c -0.0487,0 -0.0884,0.0355 -0.0884,0.0785 l -0.002,1.83418 c -3.1e-4,0.0439 0.0391,0.0788 0.0884,0.0788 h 0.3601 c 0.0491,0 0.0884,-0.0355 0.0887,-0.0785 l 0.002,-1.83417 c 0,-0.0433 -0.0394,-0.0788 -0.0884,-0.0788 z m 0.81164,1.03366 c -0.049,0 -0.0884,0.0355 -0.0884,0.0788 l -9.9e-4,0.79992 c -3.1e-4,0.0433 0.0391,0.0785 0.0878,0.0788 h 0.3607 c 0.0487,0 0.0881,-0.0352 0.0884,-0.0788 l 0.002,-0.79992 c 0,-0.0433 -0.0394,-0.0788 -0.0884,-0.0788 z m -1.60885,-0.52074 h 0.36039 c 0.0491,0 0.0885,0.0349 0.0885,0.0788 l -0.002,1.31704 c 0,0.0433 -0.0397,0.0788 -0.0884,0.0788 l -0.3604,-3e-4 c -0.0491,0 -0.0884,-0.0349 -0.0884,-0.0788 l 0.002,-1.31705 c 0,-0.0436 0.0397,-0.0785 0.0884,-0.0785 z m 4.14036,-0.0379 h -0.71749 c -0.0337,0 -0.0611,-0.0458 -0.0611,-0.10289 v -0.53007 c 0,-0.0571 0.0274,-0.10318 0.0611,-0.10318 h 0.71749 c 0.034,0 0.0611,0.046 0.0611,0.10318 v 0.53007 c 0,0.0571 -0.0271,0.10289 -0.0611,0.10289 z m 0.49817,-0.73614 h 2.2036 c 0.034,0 0.0611,0.046 0.0611,0.10318 v 0.53007 c 0,0.0571 -0.0271,0.10289 -0.0611,0.10289 h -2.2036 c -0.0337,0 -0.0608,-0.0458 -0.0608,-0.10289 v -0.53007 c 0,-0.0571 0.0271,-0.10318 0.0608,-0.10318 z"
+         fill="#f3f3f3"
+         fill-rule="nonzero"
+         id="path437"
+         style="display:inline;stroke-width:0.300832;enable-background:new" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/libreoffice-draw.svg
+++ b/icons/src/fullcolor/default/apps/libreoffice-draw.svg
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="libreoffice-draw.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
      id="base"
-     pagecolor="#909090"
+     pagecolor="#ffffff"
      bordercolor="#000000"
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2"
-     inkscape:cx="162.30601"
-     inkscape:cy="95.686135"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="219.91021"
+     inkscape:cy="159.80613"
      inkscape:current-layer="layer6"
-     showgrid="true"
+     showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -50,7 +50,7 @@
      gridtolerance="10000"
      inkscape:object-nodes="true"
      inkscape:snap-grids="true"
-     showguides="false"
+     showguides="true"
      inkscape:guide-bbox="true"
      inkscape:window-maximized="1"
      inkscape:bbox-paths="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,518 +93,89 @@
   <defs
      id="defs3">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-5">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient3194"
-       x1="335.73108"
-       y1="62"
-       x2="352.26993"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="169.66859"
-       x2="4.4137931"
-       y1="386.30838"
-       x1="494.34482"
-       id="linearGradient4226-1"
-       xlink:href="#linearGradient4338"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.96286,268)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6646"
-       x="-0.01363613"
-       width="1.0272723"
-       y="-0.01071443"
-       height="1.0214289">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.0000135"
-         id="feGaussianBlur6648" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6668"
-       x="-0.054544518"
-       width="1.109089"
-       y="-0.042857721"
-       height="1.0857154">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.000054"
-         id="feGaussianBlur6670" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4338">
-      <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
-         offset="0"
-         id="stop4340" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="1"
-         id="stop4342" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7707"
-       id="linearGradient18935"
-       x1="352.77151"
-       y1="106.5"
-       x2="335.23242"
-       y2="61.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983-6">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985-0"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971-6">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1311"
-       x1="327.99951"
-       y1="188"
-       x2="335.99951"
-       y2="212"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1309"
-       x1="332"
-       y1="236"
-       x2="324"
-       y2="252"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7707"
-       id="linearGradient916"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05664062,-0.05663901,0,349.74506,214)"
-       x1="44.137936"
-       y1="240.29004"
-       x2="450.20694"
-       y2="386.29437" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7707"
-       id="linearGradient920"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.03604403,-0.03604301,0,339.56482,252.90909)"
-       x1="39.093575"
-       y1="240.26906"
-       x2="455.25125"
-       y2="401.58029" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient7707"
-       id="linearGradient18935-0"
-       x1="352.89749"
-       y1="106.50614"
-       x2="334.86411"
-       y2="61.500103"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient4316"
-       x1="372"
-       y1="134"
-       x2="372"
-       y2="162"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-37.000489)" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient18935-0-8"
-       x1="336.64893"
-       y1="59.040947"
-       x2="348.54202"
-       y2="108.83411"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient15606-6">
-      <stop
-         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.588235;"
-         offset="0"
-         id="stop15608-8" />
-      <stop
-         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.862745;"
-         offset="1"
-         id="stop15610-7" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7723">
-      <stop
-         id="stop7721"
-         style="stop-color:#2e851b;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7715"
-         style="stop-color:#18a003;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient13791">
-      <stop
-         id="stop13793"
-         style="stop-color:#d36118;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop13795"
-         style="stop-color:#f09e6f;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient16134-3-1-8">
-      <stop
-         id="stop16136-6-3-7"
-         style="stop-color:#000000;stop-opacity:0.50196099"
-         offset="0" />
-      <stop
-         id="stop16138-4-6-2"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10286-8">
-      <stop
-         id="stop10288-2-1"
-         offset="0"
-         style="stop-color: rgb(179, 179, 179); stop-opacity: 1;" />
-      <stop
-         id="stop10290-6"
-         offset="1"
-         style="stop-color: rgb(230, 230, 230); stop-opacity: 1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7713">
-      <stop
-         id="stop7711"
-         style="stop-color:#993a03;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7709"
-         style="stop-color:#f0692c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6989-5">
-      <stop
-         id="stop6991-5"
-         offset="0"
-         style="stop-color: rgb(240, 158, 111); stop-opacity: 1;" />
-      <stop
-         id="stop6993-1"
-         offset="1"
-         style="stop-color: rgb(249, 207, 181); stop-opacity: 1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6975-88">
-      <stop
-         id="stop6977-8"
-         offset="0"
-         style="stop-color: rgb(245, 206, 83); stop-opacity: 1;" />
-      <stop
-         id="stop6979-6"
-         offset="1"
-         style="stop-color: rgb(253, 233, 169); stop-opacity: 1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10125-8">
-      <stop
-         style="stop-color: rgb(201, 156, 0); stop-opacity: 1;"
-         offset="0"
-         id="stop10127-5" />
-      <stop
-         style="stop-color: rgb(135, 105, 0); stop-opacity: 1;"
-         offset="1"
-         id="stop10129-5" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7707">
-      <stop
-         offset="0"
-         style="stop-color:#d98027;stop-opacity:1"
-         id="stop7703" />
-      <stop
-         offset="1"
-         style="stop-color:#be5e0f;stop-opacity:1"
-         id="stop7705" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7707"
-       id="linearGradient18820-3"
-       x1="201.07812"
-       y1="269.99988"
-       x2="102.92188"
-       y2="45.999878"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3976">
-      <stop
-         offset="0"
-         style="stop-color:#626262;stop-opacity:1"
-         id="stop3972" />
-      <stop
-         offset="1"
-         style="stop-color:#4e4e4e;stop-opacity:1"
-         id="stop3974" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear22"
-       x1="0"
-       y1="0"
+       id="b"
        x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-64.473,64.473,0,534.297,183.148)">
+       gradientTransform="matrix(0,-203.23056,203.23056,0,561.91612,254.13381)"
+       gradientUnits="userSpaceOnUse">
       <stop
+         stop-color="#c26d00"
          offset="0"
-         style="stop-color:rgb(240,188,111);stop-opacity:1"
-         id="stop380" />
+         id="stop7" />
       <stop
+         stop-color="#eea54f"
          offset="1"
-         style="stop-color:rgb(249,234,181);stop-opacity:1"
-         id="stop382" />
+         id="stop9" />
     </linearGradient>
     <linearGradient
-       id="_Linear23"
-       x1="0"
-       y1="0"
+       id="a"
        x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,82.553,-82.553,0,583.977,140.504)">
+       gradientTransform="matrix(-0.00528208,-207.68287,207.68287,-0.00528208,235.61349,259.06168)"
+       gradientUnits="userSpaceOnUse">
       <stop
+         stop-color="#b7b4b4"
          offset="0"
-         style="stop-color:rgb(201,156,0);stop-opacity:1"
-         id="stop385" />
+         id="stop2" />
       <stop
+         stop-color="#f1f1f1"
          offset="1"
-         style="stop-color:rgb(135,105,0);stop-opacity:1"
-         id="stop387" />
+         id="stop4" />
     </linearGradient>
     <linearGradient
-       id="_Linear24"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient499"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-63.914,63.914,0,553.935,220.506)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(245,206,83);stop-opacity:1"
-         id="stop390" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(253,233,169);stop-opacity:1"
-         id="stop392" />
-    </linearGradient>
+       gradientTransform="matrix(0,-41.734847,41.734847,0,428.17921,104.15248)"
+       x2="1" />
     <linearGradient
-       id="_Linear9"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient501"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-12.8947,12.8947,0,751.658,85.0297)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(240,188,111);stop-opacity:1"
-         id="stop299" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(249,234,181);stop-opacity:1"
-         id="stop301" />
-    </linearGradient>
+       gradientTransform="matrix(-0.00108471,-42.64916,42.64916,-0.00108471,361.17062,105.16445)"
+       x2="1" />
     <linearGradient
-       id="_Linear10"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient515"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,16.5107,-16.5107,0,761.594,76.5008)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(201,156,0);stop-opacity:1"
-         id="stop304" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(135,105,0);stop-opacity:1"
-         id="stop306" />
-    </linearGradient>
+       gradientTransform="matrix(0,-27.218378,27.218378,0,390.89946,161.14292)"
+       x2="1" />
     <linearGradient
-       id="_Linear11"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient517"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-12.783,12.783,0,755.585,92.5013)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(245,206,83);stop-opacity:1"
-         id="stop309" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(253,233,169);stop-opacity:1"
-         id="stop311" />
-    </linearGradient>
+       gradientTransform="matrix(-7.0741956e-4,-27.814669,27.814669,-7.0741956e-4,347.19821,161.8029)"
+       x2="1" />
     <linearGradient
-       id="_Linear12"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient531"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-8.29,8.29,0,745.808,146.553)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(240,188,111);stop-opacity:1"
-         id="stop314" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(249,234,181);stop-opacity:1"
-         id="stop316" />
-    </linearGradient>
+       gradientTransform="matrix(0,-19.960145,19.960145,0,372.25958,209.63814)"
+       x2="1" />
     <linearGradient
-       id="_Linear13"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient533"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-8.85,8.85,0,748.051,150.5)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(245,206,83);stop-opacity:1"
-         id="stop319" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(253,233,169);stop-opacity:1"
-         id="stop321" />
-    </linearGradient>
+       gradientTransform="matrix(-5.1877438e-4,-20.397426,20.397426,-5.1877438e-4,340.21199,210.12213)"
+       x2="1" />
     <linearGradient
-       id="_Linear14"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient547"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-8.29,8.29,0,743.808,196.553)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(240,188,111);stop-opacity:1"
-         id="stop324" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(249,234,181);stop-opacity:1"
-         id="stop326" />
-    </linearGradient>
+       gradientTransform="matrix(0,-12.701913,12.701913,0,353.61975,250.13337)"
+       x2="1" />
     <linearGradient
-       id="_Linear15"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient549"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-8.85,8.85,0,746.051,200.5)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(245,206,83);stop-opacity:1"
-         id="stop329" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(253,233,169);stop-opacity:1"
-         id="stop331" />
-    </linearGradient>
+       gradientTransform="matrix(-3.3012921e-4,-12.980182,12.980182,-3.3012921e-4,333.22583,250.44136)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -703,7 +275,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">libreoffice-draw</tspan></text>
+           id="tspan924">libreoffice-draw</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -738,483 +310,159 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.991584;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 342.28786,133.99591 c -0.0832,0 -0.1556,0.007 -0.2168,0.0156 l -0.0371,0.006 -0.0371,0.0117 c -1.02052,0.30458 -1.3544,1.66824 -0.54687,2.36914 0,0 0,0.002 0,0.002 l 5.08984,4.76563 0.006,0.004 c 0.44144,0.39204 1.03582,0.39851 1.50781,0.21874 0.47199,-0.17975 0.9171,-0.5946 0.94141,-1.18945 v -0.01 -1.35352 -0.002 c 0.006,-1.0363 0.0251,-1.82214 -0.0176,-2.45508 -0.0427,-0.63344 -0.14348,-1.14825 -0.47266,-1.55274 -0.32917,-0.40448 -0.82834,-0.59266 -1.42968,-0.68554 -0.60135,-0.0929 -1.35232,-0.1114 -2.36133,-0.13281 h -0.006 -2.26953 c -0.0478,-0.005 -0.0951,-0.0117 -0.15039,-0.0117 z m -7.25782,0.002 -4.95507,0.002 c -2.79936,0 -4.57517,0.10197 -5.71875,1.13282 -0.24259,0.21892 -0.43083,0.4754 -0.5879,0.74414 -0.0117,0.02 -0.0564,0.0782 -0.11132,0.1875 -0.0907,0.18027 -0.17065,0.37241 -0.23828,0.57617 -0.0671,0.20198 -0.12496,0.41859 -0.17383,0.65039 -0.0486,0.23023 -0.0869,0.47111 -0.11914,0.72851 v 0.002 c -0.0646,0.51578 -0.10015,1.09026 -0.11524,1.73633 -0.007,0.32198 -0.0116,0.66266 -0.01,1.02343 v 8.21875 8.22071 c -0.002,0.3594 0.002,0.69873 0.01,1.02148 0.0151,0.64603 0.0505,1.22236 0.11524,1.73828 0.0323,0.25754 0.0707,0.4986 0.11914,0.72852 0.0971,0.4603 0.23097,0.86702 0.41211,1.22656 0.18147,0.36018 0.41279,0.67544 0.69922,0.93359 0.14342,0.12929 0.30075,0.24284 0.46679,0.34375 0.33271,0.20222 0.70911,0.35057 1.12891,0.46094 v 0.002 c 1.04936,0.27537 2.37421,0.32422 4.12305,0.32422 h 11.85546 c 0.69562,0 1.32241,-0.0101 1.89063,-0.0371 h 0.002 c 0.23885,-0.0115 0.45772,-0.0289 0.66992,-0.0469 h 0.002 0.002 c 0.006,-5.4e-4 0.052,-0.004 0.0898,-0.006 h 0.0137 c 0.0155,-0.001 0.0141,-1.1e-4 0.0332,-0.002 h 0.002 c 0.51385,-0.0486 0.97388,-0.12251 1.38867,-0.23047 0.20576,-0.0536 0.4054,-0.11525 0.59571,-0.19141 0.18901,-0.0755 0.36479,-0.163 0.52929,-0.26172 0.1657,-0.0995 0.3216,-0.21271 0.46485,-0.33984 0.12928,-0.11465 0.24087,-0.23957 0.34179,-0.36524 0,2e-5 0.005,-0.005 0.006,-0.006 l 0.0215,-0.0215 0.0156,-0.0195 0.006,-0.008 0.002,-0.004 0.008,-0.008 0.008,-0.0137 c 4e-5,-7e-5 0.008,-0.016 0.0117,-0.0234 0.003,-0.004 0.009,-0.008 0.0117,-0.0117 -5.4e-4,7e-4 -0.007,0.003 -0.008,0.004 0.01,-0.0181 0.0172,-0.0306 0.0254,-0.0469 -0.006,0.0128 -0.01,0.0233 -0.0117,0.0273 0.095,-0.13149 0.18742,-0.26844 0.26562,-0.41992 0.0922,-0.17881 0.17175,-0.3686 0.24024,-0.56836 0.069,-0.20111 0.12594,-0.41283 0.17578,-0.63867 0.0501,-0.22709 0.0911,-0.46643 0.125,-0.71875 0.0307,-0.22912 0.0546,-0.4717 0.0742,-0.71875 l 0.002,-0.002 v -0.004 c -10e-4,0.0185 0.005,-0.009 0.01,-0.082 v -0.002 c 0.002,-0.0307 0.004,-0.0623 0,-0.006 v -0.002 -0.002 c 0.0411,-0.56466 0.0568,-1.18956 0.0586,-1.89062 v -0.004 -11.1875 c -0.007,-1.5618 -1.32097,-2.69049 -2.26758,-3.50391 l -0.01,-0.008 -0.002,-0.002 -6.71093,-6.47461 -0.008,-0.006 c -1.54333,-1.391 -2.79437,-2.15039 -4.97461,-2.15039 z"
-         id="path964-1-7-1"
-         inkscape:connector-curvature="0" />
+         d="m 247.78973,259.06168 -58.16888,-0.0674 V 51.54534 l 59.83429,-0.2166 c 10.39675,0.12515 15.59513,8.22114 15.59513,17.94885 v 170.99773 c 0.45245,10.68074 -6.60387,18.55532 -17.26054,18.78636 z"
+         fill="url(#a)"
+         id="path12"
+         style="display:inline;fill:url(#a);stroke-width:4.81331;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.135116;marker:none;enable-background:accumulate"
-         d="m 330.09375,134.60938 c -1.53776,0.11477 -3.25436,-0.13127 -4.6582,0.60546 -1.33891,1.34119 -0.66267,3.37044 -0.83594,5.0625 0.0321,6.28217 -0.21042,12.57402 0.0977,18.84961 0.0572,1.23796 1.04804,2.17067 2.29296,2.16602 4.54151,0.3923 9.11759,0.13946 13.67188,0.16211 1.87815,-0.15137 3.79774,0.23075 5.56641,-0.52344 1.15807,-1.01391 0.94154,-2.7281 1.1289,-4.11719 0.11466,-3.95496 0.16154,-7.92907 -0.10156,-11.87695 -0.35922,-1.32649 -1.77473,-2.02449 -2.60352,-3.04492 -2.49842,-2.28372 -4.75555,-4.88808 -7.54687,-6.82031 -1.44279,-0.81424 -3.21433,-0.25751 -4.80469,-0.45508 -0.73572,-0.009 -1.47126,-0.0141 -2.20703,-0.008 z"
-         id="rect4158-92-6-7-3"
-         inkscape:connector-curvature="0" />
+         d="m 155.74957,51.57903 79.47742,-7.451003 c 10.6326,-1.073368 15.27744,4.630407 15.35928,16.062023 l -0.67388,187.96466 C 249.71987,260.87149 244.03052,267.53311 232.81551,268 L 156.2694,259.06168 H 74.520105 c -10.44007,0 -21.04861,-8.50031 -21.10637,-21.74655 V 72.58915 c 0.3995,-15.23895 6.75308,-20.98124 21.99202,-21.26041 z"
+         fill="url(#b)"
+         id="path14"
+         style="display:inline;fill:url(#b);stroke-width:4.81331;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.135116;marker:none;enable-background:accumulate"
-         d="m 342.43453,133.5 c -0.0499,0 -0.0992,0.005 -0.14846,0.0114 -0.63275,0.19268 -0.84778,1.10823 -0.35998,1.53887 l 5.15449,4.82872 c 0.52901,0.47937 1.38249,0.0699 1.41036,-0.62634 v -1.36063 c 0.0226,-4.21424 0.33006,-4.29412 -3.66401,-4.38062 h -2.24263 c -0.0493,-0.007 -0.0999,-0.0114 -0.14977,-0.0114 z m -12.63559,0.0804 c -5.53701,-3.3e-4 -6.32794,0.58227 -6.29884,6.26467 v 8.19515 8.19514 c -0.0291,5.68242 1.00827,6.26467 6.54528,6.26467 h 11.7978 c 5.49726,0 6.52858,-0.57993 6.54266,-6.15295 v -11.14923 c -0.006,-1.25658 -1.15546,-2.31787 -2.08629,-3.11916 l -0.008,-0.006 -6.70166,-6.47491 c -1.50985,-1.36345 -2.55339,-2.01695 -4.61908,-2.01707 z m 7.22852,2.4196 8.97205,8.99977 v 13.00023 c 0,0 -0.11213,1.17819 -0.44846,1.49951 -0.33633,0.32134 -1.56951,0.42847 -1.56951,0.42847 h -15.96407 c 0,0 -1.23318,-0.10713 -1.56951,-0.42847 -0.33632,-0.32132 -0.44845,-1.49951 -0.44845,-1.49951 l -0.018,-20.07203 c 0,0 0.11213,-1.17819 0.44845,-1.49951 0.33637,-0.32133 1.56955,-0.42846 1.56955,-0.42846 z"
-         id="rect4158-92-6-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 249.9124,248.15471 c -0.19253,12.71678 -5.88187,19.3784 -17.09688,19.84529 l -77.41251,-9.0394 V 51.61273 l 79.82398,-7.484703 c 10.6326,-1.073368 15.27745,4.630407 15.35928,16.062023 z"
+         fill-opacity="0.15"
+         id="path16"
+         style="display:inline;stroke-width:4.81331;enable-background:new" />
       <path
-         style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 323.49951,148 v 0.041 8.19531 c -0.0291,5.68242 1.00791,6.26367 6.54492,6.26367 h 11.79883 c 5.49726,0 6.52889,-0.57932 6.54297,-6.15234 v -8.34764 z"
-         id="rect4398"
-         inkscape:connector-curvature="0" />
+         d="m 363.6711,105.16445 -11.9454,-0.0138 V 62.549489 l 12.2874,-0.04448 c 2.13505,0.0257 3.20257,1.688269 3.20257,3.685924 v 35.115607 c 0.0929,2.19337 -1.35615,3.81047 -3.54457,3.85791 z"
+         fill="url(#a)"
+         id="path487"
+         style="display:inline;fill:url(#linearGradient501);stroke-width:0.988448;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 353.50267,61.373185 c -0.13268,1.3e-4 -0.25604,0.01264 -0.36719,0.0293 l -0.0781,0.01172 -0.0762,0.02344 c -0.87574,0.279121 -1.39412,1.031903 -1.56445,1.792968 -0.1518,0.678132 0.0116,1.444638 0.51367,2.050782 l -0.36328,-0.363282 -0.01,-0.0078 -0.002,-0.0039 c 0,0 -0.002,0.0038 -0.002,0.0039 -0.28283,-0.267301 -0.55686,-0.524525 -0.83398,-0.767578 h -0.002 l -0.002,-0.0039 -0.002,-0.002 c 0,0 -0.006,-0.0019 -0.006,-0.002 -0.2711,-0.237536 -0.5406,-0.460957 -0.81055,-0.669923 0,0 -0.006,-0.0038 -0.006,-0.0039 -1.8e-4,-8.6e-5 -0.006,-0.0038 -0.006,-0.0039 -0.26922,-0.208011 -0.54257,-0.405967 -0.82617,-0.587891 h -0.002 l -0.002,-0.002 c 0,10e-7 -0.004,-0.0019 -0.004,-0.002 -0.27684,-0.177258 -0.55998,-0.341168 -0.85742,-0.488281 1e-5,0 -0.006,-0.0019 -0.006,-0.002 -0.29595,-0.146081 -0.60404,-0.275888 -0.92383,-0.386719 l -0.004,-0.002 h -0.002 -0.002 c -0.31787,-0.109783 -0.64897,-0.202793 -0.99414,-0.275391 0,-1e-6 -0.009,7.3e-5 -0.01,0 -0.34183,-0.07151 -0.69666,-0.126987 -1.07031,-0.162109 h -0.002 c -0.37669,-0.03533 -0.76878,-0.05072 -1.17774,-0.05078 h -0.002 -8.26738 c -4.1516,0 -6.86541,0.144562 -8.65234,1.832031 -0.89392,0.844181 -1.42053,2.015243 -1.71289,3.464843 -0.29235,1.449602 -0.3762,2.716182 -0.36524,4.956606 v 12.746094 12.751955 c -0.0108,2.23702 0.0732,4.00312 0.36524,5.45117 0.29236,1.44961 0.81896,2.62067 1.71289,3.46485 0.22046,0.20818 0.46372,0.3989 0.72656,0.5664 l 0.004,0.002 0.006,0.004 c 0,0 0.011,0.004 0.0117,0.004 0.24938,0.15738 0.51414,0.29744 0.79688,0.41797 l 0.006,0.002 c 10e-4,5.8e-4 0.003,0.003 0.004,0.004 h 0.002 c 0.001,2.9e-4 0.01,0.003 0.0117,0.004 0.28562,0.12045 0.58739,0.22665 0.90625,0.31446 h 0.002 0.002 c 0.31721,0.0872 0.65158,0.16192 1.00586,0.22265 h 0.004 0.002 0.002 c 0.35215,0.0602 0.71743,0.1063 1.10157,0.14453 2e-5,0 0.005,-1e-5 0.006,0 0.38435,0.0381 0.78775,0.0683 1.21289,0.0899 h 0.004 0.002 c 4.7e-4,1e-5 0.005,-1e-5 0.006,0 l 0.004,0.002 c 3.5e-4,1e-5 0.0746,-7e-5 0.0723,0 0.83602,0.0405 1.74479,0.0566 2.7539,0.0566 h 0.002 17.03691 c 4.12301,0 6.31689,-0.14165 8.10202,-1.80263 0.89298,-0.83017 1.42413,-1.9843 1.72461,-3.41016 0.30048,-1.42587 0.39703,-3.161323 0.40234,-5.359373 v -18.908211 -0.002 c -0.009,-1.901937 -1.18883,-3.38937 -2.32226,-4.541016 -0.37676,-0.382884 -0.75737,-0.733609 -1.10938,-1.050781 l -0.28515,-0.257813 h 0.0273 l -0.0117,-0.01172 h -0.002 l -0.0508,-0.05078 c 0.7203,0.562642 1.63962,0.613597 2.36523,0.31836 0.78035,-0.317514 1.50219,-1.045367 1.54102,-2.060547 v -0.01953 -2.13086 -0.0059 c 0.008,-1.627913 0.0362,-2.366723 -0.0274,-3.374573 -0.0638,-1.009375 -0.2058,-1.850441 -0.73633,-2.546875 -0.53053,-0.696434 -1.36221,-1.029213 -2.28515,-1.181641 -0.92293,-0.152428 -2.03533,-0.179157 -3.52344,-0.21289 h -0.0117 l -2.84421,-9.8e-5 h -0.002 c -0.073,-0.0069 -0.14393,-0.0174 -0.2207,-0.01758 z m -24.57206,43.876525 c 7.7e-4,4.2e-4 10e-4,0.002 0.002,0.002 -0.0334,0.003 -0.0689,0.006 -0.0684,0.006 5.2e-4,-8e-5 0.0335,-0.004 0.0664,-0.008 z m -0.0312,1.98438 c 0.005,2.6e-4 0.0335,0.004 0.0645,0.006 -0.0263,-10e-4 -0.0586,-0.004 -0.0586,-0.004 z"
-         id="path964-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccscccccccccccccccccccccccccccccccscsccccccccccccccccccsccccccccccccccc" />
+         d="m 344.77,62.556407 16.32125,-1.530116 c 2.18348,-0.220424 3.13733,0.950887 3.15415,3.298451 l -0.13839,38.599888 c -0.0395,2.61148 -1.20788,3.97949 -3.51097,4.07537 l -15.71929,-1.83555 h -16.78781 c -2.14393,0 -4.32248,-1.7456 -4.33434,-4.46581 V 66.870986 c 0.082,-3.129428 1.38679,-4.308648 4.51622,-4.365977 z"
+         fill="url(#b)"
+         id="path489"
+         style="display:inline;fill:url(#linearGradient499);stroke-width:0.988448;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6668);enable-background:accumulate"
-         d="m 102.92188,46 c -35.29673,0 -38.92188,3.625611 -38.92188,38.994141 v 71.005859 2 71.00586 c 0,15.47373 0.693319,24.87213 4.429688,30.54883 0.533765,0.81095 1.130124,1.54501 1.794921,2.21093 5.31838,5.32748 15.048901,6.23438 32.697271,6.23438 h 98.15624 c 2.05464,0 3.9874,-0.0148 5.83399,-0.0449 0.6589,-0.0108 1.26119,-0.0352 1.89453,-0.0508 1.14935,-0.0283 2.29189,-0.0591 3.35938,-0.10547 1.26994,-0.0552 2.50934,-0.11952 3.66796,-0.20508 0.47389,-0.035 0.93478,-0.0745 1.39063,-0.11523 0.22056,-0.0197 0.44963,-0.0375 0.66601,-0.0586 0.72759,-0.0709 1.43573,-0.14684 2.11719,-0.23437 0.66796,-0.0858 1.31051,-0.18193 1.93555,-0.28516 0.22197,-0.0367 0.43176,-0.0802 0.64844,-0.11914 0.39648,-0.0713 0.79087,-0.14326 1.16992,-0.22266 0.24847,-0.052 0.4874,-0.10842 0.72851,-0.16406 0.31951,-0.0737 0.63656,-0.15017 0.94336,-0.23047 0.25892,-0.0678 0.51169,-0.13834 0.76172,-0.21094 0.28349,-0.0823 0.56172,-0.16909 0.83399,-0.25781 0.22709,-0.074 0.45245,-0.1499 0.67187,-0.22851 0.28508,-0.10213 0.5616,-0.20821 0.83399,-0.31836 0.19615,-0.0793 0.39429,-0.15856 0.58398,-0.24219 0.27476,-0.12111 0.53736,-0.25048 0.79883,-0.38086 0.17443,-0.087 0.3548,-0.17048 0.52344,-0.26172 0.40967,-0.22161 0.80523,-0.45357 1.18164,-0.70117 0.40638,-0.26732 0.79483,-0.54837 1.16406,-0.84766 0.33966,-0.27532 0.65922,-0.56925 0.96875,-0.87304 0.0745,-0.0731 0.14592,-0.14979 0.21875,-0.22461 0.22962,-0.23599 0.45095,-0.48113 0.66406,-0.73438 0.077,-0.0915 0.15554,-0.18158 0.23047,-0.27539 0.54111,-0.67772 1.02765,-1.41677 1.46484,-2.2207 0.0553,-0.10155 0.10843,-0.20689 0.16211,-0.31055 0.15861,-0.30642 0.3098,-0.62208 0.45508,-0.94726 0.0614,-0.1373 0.12454,-0.27336 0.1836,-0.41407 0.1819,-0.4336 0.35679,-0.8789 0.51757,-1.3457 0.16052,-0.46603 0.30667,-0.95474 0.44727,-1.45508 0.0408,-0.14516 0.08,-0.29328 0.11914,-0.4414 0.0645,-0.24379 0.12339,-0.50007 0.18359,-0.75196 0.14384,-0.60169 0.27581,-1.22778 0.39649,-1.87695 0.0319,-0.17177 0.0674,-0.3385 0.0976,-0.51367 0.14069,-0.8111 0.26747,-1.65503 0.37696,-2.54102 0.022,-0.17777 0.0398,-0.36992 0.0605,-0.55078 0.0825,-0.71822 0.15576,-1.46049 0.22071,-2.22851 0.0255,-0.30185 0.0493,-0.60826 0.0723,-0.91797 0.057,-0.7684 0.10605,-1.56297 0.14844,-2.38086 0.0132,-0.25434 0.0311,-0.49859 0.043,-0.75782 0.007,-0.14749 0.009,-0.31184 0.0156,-0.46093 0.0622,-1.46308 0.10249,-3.01983 0.12891,-4.64063 0.007,-0.4186 0.0128,-0.84593 0.0176,-1.27539 0.0196,-1.77364 0.0291,-3.60559 0.0195,-5.57031 v -100.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67689,-10.56116 -18.05782,-15.619141 -32.66602,-15.619141 z m 96.98242,0.08984 c -2.16918,2.775877 -2.38539,7.403545 0.20898,9.912109 l 28.4961,30.386719 c 3.72376,3.695922 11.11845,0.568263 11.38085,-4.779297 -0.002,-0.42002 0.001,-0.861231 -0.002,-1.271484 -9e-4,-0.49135 -0.009,-0.953362 -0.0117,-1.431641 -0.36165,-27.253999 -4.96046,-32.190518 -31.3457,-32.816406 z"
-         id="path5316-1" />
+         d="m 364.10701,102.92463 c -0.0395,2.61148 -1.20788,3.97949 -3.51097,4.07537 l -15.89721,-1.85631 V 62.563328 l 16.39242,-1.537037 c 2.18348,-0.220424 3.13733,0.950887 3.15415,3.298451 z"
+         fill-opacity="0.15"
+         id="path491"
+         style="display:inline;stroke-width:0.988448;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6646);enable-background:accumulate"
-         d="m 102.92188,45 c -35.29673,0 -38.92188,3.625611 -38.92188,38.994141 v 72.005859 1 72.00586 c 0,15.47373 0.693319,24.87213 4.429688,30.54883 0.533765,0.81095 1.130124,1.54501 1.794921,2.21093 5.31838,5.32748 15.048901,6.23438 32.697271,6.23438 h 98.15624 c 2.05464,0 3.9874,-0.0148 5.83399,-0.0449 0.6589,-0.0108 1.26119,-0.0352 1.89453,-0.0508 1.14935,-0.0283 2.29189,-0.0591 3.35938,-0.10547 1.26994,-0.0552 2.50934,-0.11952 3.66796,-0.20508 0.47389,-0.035 0.93478,-0.0745 1.39063,-0.11523 0.22056,-0.0197 0.44963,-0.0375 0.66601,-0.0586 0.72759,-0.0709 1.43573,-0.14684 2.11719,-0.23437 0.66796,-0.0858 1.31051,-0.18193 1.93555,-0.28516 0.22197,-0.0367 0.43176,-0.0802 0.64844,-0.11914 0.39648,-0.0713 0.79087,-0.14326 1.16992,-0.22266 0.24847,-0.052 0.4874,-0.10842 0.72851,-0.16406 0.31951,-0.0737 0.63656,-0.15017 0.94336,-0.23047 0.25892,-0.0678 0.51169,-0.13834 0.76172,-0.21094 0.28349,-0.0823 0.56172,-0.16909 0.83399,-0.25781 0.22709,-0.074 0.45245,-0.1499 0.67187,-0.22851 0.28508,-0.10213 0.5616,-0.20821 0.83399,-0.31836 0.19615,-0.0793 0.39429,-0.15856 0.58398,-0.24219 0.27476,-0.12111 0.53736,-0.25048 0.79883,-0.38086 0.17443,-0.087 0.3548,-0.17048 0.52344,-0.26172 0.40967,-0.22161 0.80523,-0.45357 1.18164,-0.70117 0.40638,-0.26732 0.79483,-0.54837 1.16406,-0.84766 0.33966,-0.27532 0.65922,-0.56925 0.96875,-0.87304 0.0745,-0.0731 0.14592,-0.14979 0.21875,-0.22461 0.22962,-0.23599 0.45095,-0.48113 0.66406,-0.73438 0.077,-0.0915 0.15554,-0.18158 0.23047,-0.27539 0.54111,-0.67772 1.02765,-1.41677 1.46484,-2.2207 0.0553,-0.10155 0.10843,-0.20689 0.16211,-0.31055 0.15861,-0.30642 0.3098,-0.62208 0.45508,-0.94726 0.0614,-0.1373 0.12454,-0.27336 0.1836,-0.41407 0.1819,-0.4336 0.35679,-0.8789 0.51757,-1.3457 0.16052,-0.46603 0.30667,-0.95474 0.44727,-1.45508 0.0408,-0.14516 0.08,-0.29328 0.11914,-0.4414 0.0645,-0.24379 0.12339,-0.50007 0.18359,-0.75196 0.14384,-0.60169 0.27581,-1.22778 0.39649,-1.87695 0.0319,-0.17177 0.0674,-0.3385 0.0976,-0.51367 0.14069,-0.8111 0.26747,-1.65503 0.37696,-2.54102 0.022,-0.17777 0.0398,-0.36992 0.0605,-0.55078 0.0825,-0.71822 0.15576,-1.46049 0.22071,-2.22851 0.0255,-0.30185 0.0493,-0.60826 0.0723,-0.91797 0.057,-0.7684 0.10605,-1.56297 0.14844,-2.38086 0.0132,-0.25434 0.0311,-0.49859 0.043,-0.75782 0.007,-0.14749 0.009,-0.31184 0.0156,-0.46093 0.0622,-1.46308 0.10249,-3.01983 0.12891,-4.64063 0.007,-0.4186 0.0128,-0.84593 0.0176,-1.27539 0.0196,-1.77364 0.0291,-3.60559 0.0195,-5.57031 v -101.76563 c -0.044,-9.7329 -8.17907,-17.95561 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67689,-10.56116 -18.05782,-15.619141 -32.66602,-15.619141 z m 97.96874,0.08984 c -3.03973,2.502305 -3.72055,8.066242 -0.77734,10.912109 l 28.4961,30.386719 c 3.72891,3.701032 11.14177,0.560315 11.38476,-4.800781 -2.2e-4,-0.210853 -10e-4,-0.418504 -0.002,-0.626953 -1e-4,-1.198304 -0.0128,-2.328552 -0.0254,-3.451172 -0.40326,-26.889233 -5.08512,-31.797223 -31.33594,-32.419922 z"
-         id="path5316-84" />
+         d="m 348.82895,161.8029 -7.79048,-0.009 v -27.78336 l 8.01352,-0.029 c 1.39243,0.0168 2.08864,1.10104 2.08864,2.40386 v 22.90148 c 0.0606,1.43046 -0.88445,2.48509 -2.31168,2.51603 z"
+         fill="url(#a)"
+         id="path503"
+         style="display:inline;fill:url(#linearGradient517);stroke-width:0.64464;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -2.17574,0 -4.226351,0.01468 -6.167974,0.04883 -29.48187,0.527845 -32.667968,5.787316 -32.667968,38.945313 v 73.005857 73.00586 c 0,33.158 3.186098,38.41747 32.667968,38.94531 1.941623,0.0342 3.992234,0.0488 6.167974,0.0488 0.0303,10e-6 0.0556,0 0.0859,0 h 98.07031 c 2.05464,0 3.9874,-0.0148 5.83399,-0.0449 0.6589,-0.0108 1.26119,-0.0352 1.89453,-0.0508 1.14935,-0.0283 2.29189,-0.0591 3.35938,-0.10547 1.26994,-0.0552 2.50934,-0.11952 3.66796,-0.20508 0.47389,-0.035 0.93478,-0.0745 1.39063,-0.11523 0.22056,-0.0197 0.44963,-0.0375 0.66601,-0.0586 0.72759,-0.0709 1.43573,-0.14684 2.11719,-0.23437 0.66796,-0.0858 1.31051,-0.18193 1.93555,-0.28516 0.22197,-0.0367 0.43176,-0.0802 0.64844,-0.11914 0.39648,-0.0713 0.79087,-0.14326 1.16992,-0.22266 0.24847,-0.052 0.4874,-0.10842 0.72851,-0.16406 0.31951,-0.0737 0.63656,-0.15017 0.94336,-0.23047 0.25892,-0.0678 0.51169,-0.13834 0.76172,-0.21094 0.28349,-0.0823 0.56172,-0.16909 0.83399,-0.25781 0.22709,-0.074 0.45245,-0.1499 0.67187,-0.22851 0.28508,-0.10213 0.5616,-0.20821 0.83399,-0.31836 0.19615,-0.0793 0.39429,-0.15856 0.58398,-0.24219 0.27476,-0.12111 0.53736,-0.25048 0.79883,-0.38086 0.17443,-0.087 0.3548,-0.17048 0.52344,-0.26172 0.40967,-0.22161 0.80523,-0.45357 1.18164,-0.70117 0.40638,-0.26732 0.79483,-0.54837 1.16406,-0.84766 0.33966,-0.27532 0.65922,-0.56925 0.96875,-0.87304 0.0745,-0.0731 0.14592,-0.14979 0.21875,-0.22461 0.22962,-0.23599 0.45095,-0.48113 0.66406,-0.73438 0.077,-0.0915 0.15554,-0.18158 0.23047,-0.27539 0.54111,-0.67772 1.02765,-1.41677 1.46484,-2.2207 0.0553,-0.10155 0.10843,-0.20689 0.16211,-0.31055 0.15861,-0.30642 0.3098,-0.62208 0.45508,-0.94726 0.0614,-0.1373 0.12454,-0.27336 0.1836,-0.41407 0.1819,-0.4336 0.35679,-0.8789 0.51757,-1.3457 0.16052,-0.46603 0.30667,-0.95474 0.44727,-1.45508 0.0408,-0.14516 0.08,-0.29328 0.11914,-0.4414 0.0645,-0.24379 0.12339,-0.50007 0.18359,-0.75196 0.14384,-0.60169 0.27581,-1.22778 0.39649,-1.87695 0.0319,-0.17177 0.0674,-0.3385 0.0976,-0.51367 0.14069,-0.8111 0.26747,-1.65503 0.37696,-2.54102 0.022,-0.17777 0.0398,-0.36992 0.0605,-0.55078 0.0825,-0.71822 0.15576,-1.46049 0.22071,-2.22851 0.0255,-0.30185 0.0493,-0.60826 0.0723,-0.91797 0.057,-0.7684 0.10605,-1.56297 0.14844,-2.38086 0.0132,-0.25434 0.0311,-0.49859 0.043,-0.75782 0.007,-0.14749 0.009,-0.31184 0.0156,-0.46093 0.0622,-1.46308 0.10249,-3.01983 0.12891,-4.64063 0.007,-0.4186 0.0128,-0.84593 0.0176,-1.27539 0.0196,-1.77364 0.0291,-3.60559 0.0195,-5.57031 v -102.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408197 c -10.67684,-10.56116 -18.05782,-15.619141 -32.66602,-15.619141 z m 99.73242,0.08984 c -4.47461,1.4924 -5.99062,8.576599 -2.54102,11.912109 l 28.4961,30.386719 c 3.73355,3.705631 11.16128,0.552964 11.38671,-4.820313 0.0482,-31.329014 -3.55328,-36.818783 -31.36523,-37.478515 z"
-         id="path5316-3" />
+         d="m 336.50215,134.01505 10.64429,-0.9979 c 1.42401,-0.14376 2.04608,0.62014 2.05705,2.15116 l -0.0902,25.17384 c -0.0258,1.70314 -0.78775,2.59532 -2.28976,2.65785 l -10.25171,-1.1971 h -10.94858 c -1.39821,0 -2.81901,-1.13843 -2.82673,-2.91248 V 136.8289 c 0.0535,-2.04093 0.90443,-2.80998 2.94536,-2.84737 z"
+         fill="url(#b)"
+         id="path505"
+         style="display:inline;fill:url(#linearGradient515);stroke-width:0.64464;enable-background:new" />
       <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
+         d="m 349.11324,160.34215 c -0.0258,1.70314 -0.78775,2.59532 -2.28976,2.65785 l -10.36775,-1.21064 v -27.7698 l 10.69071,-1.00241 c 1.42401,-0.14376 2.04608,0.62014 2.05705,2.15116 z"
+         fill-opacity="0.15"
+         id="path507"
+         style="display:inline;stroke-width:0.64464;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44.000001 c -35.29672,0 -38.92188,3.62561 -38.92188,38.99414 v 73.005859 73.00586 c 0,35.36853 3.62516,38.99414 38.92188,38.99414 h 98.15625 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 v -102.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67686,-10.56118 -18.05785,-15.61912 -32.66605,-15.61912 z"
-         id="path5316"
-         inkscape:connector-curvature="0" />
+         d="m 341.40787,210.12213 -5.71302,-0.007 v -20.37447 l 5.87658,-0.0213 c 1.02112,0.0123 1.53167,0.80743 1.53167,1.76283 v 16.79442 c 0.0444,1.049 -0.6486,1.8224 -1.69523,1.84509 z"
+         fill="url(#a)"
+         id="path519"
+         style="display:inline;fill:url(#linearGradient533);stroke-width:0.472736;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 v 2.89258 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 0.0896,-0.53386 0.10352,-1.11551 0.10352,-1.83594 v -3.89844 -2.89844 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 -0.5334,-0.0898 -1.11494,-0.10352 -1.83398,-0.10352 z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
+         d="m 332.36821,189.74437 7.80582,-0.73179 c 1.04427,-0.10543 1.50046,0.45477 1.5085,1.57751 l -0.0661,18.46082 c -0.0189,1.24897 -0.57768,1.90324 -1.67915,1.94909 l -7.51793,-0.87787 h -8.02895 c -1.02536,0 -2.06728,-0.83485 -2.07294,-2.13582 v -16.17845 c 0.0392,-1.49668 0.66325,-2.06065 2.15993,-2.08807 z"
+         fill="url(#b)"
+         id="path521"
+         style="display:inline;fill:url(#linearGradient531);stroke-width:0.472736;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 336.33594,62.601562 c -2.69598,0.180155 -5.69746,-0.446231 -8.12696,1.025391 -1.97543,1.787488 -1.36873,4.690349 -1.54296,7.054688 -0.0459,9.970718 -0.22715,19.947744 0.0273,29.916019 0.10954,1.8029 0.81822,4.03547 2.86523,4.4082 2.57246,0.50241 5.21592,0.22602 7.82813,0.36133 6.66188,0.0262 13.39064,0.15688 20.00195,-0.13281 1.60814,-0.14431 3.19377,-1.07415 3.59766,-2.73047 0.60884,-3.210246 0.30931,-6.467884 0.43359,-9.732426 0.0328,-5.057228 0.0598,-10.114629 0.0899,-15.171875 -1.06525,-2.408432 -3.31113,-3.992777 -5.0293,-5.908203 -2.89474,-2.759602 -5.55114,-5.810351 -8.75195,-8.226562 -1.76703,-1.252059 -3.89457,-0.684517 -5.90235,-0.855469 -1.82989,-0.01151 -3.66031,-0.01001 -5.49023,-0.0078 z"
-         id="path964"
-         inkscape:connector-curvature="0" />
+         d="m 341.61635,209.05091 c -0.0189,1.24897 -0.57769,1.90324 -1.67916,1.94909 l -7.60302,-0.8878 v -20.36452 l 7.83986,-0.7351 c 1.04427,-0.10543 1.50046,0.45477 1.5085,1.57751 z"
+         fill-opacity="0.15"
+         id="path523"
+         style="display:inline;stroke-width:0.472736;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.205504;marker:none;enable-background:accumulate"
-         d="m 353.5,61.375 c -0.0742,0 -0.1474,0.0066 -0.2207,0.01758 -0.94065,0.29981 -1.26034,1.724451 -0.53516,2.394531 l 7.51367,7.513672 c 0.78643,0.74591 2.35309,0.108771 2.39453,-0.974609 v -2.117188 c 0.0336,-6.55752 0.34204,-6.681806 -5.5957,-6.816406 h -3.33398 c -0.0733,-0.0113 -0.14848,-0.01758 -0.22266,-0.01758 z m -18.26953,0.125 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 v 12.751953 12.751953 c -0.0433,8.842037 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70563,-0.9024 9.72656,-9.574219 v -18.904297 c -0.009,-1.95527 -1.71775,-3.606675 -3.10156,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 c -2.24459,-2.121578 -3.79625,-3.138638 -6.8672,-3.138638 z m 11.26953,3.5 12.5,12.5 v 22.5 c 0,0 -0.1667,1.8333 -0.6667,2.3333 -0.5,0.5 -2.3333,0.6667 -2.3333,0.6667 h -24 c 0,0 -1.8333,-0.1667 -2.3333,-0.6667 -0.5,-0.5 -0.6667,-2.3333 -0.6667,-2.3333 v -32 c 0,0 0.1667,-1.8333 0.6667,-2.3333 0.5,-0.5 2.3333,-0.6667 2.3333,-0.6667 z"
-         id="rect4158-92-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 333.98684,250.44136 -3.63555,-0.004 v -12.96557 l 3.73964,-0.0135 c 0.6498,0.008 0.9747,0.51382 0.9747,1.1218 v 10.68736 c 0.0283,0.66754 -0.41275,1.15971 -1.07879,1.17415 z"
+         fill="url(#a)"
+         id="path535"
+         style="display:inline;fill:url(#linearGradient549);stroke-width:0.300832;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.90435,236.5 c 0.71048,0 1.27344,0.0154 1.75195,0.0957 0.47851,0.0803 0.89671,0.23728 1.20703,0.54688 0.31032,0.30959 0.46726,0.7261 0.54688,1.20508 0.0796,0.47897 0.0933,1.04352 0.0898,1.75586 v 3.89648 3.89844 c 0.003,0.71121 -0.0103,1.27546 -0.0898,1.7539 -0.0796,0.47898 -0.23655,0.89549 -0.54688,1.20508 -0.31033,0.3096 -0.72851,0.46655 -1.20703,0.54688 -0.47852,0.0803 -1.04147,0.0957 -1.75195,0.0957 h -5.8086 c -0.71048,0 -1.27236,-0.0153 -1.75,-0.0957 -0.47763,-0.0804 -0.89584,-0.23713 -1.20508,-0.54688 -0.30921,-0.30975 -0.46469,-0.72681 -0.54492,-1.20508 -0.0802,-0.47826 -0.0957,-1.04201 -0.0957,-1.7539 v -3.89844 -3.89844 c 0,-0.71189 0.0155,-1.27564 0.0957,-1.7539 0.0802,-0.47827 0.2357,-0.89533 0.54492,-1.20508 0.30924,-0.30975 0.72745,-0.4665 1.20508,-0.54688 0.47764,-0.0804 1.03952,-0.0957 1.75,-0.0957 z"
-         id="path918"
-         inkscape:connector-curvature="0" />
+         d="m 328.23433,237.47369 4.96734,-0.46568 c 0.66454,-0.0671 0.95484,0.2894 0.95996,1.00387 l -0.0421,11.74779 c -0.012,0.7948 -0.36761,1.21116 -1.06855,1.24033 l -4.78413,-0.55864 h -5.10934 c -0.6525,0 -1.31554,-0.53127 -1.31914,-1.35916 v -10.29538 c 0.0249,-0.95243 0.42207,-1.31132 1.3745,-1.32877 z"
+         fill="url(#b)"
+         id="path537"
+         style="display:inline;fill:url(#linearGradient547);stroke-width:0.300832;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 336.13453,188.5 c 1.11158,0 1.98683,0.0256 2.70703,0.14648 0.72019,0.1209 1.3105,0.34863 1.74218,0.7793 0.43169,0.43067 0.65954,1.01974 0.7793,1.74024 0.11977,0.72049 0.14217,1.59669 0.13672,2.71093 v 6.12305 6.125 c 0.005,1.1131 -0.017,1.989 -0.13672,2.70898 -0.11976,0.72051 -0.3476,1.30957 -0.7793,1.74024 -0.43169,0.43067 -1.02199,0.6584 -1.74218,0.7793 -0.7202,0.12089 -1.59545,0.14648 -2.70703,0.14648 h -8.26954 c -1.11158,0 -1.98637,-0.0255 -2.70507,-0.14648 -0.7187,-0.12095 -1.30623,-0.34848 -1.73633,-0.7793 -0.4301,-0.43083 -0.6566,-1.01849 -0.77735,-1.73828 -0.12074,-0.71979 -0.14648,-1.59713 -0.14648,-2.71094 v -6.125 -6.125 c 0,-1.11381 0.0257,-1.99115 0.14648,-2.71094 0.12075,-0.71979 0.34725,-1.30745 0.77735,-1.73828 0.4301,-0.43082 1.01763,-0.65835 1.73633,-0.7793 0.7187,-0.12094 1.59349,-0.14648 2.70507,-0.14648 z"
-         id="path914"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1309);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0962,238 c -0.6888,0 -1.1839,0.0205 -1.5039,0.0742 -0.30449,0.0511 -0.38369,0.11806 -0.39649,0.13086 -0.0131,0.0131 -0.0746,0.0855 -0.125,0.38867 -0.0529,0.31839 -0.0733,0.81274 -0.0703,1.50195 v 0.004 3.90039 3.90234 0.002 c -0.003,0.68916 0.0176,1.18495 0.0703,1.50195 0.0504,0.30317 0.1119,0.37557 0.125,0.38867 0.0128,0.0128 0.0918,0.0798 0.39649,0.13086 0.32002,0.0537 0.8151,0.0742 1.5039,0.0742 h 5.8086 c 0.68894,0 1.18348,-0.0206 1.50195,-0.0742 0.30433,-0.0512 0.38043,-0.1186 0.39063,-0.1289 0.0112,-0.0112 0.0774,-0.0858 0.1289,-0.39258 0.0536,-0.31974 0.0742,-0.81575 0.0742,-1.50586 v -3.89855 -3 l -3,-3 z"
-         id="path1291" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1311);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86573,190 c -1.08855,0 -1.90034,0.0312 -2.45898,0.125 -0.54887,0.0921 -0.79683,0.22878 -0.93164,0.36328 -0.13436,0.13404 -0.26642,0.37645 -0.35742,0.92383 -0.0925,0.55627 -0.12219,1.36674 -0.11719,2.45703 v 0.004 6.12695 6.12891 0.002 c -0.005,1.0898 0.0249,1.9019 0.11719,2.45703 0.091,0.5474 0.22306,0.78979 0.35742,0.92383 0.13484,0.13452 0.38277,0.27118 0.93164,0.36328 0.55862,0.0938 1.37043,0.125 2.45898,0.125 h 8.26954 c 1.08864,0 1.90078,-0.0314 2.45703,-0.125 0.54703,-0.0921 0.78777,-0.227 0.92187,-0.36133 0.13429,-0.13451 0.26913,-0.37646 0.36133,-0.92578 0.0936,-0.55811 0.125,-1.37233 0.125,-2.46303 v -6.125 -3 l -7.0005,-7 z"
-         id="path1293"
-         sodipodi:nodetypes="scccccccccccsscccscccs" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 323.0005,200 v 6.125 c -0.0217,4.42101 0.45314,4.875 4.86523,4.875 h 8.26954 c 4.41209,0 4.86523,-0.45393 4.86523,-4.875 v -6.125 z"
-         id="path1007"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 322.0005,244 v 3.89844 c -0.0138,2.81337 0.28801,3.10156 3.0957,3.10156 h 5.8086 c 2.8077,0 3.0957,-0.28815 3.0957,-3.10156 v -3.89844 z"
-         id="path1016"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 325.50195,84 v 12.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 v -12.925781 z"
-         id="path964-0"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18820-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -12.133256,0 -20.524924,0.428807 -26.312505,2.427734 -2.103582,0.726592 -3.86351,1.661084 -5.333984,2.857422 -6.99e-4,5.68e-4 -0.0013,0.0014 -0.002,0.002 -1.102245,0.897465 -2.04362,1.942559 -2.84375,3.158203 -0.25536,0.38797 -0.493017,0.797219 -0.720704,1.220704 -0.05742,0.106782 -0.110296,0.220977 -0.166015,0.330078 -0.160525,0.314347 -0.31609,0.634772 -0.462891,0.96875 -0.07313,0.166359 -0.141108,0.340381 -0.210937,0.511718 -0.121003,0.2969 -0.240173,0.598017 -0.351563,0.910157 -0.07072,0.198194 -0.138107,0.401007 -0.205078,0.605469 -0.09969,0.304302 -0.195472,0.615147 -0.287109,0.933593 -0.06012,0.208926 -0.119021,0.41964 -0.175782,0.634766 -0.0932,0.353219 -0.18116,0.717644 -0.265625,1.087891 -0.04767,0.208948 -0.09564,0.414437 -0.140625,0.628906 -0.0813,0.387531 -0.155661,0.791385 -0.228515,1.197265 -0.03799,0.21171 -0.08141,0.416025 -0.117188,0.632813 -0.10327,0.625522 -0.197396,1.268747 -0.283203,1.9375 -8.5e-5,6.6e-4 8.5e-5,0.0013 0,0.002 -0.08424,0.656719 -0.159764,1.339307 -0.228515,2.039063 -0.02783,0.283412 -0.05073,0.582421 -0.07617,0.873046 -0.03812,0.435294 -0.0744,0.872494 -0.107422,1.324219 -0.08166,1.116973 -0.143662,2.302819 -0.197266,3.523438 -0.05039,1.146541 -0.08575,2.367502 -0.115234,3.609375 -0.01378,0.580741 -0.03511,1.124373 -0.04492,1.726562 -0.03028,1.853743 -0.04492,3.787114 -0.04492,5.851563 v 73.005855 73.00586 c 0,2.06445 0.01464,3.99782 0.04492,5.85156 0.0098,0.60219 0.03114,1.14582 0.04492,1.72656 0.02949,1.24188 0.06484,2.46284 0.115234,3.60938 0.0536,1.22062 0.115607,2.40646 0.197266,3.52344 0.03302,0.45172 0.0693,0.88892 0.107422,1.32422 0.02544,0.29062 0.04834,0.58963 0.07617,0.87304 0.06875,0.69976 0.144274,1.38235 0.228515,2.03906 8e-5,6.3e-4 -8e-5,10e-4 0,0.002 0.08581,0.66875 0.179933,1.31198 0.283203,1.9375 0.03578,0.21679 0.0792,0.4211 0.117188,0.63281 0.07285,0.40588 0.147218,0.80973 0.228515,1.19727 0.04498,0.21447 0.09296,0.41995 0.140625,0.6289 0.08446,0.37025 0.172428,0.73467 0.265625,1.08789 0.05676,0.21513 0.115665,0.42584 0.175782,0.63477 0.09164,0.31845 0.187417,0.62929 0.287109,0.93359 0.06697,0.20446 0.134353,0.40728 0.205078,0.60547 0.11139,0.31214 0.23056,0.61326 0.351563,0.91016 0.06983,0.17134 0.137808,0.34536 0.210937,0.51172 0.146801,0.33397 0.302366,0.6544 0.462891,0.96875 0.05572,0.1091 0.108595,0.22329 0.166015,0.33007 0.227687,0.42349 0.465344,0.83274 0.720704,1.22071 0.533766,0.81095 1.130124,1.545 1.794921,2.21093 0.332399,0.33297 0.681104,0.64798 1.048829,0.94727 7.16e-4,5.8e-4 0.0012,0.001 0.002,0.002 1.470474,1.19634 3.230402,2.13083 5.333984,2.85743 5.787581,1.99892 14.179249,2.42773 26.312505,2.42773 h 98.15624 c 2.05728,0 3.98527,-0.0147 5.83399,-0.0449 0.0115,-1.9e-4 0.0217,2e-4 0.0332,0 0.64544,-0.0111 1.23908,-0.0355 1.86133,-0.0508 0.45706,-0.0113 0.88533,-0.0281 1.33594,-0.041 0.67375,-0.0212 1.37929,-0.0364 2.02344,-0.0644 0.007,-3e-4 0.0127,-0.002 0.0195,-0.002 1.25269,-0.0546 2.47469,-0.11709 3.61914,-0.20118 0.01,-7.3e-4 0.0193,-10e-4 0.0293,-0.002 0.47389,-0.035 0.93478,-0.0745 1.39063,-0.11523 0.011,-9.8e-4 0.0222,-9.9e-4 0.0332,-0.002 0.21035,-0.0186 0.42719,-0.0366 0.63281,-0.0566 0.72759,-0.0709 1.43573,-0.14684 2.11719,-0.23437 0.66835,-0.0858 1.31017,-0.18189 1.93555,-0.28516 0.002,-3.4e-4 0.004,-0.002 0.006,-0.002 0.21969,-0.0365 0.42791,-0.0786 0.64258,-0.11719 0.39648,-0.0713 0.79087,-0.14326 1.16992,-0.22266 0.23853,-0.0499 0.4679,-0.10473 0.69922,-0.1582 0.01,-0.002 0.0195,-0.004 0.0293,-0.006 0.31951,-0.0737 0.63656,-0.15017 0.94336,-0.23047 0.25225,-0.0661 0.49847,-0.13446 0.74219,-0.20508 0.007,-0.002 0.0129,-0.004 0.0195,-0.006 0.28349,-0.0823 0.56172,-0.16909 0.83399,-0.25781 0.22709,-0.074 0.45245,-0.1499 0.67187,-0.22851 0.14966,-0.0536 0.29192,-0.11216 0.4375,-0.16797 0.13234,-0.0505 0.267,-0.098 0.39649,-0.15039 0.0111,-0.005 0.0221,-0.009 0.0332,-0.0137 0.18519,-0.0748 0.37186,-0.14964 0.55078,-0.22852 0.16735,-0.0738 0.32551,-0.15417 0.48633,-0.23242 0.10425,-0.0496 0.21026,-0.0975 0.3125,-0.14844 0.007,-0.004 0.0142,-0.008 0.0215,-0.0117 0.16707,-0.0828 0.33885,-0.16289 0.5,-0.25 5e-4,-2.7e-4 0.001,2.7e-4 0.002,0 0.40967,-0.22161 0.80523,-0.45357 1.18164,-0.70117 0.78027,-0.51326 1.48668,-1.08669 2.13281,-1.7207 0.001,-10e-4 0.003,-0.003 0.004,-0.004 0.0711,-0.07 0.13943,-0.14323 0.20898,-0.21484 0.002,-0.002 0.004,-0.004 0.006,-0.006 0.22962,-0.23599 0.45095,-0.48113 0.66406,-0.73438 0.077,-0.0915 0.15554,-0.18158 0.23047,-0.27539 0.54111,-0.67772 1.02765,-1.41677 1.46484,-2.2207 0.0553,-0.10155 0.10843,-0.20689 0.16211,-0.31055 0.15861,-0.30642 0.3098,-0.62208 0.45508,-0.94726 0.0608,-0.13598 0.12307,-0.27089 0.18164,-0.41016 5.5e-4,-10e-4 0.001,-0.003 0.002,-0.004 0.1819,-0.4336 0.35679,-0.8789 0.51757,-1.3457 0.16046,-0.46586 0.30672,-0.95495 0.44727,-1.45508 5.5e-4,-0.002 0.001,-0.004 0.002,-0.006 0.0402,-0.14328 0.0786,-0.28942 0.11719,-0.43554 0.036,-0.13607 0.0678,-0.27901 0.10156,-0.41993 0.0274,-0.10971 0.0554,-0.22073 0.082,-0.33203 6.1e-4,-0.003 10e-4,-0.005 0.002,-0.008 0.14313,-0.59937 0.27435,-1.22269 0.39453,-1.86914 0.0258,-0.13905 0.0523,-0.27642 0.0781,-0.41602 0.006,-0.0333 0.0137,-0.0642 0.0195,-0.0976 1.1e-4,-6.1e-4 -1e-4,-10e-4 0,-0.002 0.14057,-0.81053 0.26755,-1.65373 0.37696,-2.53906 0.006,-0.0479 0.0102,-0.099 0.0156,-0.14844 0.0159,-0.1309 0.0297,-0.26977 0.0449,-0.40234 0.002,-0.0201 0.004,-0.0423 0.006,-0.0625 0.079,-0.69309 0.15019,-1.40716 0.21289,-2.14648 5.5e-4,-0.006 0.001,-0.0131 0.002,-0.0195 0.0255,-0.30185 0.0493,-0.60826 0.0723,-0.91797 0.057,-0.7684 0.10605,-1.56297 0.14844,-2.38086 0.008,-0.15603 0.0182,-0.31062 0.0273,-0.46485 0.005,-0.0998 0.011,-0.19246 0.0156,-0.29297 4.1e-4,-0.009 -3.8e-4,-0.0185 0,-0.0273 0.006,-0.12849 0.009,-0.2663 0.0137,-0.39648 5e-4,-0.0117 0.001,-0.0254 0.002,-0.0371 0.0622,-1.46308 0.10249,-3.01983 0.12891,-4.64063 1.8e-4,-0.0109 -1.8e-4,-0.0223 0,-0.0332 0.007,-0.40814 0.0129,-0.82391 0.0176,-1.24219 0.0196,-1.77364 0.0291,-3.60559 0.0195,-5.57031 v -102.76563 c -0.008,-1.82491 -0.30087,-3.5971 -0.81445,-5.3125 -0.34239,-1.14359 -0.78284,-2.26106 -1.30274,-3.35351 -2.85943,-6.00849 -8.11896,-11.22913 -12.64453,-15.4961 l -0.0488,-0.0508 -40.52343,-42.408195 c -10.67695,-10.56113 -18.05782,-15.619141 -32.66602,-15.619141 z m 99.73242,0.08984 c -4.47461,1.4924 -5.99062,8.576599 -2.54102,11.912109 l 28.4961,30.386719 c 3.73355,3.705631 11.16128,0.552964 11.38671,-4.820313 0.003,-1.914857 -0.01,-3.726528 -0.0391,-5.453125 -0.003,-0.166807 -0.009,-0.319279 -0.0117,-0.484375 -0.0297,-1.557123 -0.0723,-3.047825 -0.13672,-4.457031 -0.0471,-1.032097 -0.1048,-2.024485 -0.17382,-2.980469 -1.15298,-15.945663 -5.54827,-21.536882 -19.66211,-23.361328 -1.29676,-0.167627 -2.6748,-0.302733 -4.14063,-0.412109 -0.70955,-0.05295 -1.44245,-0.09955 -2.19336,-0.140625 -0.009,-4.69e-4 -0.0187,-0.0015 -0.0273,-0.002 -1.56796,-0.085 -3.22479,-0.145853 -4.98047,-0.1875 z m -83.08789,11.855468 c 11.374,0.004 22.6305,0.04069 33.89843,0.246094 7.23783,-0.38505 13.8662,3.453873 18.85547,8.408203 16.10538,15.96283 31.4077,32.714027 47.27735,48.910165 3.41618,3.87653 8.26302,7.7632 8.17382,13.40039 0.36199,29.857 0.15427,59.71908 0.10547,89.57812 -0.26479,10.25015 0.39558,20.69609 -0.9082,30.96484 -0.54694,2.35759 -0.53276,6.03581 -3.5625,6.6504 -7.58888,1.84983 -15.51088,1.47 -23.26758,1.69726 -35.546,0.1779 -71.4284,0.29873 -106.976561,-0.13672 -4.70492,-0.41462 -9.87979,0.006 -14.11914,-2.38476 -2.82731,-3.81876 -2.108913,-9.00357 -2.445313,-13.48438 -0.58273,-48.6454 -0.702174,-97.30598 -0.583984,-145.972658 0.28307,-10.716671 -0.493631,-21.76848 1.568359,-32.4375 0.30831,-3.27336 3.855494,-4.007957 6.496094,-4.410157 11.78749,-1.12799 23.780885,-0.867606 35.488285,-1.029297 z"
-         id="rect4158-92-3" />
+         d="m 334.11951,249.75967 c -0.012,0.7948 -0.36762,1.21116 -1.06855,1.24033 l -4.83829,-0.56496 V 237.4758 l 4.989,-0.46779 c 0.66454,-0.0671 0.95484,0.2894 0.95996,1.00387 z"
+         fill-opacity="0.15"
+         id="path539"
+         style="display:inline;stroke-width:0.300832;enable-background:new" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,156 v 73.00683 c -0.17299,35.36812 3.62515,38.99317 38.921885,38.99317 h 98.15624 c 35.29672,0 38.00361,-3.63655 38.92188,-38.99317 v -73.00683 z"
-         id="path4255"
-         sodipodi:nodetypes="ccssscc" />
+         d="m 165.40508,103.15849 c -4.25497,0 -7.81201,3.55704 -7.81201,7.81201 v 22.4878 l 8.72172,15.2245 v -36.80258 h 50.13065 v 42.82885 h -46.6795 l 5.00103,8.72172 h 42.57856 c 4.25497,0 7.82163,-3.56666 7.82163,-7.82163 V 110.9705 c 0,-4.25497 -3.56666,-7.81201 -7.82163,-7.81201 z"
+         id="path18"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,227.00586 v 2 c -0.17299,35.36812 3.62515,38.99414 38.921885,38.99414 h 98.15624 c 35.29672,0 38.00361,-3.63752 38.92188,-38.99414 v -2 c -0.91827,35.35662 -3.62516,38.99414 -38.92188,38.99414 h -98.15624 c -35.296735,0 -39.094875,-3.62602 -38.921885,-38.99414 z"
-         id="path945"
-         inkscape:connector-curvature="0" />
+         d="m 115.73169,112.69367 c -18.988515,0 -34.468135,15.48923 -34.468135,34.47294 0,18.98852 15.47962,34.47294 34.468135,34.47294 h 0.26474 l 5.44867,-9.36189 c -1.83869,0.41394 -3.74476,0.6498 -5.71341,0.6498 -14.27147,0 -25.746405,-11.47013 -25.746405,-25.7416 0,-14.27628 11.474935,-25.75603 25.746405,-25.75603 11.66747,0 21.46738,7.67242 24.65379,18.27133 1.65097,-3.24898 3.7977,-6.28618 5.65564,-8.91907 -5.84817,-10.75294 -17.25091,-18.07398 -30.30943,-18.07398 z"
+         id="path20"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.08;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 180.0004,268 60,-60 v 22.48388 c -0.0523,33.99581 -3.80268,37.51612 -38.1741,37.51612 z"
-         id="path4254"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccsc" />
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g64"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 753.5,86.503 c 3.866,0 7,-3.134 7,-7 0,-3.866 -3.134,-7 -7,-7 -3.866,0 -7,3.134 -7,7 0,3.866 3.134,7 7,7 z"
-           style="fill:url(#_Linear9);fill-rule:nonzero;stroke:#cb851d;stroke-width:1px"
-           id="path62" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g68"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 753.5,85.004 c 3.038,0 5.5,-2.462 5.5,-5.5 0,-3.037 -2.462,-5.5 -5.5,-5.5 -3.038,0 -5.5,2.463 -5.5,5.5 0,3.038 2.462,5.5 5.5,5.5 z"
-           style="fill:#f0c46f;fill-opacity:0.6;fill-rule:nonzero"
-           id="path66" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g72"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="758.5"
-           y="76.5"
-           width="11"
-           height="11"
-           style="fill:url(#_Linear10);fill-rule:nonzero;stroke:#876900;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round"
-           id="rect70" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g76"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="760"
-           y="78"
-           width="8"
-           height="8"
-           style="fill:#c99c00;fill-opacity:0.6;fill-rule:nonzero"
-           id="rect74" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g80"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 761.624,89.452 c 0.82,1.332 -0.138,3.048 -1.703,3.048 h -8.842 c -1.564,0 -2.523,-1.716 -1.703,-3.048 l 4.421,-7.184 c 0.781,-1.269 2.625,-1.269 3.406,0 z"
-           style="fill:url(#_Linear11);fill-rule:nonzero;stroke:#c99c00;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round"
-           id="path78" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g84"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 761.331,91.5 h -11.662 l 5.831,-9.5 z"
-           style="fill:#f5ce53;fill-opacity:0.6;fill-rule:nonzero"
-           id="path82" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g88"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 760.43,87.5 h 9.07 v -11 h -11 l 0.07,8 z"
-           style="fill:none;fill-rule:nonzero;stroke:#876900;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round"
-           id="path86" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g92"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 745.492,237.487 -5.5,5 h 5.5 z"
-           style="fill:#f7d260;fill-rule:nonzero;stroke:#e9b913;stroke-width:1px;stroke-linejoin:round"
-           id="path90" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g96"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 745.336,237 c -0.071,0.027 -0.136,0.069 -0.188,0.125 l -5.5,5 c -0.158,0.139 -0.211,0.362 -0.134,0.558 0.076,0.196 0.268,0.322 0.478,0.317 h 5.5 c 0.276,0 0.5,-0.224 0.5,-0.5 v -5 c 0.008,-0.165 -0.065,-0.323 -0.196,-0.423 -0.132,-0.1 -0.304,-0.129 -0.46,-0.077 z m -0.344,1.625 v 3.375 h -3.719 z"
-           style="fill:#c99c00;fill-rule:nonzero"
-           id="path94" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g100"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 739.36,240.845 c -0.36,-0.314 -0.623,-0.723 -0.758,-1.181 -0.135,-0.458 -0.136,-0.945 -0.004,-1.404 0.132,-0.459 0.393,-0.87 0.751,-1.186 0.357,-0.316 0.798,-0.523 1.27,-0.597 0.471,-0.074 0.954,-0.012 1.392,0.179 0.437,0.191 0.811,0.503 1.078,0.899"
-           style="fill:#f0c46f;fill-rule:nonzero"
-           id="path98" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g104"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 739.36,240.845 c -0.36,-0.314 -0.623,-0.723 -0.758,-1.181 -0.135,-0.458 -0.136,-0.945 -0.004,-1.404 0.132,-0.459 0.393,-0.87 0.751,-1.186 0.357,-0.316 0.798,-0.523 1.27,-0.597 0.471,-0.074 0.954,-0.012 1.392,0.179 0.437,0.191 0.811,0.503 1.078,0.899"
-           style="fill:none;fill-rule:nonzero;stroke:#cb851d;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round"
-           id="path102" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g108"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 746.992,147.5 c 2.485,0 4.5,-2.015 4.5,-4.5 0,-2.485 -2.015,-4.5 -4.5,-4.5 -2.485,0 -4.5,2.015 -4.5,4.5 0,2.485 2.015,4.5 4.5,4.5 z"
-           style="fill:url(#_Linear12);fill-rule:nonzero;stroke:#cb851d;stroke-width:1px"
-           id="path106" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g112"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 746.991,146 c 1.657,0 3,-1.343 3,-3 0,-1.657 -1.343,-3 -3,-3 -1.656,0 -3,1.343 -3,3 0,1.657 1.344,3 3,3 z"
-           style="fill:#f0c46f;fill-opacity:0.6;fill-rule:nonzero"
-           id="path110" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g116"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 756.492,147.5 h -5 c -0.552,0 -1,-0.448 -1,-1 v -5 c 0,-0.552 0.448,-1 1,-1 h 5 c 0.552,0 1,0.448 1,1 v 5 c 0,0.552 -0.448,1 -1,1 z"
-           style="fill:#c99c00;fill-rule:nonzero;stroke:#876900;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round"
-           id="path114" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g120"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 752.456,148.945 c 0.443,0.665 -0.034,1.555 -0.832,1.555 h -7.432 c -0.763,0 -1.245,-0.819 -0.875,-1.486 l 3.379,-6.08 c 0.363,-0.655 1.291,-0.692 1.706,-0.069 z"
-           style="fill:url(#_Linear13);fill-rule:nonzero;stroke:#c99c00;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round"
-           id="path118" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g124"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 750.992,149 h -6 l 2.5,-5 z"
-           style="fill:#f5ce53;fill-opacity:0.6;fill-rule:nonzero"
-           id="path122" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g128"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 744.992,197.5 c 2.485,0 4.5,-2.015 4.5,-4.5 0,-2.485 -2.015,-4.5 -4.5,-4.5 -2.485,0 -4.5,2.015 -4.5,4.5 0,2.485 2.015,4.5 4.5,4.5 z"
-           style="fill:url(#_Linear14);fill-rule:nonzero;stroke:#cb851d;stroke-width:1px"
-           id="path126" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g132"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 744.991,196 c 1.657,0 3,-1.343 3,-3 0,-1.657 -1.343,-3 -3,-3 -1.656,0 -3,1.343 -3,3 0,1.657 1.344,3 3,3 z"
-           style="fill:#f0c46f;fill-opacity:0.6;fill-rule:nonzero"
-           id="path130" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g136"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 751.492,200.5 h -11 l 5,-9 z"
-           style="fill:url(#_Linear15);fill-rule:nonzero;stroke:#c99c00;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round"
-           id="path134" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g140"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 748.992,199 h -6 l 2.5,-5 z"
-           style="fill:#f5ce53;fill-opacity:0.6;fill-rule:nonzero"
-           id="path138" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g216"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 543.507,190.517 c 19.33,0 35,-15.67 35,-35 0,-19.33 -15.67,-35 -35,-35 -19.33,0 -35,15.67 -35,35 0,19.33 15.67,35 35,35 z"
-           style="fill:url(#_Linear22);fill-rule:nonzero;stroke:#cb851d;stroke-width:5px"
-           id="path214" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g220"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 543.508,183.021 c 15.188,0 27.5,-12.312 27.5,-27.5 0,-15.187 -12.312,-27.5 -27.5,-27.5 -15.187,0 -27.5,12.313 -27.5,27.5 0,15.188 12.313,27.5 27.5,27.5 z"
-           style="fill:#f0c46f;fill-opacity:0.6;fill-rule:nonzero"
-           id="path218" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g224"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 614.508,195.5 h -37 c -4.97,0 -9,-4.029 -9,-9 v -37 c 0,-4.971 4.03,-9 9,-9 h 37 c 4.971,0 9,4.029 9,9 v 37 c 0,4.971 -4.029,9 -9,9 z"
-           style="fill:url(#_Linear23);fill-rule:nonzero;stroke:#876900;stroke-width:5px;stroke-linecap:round;stroke-linejoin:round"
-           id="path222" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g228"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 609.008,148 h -26 c -3.866,0 -7,3.134 -7,7 v 26 c 0,3.866 3.134,7 7,7 h 26 c 3.866,0 7,-3.134 7,-7 v -26 c 0,-3.866 -3.134,-7 -7,-7 z"
-           style="fill:#c99c00;fill-opacity:0.6;fill-rule:nonzero"
-           id="path226" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g232"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 585.067,206.783 c 3.69,5.997 -0.624,13.717 -7.665,13.717 h -47.787 c -7.041,0 -11.356,-7.72 -7.665,-13.717 l 23.894,-38.828 c 3.514,-5.71 11.815,-5.71 15.329,10e-4 z"
-           style="fill:url(#_Linear24);fill-rule:nonzero;stroke:#c99c00;stroke-width:5px;stroke-linecap:round;stroke-linejoin:round"
-           id="path230" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g236"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 578.923,209.408 c 1.636,2.665 -0.281,6.092 -3.409,6.092 h -44.011 c -3.128,0 -5.045,-3.427 -3.409,-6.092 l 22.005,-35.854 c 1.562,-2.543 5.257,-2.543 6.819,0 z"
-           style="fill:#f5ce53;fill-opacity:0.6;fill-rule:nonzero"
-           id="path234" />
-      </g>
-      <g
-         transform="translate(-414.007,5.997)"
-         id="g240"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 575.519,191.242 c 1.641,2.648 4.534,4.258 7.649,4.258 h 31.34 c 4.971,0 9,-4.029 9,-9 v -37 c 0,-4.971 -4.029,-9 -9,-9 h -36.92 c -5.002,0 -9.044,4.078 -9,9.079 l 0.248,28.4 c 0.015,1.649 0.482,3.262 1.351,4.664 z"
-           style="fill:none;fill-rule:nonzero;stroke:#876900;stroke-width:5px;stroke-linecap:round;stroke-linejoin:round"
-           id="path238" />
-      </g>
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline">
+         d="m 148.84247,138.24273 c -0.45726,0.34656 -0.84714,0.78457 -1.13594,1.28034 l -34.07825,58.59245 c -0.38507,0.66424 -0.59204,1.42474 -0.59204,2.19487 0,2.3874 1.96383,4.35605 4.35605,4.36086 l 67.77625,0.21179 h 0.0144 c 2.39221,0 4.36086,-1.96865 4.36086,-4.36086 0,-0.76532 -0.19735,-1.51138 -0.5776,-2.17562 l -33.70281,-58.79942 c -0.77494,-1.35736 -2.22375,-2.19488 -3.78327,-2.19488 -0.95303,0 -1.87719,0.31287 -2.63769,0.89047 z m 2.61363,12.19693 26.18923,45.69759 -52.67689,-0.15884 26.48766,-45.53394 z"
+         id="path22"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23242,61.5 c -4.11577,0 -6.55968,0.226752 -7.96875,1.558594 -0.28725,0.271486 -0.52183,0.601863 -0.72851,0.972656 -0.0468,0.08393 -0.10154,0.156606 -0.14454,0.246094 -2.5e-4,5.28e-4 2.6e-4,0.0014 0,0.002 -0.11616,0.241982 -0.2184,0.50414 -0.30859,0.789062 -0.0904,0.285534 -0.16955,0.593694 -0.23633,0.925782 -0.0668,0.332095 -0.1223,0.688232 -0.16797,1.070312 -0.0913,0.764147 -0.1422,1.632501 -0.16406,2.617188 -0.0109,0.492345 -0.0144,1.013779 -0.0117,1.566406 v 12.751906 12.751953 c -0.003,0.552627 8e-4,1.074061 0.0117,1.566406 0.0219,0.984686 0.0727,1.853041 0.16406,2.617191 0.0457,0.38208 0.1012,0.73821 0.16797,1.07031 0.13356,0.66417 0.31198,1.23197 0.54492,1.7168 0.23295,0.48482 0.52078,0.88581 0.87305,1.21875 0.17614,0.16648 0.36842,0.31556 0.57813,0.44921 0.41895,0.26701 0.90872,0.47238 1.47656,0.62891 6.2e-4,1.7e-4 0.001,-1.7e-4 0.002,0 1.42142,0.39113 3.3408,0.48047 5.91211,0.48047 h 17.53906 c 1.02156,0 1.93959,-0.015 2.76368,-0.0566 0.34097,-0.0172 0.65525,-0.0427 0.96484,-0.0703 0.0645,-0.006 0.13795,-0.007 0.20117,-0.0137 0.001,-1.4e-4 0.003,1.3e-4 0.004,0 0.73118,-0.0725 1.37505,-0.17995 1.93945,-0.33399 0.28273,-0.0772 0.54639,-0.16492 0.79102,-0.26758 0.24462,-0.10265 0.47066,-0.22006 0.67968,-0.35156 0.20903,-0.1315 0.40024,-0.27771 0.57618,-0.44141 0.15581,-0.14498 0.29602,-0.30775 0.42773,-0.48046 0.017,-0.0223 0.0381,-0.0397 0.0547,-0.0625 0.001,-0.002 0.003,-0.004 0.004,-0.006 0.14374,-0.19776 0.2725,-0.41443 0.38868,-0.6504 0.11725,-0.23815 0.22082,-0.49693 0.3125,-0.77734 0.0917,-0.28041 0.17164,-0.58218 0.24023,-0.9082 0.0686,-0.32602 0.12581,-0.6758 0.17383,-1.05078 0.0428,-0.33417 0.0752,-0.6967 0.10351,-1.072269 0.003,-0.04534 0.0104,-0.0849 0.0137,-0.130859 4.2e-4,-0.0061 -4.3e-4,-0.01341 0,-0.01953 0.059,-0.850021 0.0853,-1.80463 0.0879,-2.88086 v -18.904178 c -0.009,-1.95527 -1.71776,-3.606675 -3.10157,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 c -2.24485,-2.121612 -3.79653,-3.138638 -6.86748,-3.138638 z"
-         id="path964-1"
-         inkscape:connector-curvature="0" />
+         d="m 346.75282,73.148618 c -0.87379,0 -1.60425,0.730464 -1.60425,1.604252 v 4.61803 l 1.79107,3.12646 v -7.557672 h 10.29469 v 8.79521 h -9.58597 l 1.02699,1.791067 h 8.74382 c 0.87378,0 1.60622,-0.732439 1.60622,-1.606227 V 74.75287 c 0,-0.873788 -0.73244,-1.604252 -1.60622,-1.604252 z"
+         id="path493"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -2.50815,0 -4.811706,0.02551 -7.011724,0.07227 -1.569123,0.03333 -3.085758,0.07665 -4.505859,0.142578 -0.892728,0.04133 -1.761123,0.08803 -2.597656,0.144531 -0.07361,0.005 -0.155337,0.0086 -0.228516,0.01367 -0.03977,0.0028 -0.07364,0.0069 -0.113281,0.0098 -1.116046,0.0793 -2.169724,0.179402 -3.1875,0.291016 -0.281404,0.03076 -0.565732,0.06033 -0.839844,0.09375 -0.275699,0.03373 -0.547991,0.06893 -0.816406,0.105469 -0.386448,0.05241 -0.763169,0.107586 -1.134766,0.166015 -0.245075,0.0387 -0.493706,0.07575 -0.732422,0.117188 -0.386715,0.06683 -0.756638,0.14255 -1.126953,0.216797 -0.50787,0.102283 -1.000729,0.211021 -1.478515,0.328125 -0.190937,0.04659 -0.386033,0.09158 -0.572266,0.140625 -0.3252,0.08602 -0.638123,0.17771 -0.949219,0.271484 -0.174107,0.05225 -0.347813,0.105409 -0.517578,0.160157 -0.32699,0.105899 -0.647816,0.216555 -0.958984,0.332031 -0.09794,0.0362 -0.19267,0.07416 -0.289063,0.111328 -1.533658,0.593687 -2.876219,1.308506 -4.044922,2.173828 -0.01464,0.01084 -0.03034,0.02036 -0.04492,0.03125 -4.841904,3.613548 -6.740009,9.796263 -7.419922,20.238281 -0.01716,0.264046 -0.02929,0.544903 -0.04492,0.814453 -0.06629,1.140594 -0.126494,2.305415 -0.167969,3.546875 -9.88e-4,0.02958 -9.78e-4,0.06216 -0.002,0.0918 -0.04738,1.439614 -0.07924,2.944486 -0.09961,4.525391 0.472511,-28.9634 6.027958,-32.138712 38.884815,-32.138712 h 62.52929 c -0.85989,-0.295464 -1.74582,-0.553137 -2.65429,-0.783203 -0.15701,-0.03958 -0.31205,-0.08153 -0.47071,-0.119141 -0.38771,-0.0924 -0.78156,-0.17709 -1.17969,-0.257812 -0.28362,-0.0571 -0.57205,-0.108999 -0.86132,-0.160156 -0.33217,-0.05924 -0.66192,-0.122415 -1.00196,-0.173829 -0.61547,-0.09216 -1.24344,-0.171652 -1.88672,-0.238281 -0.25531,-0.02678 -0.51929,-0.04563 -0.77929,-0.06836 -0.49344,-0.04258 -0.99476,-0.07925 -1.50586,-0.107422 -0.26087,-0.01459 -0.52138,-0.03022 -0.78711,-0.04102 -0.75738,-0.03032 -1.52534,-0.05078 -2.32422,-0.05078 z"
-         id="path7784" />
+         d="m 336.55205,75.106735 c -3.89944,0 -7.07829,3.180824 -7.07829,7.079265 0,3.899428 3.17885,7.079264 7.07829,7.079264 h 0.0544 l 1.11892,-1.922531 c -0.37759,0.08501 -0.76901,0.133441 -1.17329,0.133441 -2.93075,0 -5.28721,-2.355473 -5.28721,-5.286221 0,-2.931736 2.35646,-5.289185 5.28721,-5.289185 2.396,0 4.40848,1.575586 5.06283,3.752148 0.33904,-0.667201 0.77989,-1.290912 1.16143,-1.831594 -1.20096,-2.208194 -3.5426,-3.711621 -6.22426,-3.711621 z"
+         id="path495"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 202.6543,44.089844 c -1.07122,0.357279 -1.96732,1.040077 -2.67188,1.910156 h 1.0957 c 34.15108,4e-6 38.64021,3.484765 38.89649,35.740234 0.003,-0.03712 0.0117,-0.07204 0.0137,-0.109375 -0.0536,-17.671398 -1.15787,-27.178174 -7.08008,-32.177734 -0.31691,-0.265045 -0.64554,-0.519153 -0.99023,-0.759766 -1.34338,-0.937742 -2.91268,-1.68853 -4.71875,-2.296875 -0.14212,-0.04772 -0.27668,-0.09862 -0.42188,-0.144531 -0.31902,-0.101184 -0.65609,-0.192499 -0.99023,-0.285156 -0.25795,-0.07131 -0.51412,-0.144507 -0.78125,-0.210938 -0.32384,-0.08078 -0.65655,-0.156631 -0.99414,-0.230468 -0.32254,-0.07033 -0.65294,-0.136909 -0.98828,-0.201172 -0.32063,-0.06164 -0.64012,-0.123397 -0.97266,-0.179688 -0.46228,-0.07802 -0.94194,-0.148582 -1.42773,-0.216797 -0.21622,-0.03046 -0.42163,-0.06516 -0.64258,-0.09375 -0.003,-3.28e-4 -0.005,-0.0016 -0.008,-0.002 -0.70741,-0.09114 -1.44413,-0.170948 -2.20118,-0.24414 -0.30752,-0.02983 -0.6294,-0.05499 -0.94531,-0.08203 -0.52075,-0.04445 -1.04787,-0.08768 -1.59179,-0.125 -0.34138,-0.02349 -0.68841,-0.04362 -1.03907,-0.06445 -0.36733,-0.02177 -0.74929,-0.04154 -1.12695,-0.06055 -1.40861,-0.07105 -2.86508,-0.128967 -4.42188,-0.166015 -0.006,-1.28e-4 -0.0105,5e-6 -0.0156,0 h -0.004 z"
-         id="path7782" />
+         d="m 343.35158,80.353417 c -0.0939,0.07117 -0.17397,0.161117 -0.23328,0.262927 l -6.99821,12.032378 c -0.0791,0.136407 -0.12158,0.292581 -0.12158,0.450733 0,0.490269 0.40328,0.894546 0.89454,0.895533 l 13.91834,0.04349 h 0.003 c 0.49126,0 0.89553,-0.404276 0.89553,-0.895534 0,-0.157164 -0.0405,-0.310372 -0.11861,-0.446779 l -6.92115,-12.074878 c -0.15913,-0.278743 -0.45666,-0.450734 -0.77693,-0.450734 -0.1957,0 -0.38549,0.06425 -0.54166,0.182864 z m 0.53672,2.504727 5.37815,9.384326 -10.81757,-0.03262 5.43942,-9.35072 z"
+         id="path497"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.011719,81.421875 c -0.0019,0.539192 -0.01172,1.017567 -0.01172,1.572266 v 2 c -0.0062,-1.260292 0.0066,-2.391311 0.01172,-3.572266 z"
-         id="path5316-7" />
+         d="m 337.79529,140.92301 c -0.56986,0 -1.04625,0.47639 -1.04625,1.04625 v 3.01176 l 1.16809,2.039 v -4.92892 h 6.71393 v 5.73601 h -6.25172 l 0.66978,1.16808 h 5.70249 c 0.56986,0 1.04754,-0.47767 1.04754,-1.04753 v -5.9784 c 0,-0.56986 -0.47768,-1.04625 -1.04754,-1.04625 z"
+         id="path509"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.005859,227.00586 v 2 c -0.0022,0.44238 0.0048,0.82141 0.0039,1.25391 0.0013,0.45945 0.007,0.88359 0.0098,1.33203 -0.01134,-1.48776 -0.02159,-2.96803 -0.01367,-4.58594 z m 175.994141,0.75195 c -0.0555,34.63219 -3.88404,38.24219 -38.91602,38.24219 h -98.15625 c -32.934263,0 -38.440959,-3.18029 -38.890621,-32.33398 0.304544,24.87428 3.489356,31.9654 22.175782,33.76562 0.0033,3.2e-4 0.0064,-3.2e-4 0.0098,0 0.761225,0.073 1.548247,0.13868 2.361328,0.19531 0.002,1.4e-4 0.0039,-1.4e-4 0.0059,0 0.814659,0.0567 1.655065,0.10648 2.523437,0.14844 6.7e-4,3e-5 0.0013,-3e-5 0.002,0 0.579873,0.028 1.24712,0.0365 1.851563,0.0586 1.208255,0.0442 2.391096,0.0937 3.701172,0.11719 0.0014,3e-5 0.0025,-2e-5 0.0039,0 1.964377,0.0351 4.045339,0.0488 6.250009,0.0488 0.002,0 0.004,0 0.006,0 h 98.15039 c 3.67649,0 6.93682,-0.0556 9.96094,-0.16602 2.42031,-0.0885 4.71577,-0.20623 6.75196,-0.40234 19.49586,-1.8777 22.12352,-9.49921 22.20507,-37.08398 -8.2e-4,-0.46208 0.006,-0.86842 0.004,-1.3418 z"
-         id="path5316-8"
-         inkscape:connector-curvature="0" />
+         d="m 331.14261,142.20004 c -2.54311,0 -4.61627,2.07446 -4.61627,4.61692 0,2.5431 2.07316,4.61691 4.61627,4.61691 h 0.0355 l 0.72973,-1.25383 c -0.24625,0.0554 -0.50153,0.087 -0.76519,0.087 -1.91136,0 -3.44818,-1.53617 -3.44818,-3.44753 0,-1.912 1.53682,-3.44947 3.44818,-3.44947 1.56261,0 2.8751,1.02756 3.30185,2.44705 0.22111,-0.43513 0.50862,-0.8419 0.75745,-1.19452 -0.78323,-1.44012 -2.31039,-2.42062 -4.0593,-2.42062 z"
+         id="path511"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:0.64464" />
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 353.49905,61.375285 c -0.0742,0 -0.14719,0.007 -0.22049,0.018 -0.94065,0.29981 -1.25935,1.72298 -0.53417,2.39306 l 7.51333,7.51498 c 0.78643,0.74591 2.35311,0.10873 2.39455,-0.97465 v -2.118 c 0.0336,-6.55752 0.34308,-6.68079 -5.59466,-6.81539 h -3.33561 c -0.0733,-0.0113 -0.14877,-0.018 -0.22295,-0.018 z"
-         id="rect4158-92-6-6"
-         sodipodi:nodetypes="scccccccs" />
+         d="m 335.57709,145.62179 c -0.0612,0.0464 -0.11346,0.10508 -0.15214,0.17148 l -4.56405,7.8472 c -0.0516,0.089 -0.0793,0.19081 -0.0793,0.29396 0,0.31974 0.26301,0.5834 0.58339,0.58404 l 9.07718,0.0284 h 0.002 c 0.32039,0 0.58404,-0.26366 0.58404,-0.58404 0,-0.1025 -0.0264,-0.20242 -0.0774,-0.29138 l -4.5138,-7.87492 c -0.10378,-0.18179 -0.29782,-0.29396 -0.50669,-0.29396 -0.12763,0 -0.25141,0.0419 -0.35326,0.11926 z m 0.35003,1.63352 3.50749,6.12021 -7.05493,-0.0213 3.54744,-6.09829 z"
+         id="path513"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:0.64464" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1004);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         clip-path="url(#clipPath994-5)"
-         d="m 335.23242,61.5 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 v 12.751953 12.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 v -17.903968 c -0.006,-1.214011 -0.66655,-2.310001 -1.49805,-3.265625 v 8.243812 12.251953 c 0,2.193451 -0.0614,3.870697 -0.26562,5.087887 -0.20419,1.2172 -0.52867,1.92435 -0.99805,2.39454 -0.46938,0.47016 -1.17436,0.79564 -2.38867,1 -1.21432,0.20434 -2.8892,0.26562 -5.07813,0.26562 h -16.53906 c -2.18893,0 -3.86589,-0.0612 -5.08399,-0.26562 -1.21809,-0.20448 -1.92877,-0.5295 -2.40039,-1 -0.47161,-0.47052 -0.79596,-1.17682 -0.99804,-2.39258 -0.20209,-1.21576 -0.25879,-2.893414 -0.24805,-5.085941 v -0.002 -12.253859 -12.253906 -0.002 c -0.0107,-2.192528 0.046,-3.870175 0.24805,-5.085938 0.20209,-1.215763 0.52643,-1.922078 0.99804,-2.392578 0.47161,-0.4705 1.18426,-0.79553 2.40235,-1 1.21809,-0.204376 2.8931,-0.265578 5.08203,-0.265578 h 12.26953 c -1.40176,-1.001118 -3.79892,-1.5 -5.922,-1.5 z"
-         id="path990"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssccccscccsscccccccccscscss" />
+         d="m 333.31652,194.81021 c -0.4179,0 -0.76725,0.34935 -0.76725,0.76725 v 2.20862 l 0.8566,1.49527 v -3.61454 h 4.92354 v 4.20641 h -4.58459 l 0.49117,0.85659 h 4.18183 c 0.4179,0 0.76819,-0.35029 0.76819,-0.76819 v -4.38416 c 0,-0.4179 -0.35028,-0.76725 -0.76819,-0.76725 z"
+         id="path525"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:0.472736" />
       <path
-         inkscape:connector-curvature="0"
-         style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0441942;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 353.35547,61.876953 -0.14453,0.121094 c -0.28875,0.242959 -0.43321,0.748579 -0.31836,1.111328 0.007,0.0217 0.07,0.0936 0.11523,0.150391 0.056,-0.101219 0.12158,-0.193105 0.20313,-0.261719 l 0.14453,-0.121094 2.71875,0.02539 c 2.70745,0.02522 3.50936,0.05935 4.26562,0.185547 1.36683,0.228076 1.67801,0.658049 1.79102,2.474609 0.0245,0.393967 0.0317,1.552688 0.0352,2.636719 0.007,-1.466927 -5.4e-4,-3.080545 -0.0352,-3.636719 -0.11301,-1.81656 -0.42419,-2.246533 -1.79102,-2.474609 -0.75626,-0.126199 -1.55817,-0.160327 -4.26562,-0.185547 z"
-         id="path7025" />
+         d="m 328.43788,195.7467 c -1.86494,0 -3.38526,1.52127 -3.38526,3.38574 0,1.86494 1.52032,3.38573 3.38526,3.38573 h 0.026 l 0.53513,-0.91947 c -0.18058,0.0406 -0.36779,0.0638 -0.56114,0.0638 -1.40166,0 -2.52866,-1.12653 -2.52866,-2.52819 0,-1.40213 1.127,-2.52961 2.52866,-2.52961 1.14592,0 2.10841,0.75354 2.42136,1.7945 0.16215,-0.31909 0.37299,-0.61739 0.55546,-0.87598 -0.57437,-1.05609 -1.69428,-1.77512 -2.97682,-1.77512 z"
+         id="path527"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:0.472736" />
       <path
-         transform="translate(4.9980746e-4)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 v 6.12581 6.12581 c -0.0217,4.42101 0.45311,4.87419 4.8652,4.87419 h 8.2696 c 4.41209,0 4.8652,-0.45312 4.8652,-4.87419 v -6.12581 -6.12581 c 0,-4.42106 -0.45312,-4.87419 -4.86521,-4.87419 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971-6)" />
+         d="m 331.68984,198.25598 c -0.0449,0.034 -0.0832,0.0771 -0.11156,0.12575 l -3.34697,5.75462 c -0.0378,0.0653 -0.0582,0.13992 -0.0582,0.21557 0,0.23447 0.19288,0.42782 0.42782,0.42829 l 6.6566,0.0208 h 0.001 c 0.23495,0 0.42829,-0.19335 0.42829,-0.4283 0,-0.0752 -0.0194,-0.14844 -0.0568,-0.21367 l -3.31012,-5.77495 c -0.0761,-0.13331 -0.2184,-0.21557 -0.37158,-0.21557 -0.0936,0 -0.18437,0.0307 -0.25905,0.0875 z m 0.25668,1.19792 2.57216,4.48815 -5.17361,-0.0156 2.60145,-4.47208 z"
+         id="path529"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:0.472736" />
       <path
-         id="path1085"
-         d="m 327.86573,188.5 c -1.11158,0 -1.98683,0.0256 -2.70703,0.14648 -0.72019,0.1209 -1.3105,0.34863 -1.74218,0.7793 -0.43169,0.43067 -0.65954,1.01974 -0.7793,1.74024 -0.11977,0.72049 -0.14217,1.59669 -0.13672,2.71093 v 6.12305 6.125 c -0.005,1.1131 0.017,1.989 0.13672,2.70898 0.11976,0.72051 0.3476,1.30957 0.7793,1.74024 0.43169,0.43067 1.02199,0.6584 1.74218,0.7793 0.7202,0.12089 1.59545,0.14648 2.70703,0.14648 h 8.26954 c 1.11158,0 1.98637,-0.0255 2.70507,-0.14648 0.7187,-0.12095 1.30623,-0.34848 1.73633,-0.7793 0.4301,-0.43083 0.6566,-1.01849 0.77735,-1.73828 0.12074,-0.71979 0.14648,-1.59713 0.14648,-2.71094 v -6.125 -6.125 c 0,-1.11381 -0.0257,-1.99115 -0.14648,-2.71094 -0.12075,-0.71979 -0.34725,-1.30745 -0.77735,-1.73828 -0.4301,-0.43082 -1.01763,-0.65835 -1.73633,-0.7793 -0.7187,-0.12094 -1.59349,-0.14648 -2.70507,-0.14648 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
+         d="m 328.8378,240.69741 c -0.26593,0 -0.48825,0.22231 -0.48825,0.48825 v 1.40548 l 0.54511,0.95154 v -2.30016 h 3.13316 v 2.6768 h -2.91746 l 0.31256,0.54511 h 2.66117 c 0.26593,0 0.48884,-0.22291 0.48884,-0.48885 v -2.78992 c 0,-0.26594 -0.2229,-0.48825 -0.48884,-0.48825 z"
+         id="path541"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:0.300832" />
       <path
-         id="path1087"
-         d="m 325.0962,236.5 c -0.71048,0 -1.27344,0.0154 -1.75195,0.0957 -0.47851,0.0803 -0.89671,0.23728 -1.20703,0.54688 -0.31032,0.30959 -0.46726,0.7261 -0.54688,1.20508 -0.0796,0.47897 -0.0933,1.04352 -0.0898,1.75586 v 3.89648 3.89844 c -0.003,0.71121 0.0103,1.27546 0.0898,1.7539 0.0796,0.47898 0.23655,0.89549 0.54688,1.20508 0.31033,0.3096 0.72851,0.46655 1.20703,0.54688 0.47852,0.0803 1.04147,0.0957 1.75195,0.0957 h 5.8086 c 0.71048,0 1.27236,-0.0153 1.75,-0.0957 0.47763,-0.0804 0.89584,-0.23713 1.20508,-0.54688 0.30921,-0.30975 0.46469,-0.72681 0.54492,-1.20508 0.0802,-0.47826 0.0957,-1.04201 0.0957,-1.7539 v -3.89844 -3.89844 c 0,-0.71189 -0.0155,-1.27564 -0.0957,-1.7539 -0.0802,-0.47827 -0.2357,-0.89533 -0.54492,-1.20508 -0.30924,-0.30975 -0.72745,-0.4665 -1.20508,-0.54688 -0.47764,-0.0804 -1.03952,-0.0957 -1.75,-0.0957 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
+         d="m 325.73321,241.29336 c -1.18678,0 -2.15425,0.96808 -2.15425,2.15456 0,1.18678 0.96747,2.15455 2.15425,2.15455 h 0.0165 l 0.34054,-0.58511 c -0.11492,0.0258 -0.23405,0.0406 -0.35709,0.0406 -0.89197,0 -1.60915,-0.71689 -1.60915,-1.60885 0,-0.89227 0.71718,-1.60975 1.60915,-1.60975 0.72922,0 1.34171,0.47952 1.54086,1.14195 0.10319,-0.20306 0.23736,-0.39288 0.35348,-0.55744 -0.36551,-0.67206 -1.07818,-1.12962 -1.89434,-1.12962 z"
+         id="path543"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:0.300832" />
       <path
-         transform="translate(4.9980746e-4)"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 v 3.89824 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 c 2.8077,0 3.09604,-0.28835 3.09604,-3.10176 v -3.89824 -3.89824 c 0,-2.8134 -0.28835,-3.10176 -3.09604,-3.10176 z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983-6)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.991584;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 342.28662,133.49219 c -0.0504,0 -0.10067,0.005 -0.15039,0.0117 -0.63831,0.19051 -0.85538,1.0957 -0.36328,1.52148 l 5.09961,4.77344 c 0.53367,0.47395 1.59687,0.0693 1.625,-0.61914 v -1.34571 c 0.0228,-4.16669 0.23241,-4.24454 -3.79688,-4.33007 h -2.26367 c -0.0498,-0.007 -0.10004,-0.0117 -0.15039,-0.0117 z m -12.21289,0.004 c -2.78209,0 -4.43425,0.14534 -5.38672,1.00391 -0.19416,0.175 -0.35249,0.38793 -0.49219,0.62695 -0.0316,0.054 -0.0686,0.10247 -0.0976,0.16016 -0.0785,0.156 -0.14802,0.3261 -0.20899,0.50977 -0.0611,0.18405 -0.11501,0.38162 -0.16015,0.5957 -0.0452,0.21409 -0.0824,0.44315 -0.11329,0.68945 -0.0617,0.49261 -0.0965,1.05274 -0.11132,1.6875 -0.007,0.31739 -0.01,0.65353 -0.008,1.00977 v 8.2206 8.2207 c -0.002,0.35623 3.5e-4,0.69239 0.008,1.00977 0.0148,0.63477 0.0495,1.19491 0.11132,1.6875 0.0309,0.24631 0.0682,0.47537 0.11329,0.68945 0.0903,0.42816 0.21168,0.79292 0.36914,1.10547 0.15746,0.31252 0.35171,0.57249 0.58984,0.78711 0.11906,0.10732 0.24887,0.20291 0.39062,0.28906 0.28319,0.17212 0.61423,0.30534 0.99805,0.40625 0.96081,0.25213 2.25995,0.3086 3.99805,0.3086 h 11.85547 c 0.69054,0 1.31013,-0.0106 1.86719,-0.0371 0.23047,-0.0111 0.44308,-0.0272 0.65234,-0.0449 0.0436,-0.004 0.094,-0.004 0.13672,-0.008 h 0.002 c 0.49424,-0.0467 0.92903,-0.11749 1.31055,-0.21679 0.19111,-0.0498 0.36981,-0.10571 0.53515,-0.17188 0.16536,-0.0661 0.31771,-0.14178 0.45899,-0.22656 0.14129,-0.0848 0.2717,-0.17962 0.39062,-0.28516 0.10532,-0.0934 0.20005,-0.19727 0.28907,-0.30859 0.0115,-0.0144 0.0259,-0.0264 0.0371,-0.041 6.7e-4,-0.001 9.5e-4,-0.003 0.002,-0.004 0.0971,-0.12749 0.18514,-0.26586 0.26367,-0.41797 0.0792,-0.15352 0.14897,-0.32121 0.21094,-0.50196 0.062,-0.18077 0.11573,-0.37576 0.16211,-0.58593 0.0464,-0.21016 0.0847,-0.43601 0.11718,-0.67774 0.0289,-0.21541 0.0511,-0.44929 0.0703,-0.6914 0.002,-0.0292 0.008,-0.0543 0.01,-0.084 2.9e-4,-0.004 -2.9e-4,-0.008 0,-0.0117 0.0399,-0.54795 0.0568,-1.16365 0.0586,-1.85742 v -11.18578 c -0.006,-1.26044 -1.16032,-2.32513 -2.09571,-3.1289 l -0.008,-0.006 -6.72986,-6.49196 c -1.51744,-1.36767 -2.56676,-2.02344 -4.64258,-2.02344 z"
-         id="path964-1-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccccccccccccccccsscccccccccccccccccccccccss" />
-      <path
-         style="opacity:0.3;fill:url(#linearGradient4316);fill-opacity:1;stroke:none;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 343.16802,134.07487 c -0.99147,0.035 -1.02734,0.0465 -1.02734,0.33594 0,0.10178 0.15173,0.31016 0.45898,0.64648 h 2.87891 c 0.15931,0 0.30929,0.0306 0.45312,0.0762 0.32342,0.02 0.64497,0.0487 0.96485,0.10352 0.0264,0.32124 0.0306,0.64828 0.0371,0.97461 0.0263,0.11154 0.0449,0.2259 0.0449,0.3457 v 2.61719 c 0.25501,0.21272 0.45277,0.36813 0.49023,0.36914 0.45172,0.0121 0.5059,-0.28833 0.46289,-2.54883 -0.0534,-2.80528 0.043,-2.67754 -2.15624,-2.83984 -0.86922,-0.0642 -2.04216,-0.1 -2.60743,-0.0801 z m -10.83984,0.0371 c -5.16676,0.002 -5.89229,0.0632 -6.90234,0.57617 -0.60351,0.30649 -1.03843,1.06517 -1.2461,2.17187 -0.24355,1.30043 -0.239,21.42491 0.006,22.5 0.4115,1.80781 1.06039,2.3312 3.18555,2.56446 0.49142,0.054 4.63516,0.0862 9.20703,0.0723 7.44102,-0.0226 8.39113,-0.0477 9.0625,-0.24023 1.20765,-0.3464 1.67604,-0.80148 2.02539,-1.96289 0.17841,-0.59326 0.21211,-1.68489 0.25391,-8.28321 0.0479,-7.5564 0.0468,-6.60393 -0.21875,-7.15257 -0.0736,-0.15205 -0.33859,-0.46265 -0.72266,-0.875 v 4.07422 c 0,0.12416 -0.0206,0.24218 -0.0488,0.35742 0.0246,3.83198 -0.0428,6.67596 -0.12305,10.47289 0.094,0.98908 -0.26416,2.20979 -1.37304,2.42969 -4.17852,0.21246 -8.39772,0.16055 -12.60547,0.18945 -2.09316,-0.0712 -4.2187,0.13385 -6.29102,-0.20117 -1.20786,-0.09 -1.37139,-1.432 -1.46679,-2.37696 -0.1751,-6.57883 -0.13104,-13.28191 -0.041,-19.88867 0.0853,-1.09208 -0.0376,-2.65795 1.18164,-3.16406 2.366,-0.42229 4.785,-0.2218 7.17578,-0.3125 0.61114,0.0344 0.29054,0.0147 0.94202,0.0117 0.059,-0.007 0.11677,-0.0176 0.17773,-0.0176 h 3.5918 c -0.42688,-0.30915 -0.78914,-0.52782 -1.16797,-0.68359 -0.60974,-0.25114 0.12581,-0.26372 -4.60217,-0.26172 z"
-         id="path4296"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cscscccscccccccccccccccccsccccccccccscccc" />
+         d="m 327.80264,242.89017 c -0.0286,0.0216 -0.0529,0.0491 -0.071,0.08 l -2.12989,3.66204 c -0.0241,0.0416 -0.037,0.089 -0.037,0.13718 0,0.14921 0.12275,0.27225 0.27225,0.27255 l 4.23602,0.0132 h 6.4e-4 c 0.14951,0 0.27255,-0.12304 0.27255,-0.27255 0,-0.0479 -0.0124,-0.0945 -0.0362,-0.13598 l -2.10644,-3.67496 c -0.0484,-0.0848 -0.13898,-0.13718 -0.23646,-0.13718 -0.0596,0 -0.11733,0.0195 -0.16485,0.0557 z m 0.16334,0.76231 1.63683,2.8561 -3.29229,-0.01 1.65546,-2.84587 z"
+         id="path545"
+         style="display:inline;enable-background:new;fill:#e5eaee;fill-rule:nonzero;stroke-width:0.300832" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/libreoffice-impress.svg
+++ b/icons/src/fullcolor/default/apps/libreoffice-impress.svg
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="libreoffice-impress.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
      id="base"
-     pagecolor="#979797"
+     pagecolor="#ffffff"
      bordercolor="#000000"
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:zoom="2"
-     inkscape:cx="275.79392"
-     inkscape:cy="83.785616"
+     inkscape:cx="366"
+     inkscape:cy="182"
      inkscape:current-layer="layer6"
-     showgrid="true"
+     showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -50,7 +50,7 @@
      gridtolerance="10000"
      inkscape:object-nodes="true"
      inkscape:snap-grids="true"
-     showguides="false"
+     showguides="true"
      inkscape:guide-bbox="true"
      inkscape:window-maximized="1"
      inkscape:bbox-paths="true"
@@ -61,8 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:lockguides="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -93,735 +93,89 @@
   <defs
      id="defs3">
     <linearGradient
-       id="linearGradient5578">
+       id="b"
+       x2="1"
+       gradientTransform="matrix(0,-203.23056,203.23056,0,561.9161,254.13381)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         id="stop5574"
-         style="stop-color:#e76428;stop-opacity:1"
-         offset="0" />
+         stop-color="#a93413"
+         offset="0"
+         id="stop287" />
       <stop
-         id="stop5576"
-         style="stop-color:#9f3d06;stop-opacity:1"
-         offset="1" />
+         stop-color="#fb6842"
+         offset="1"
+         id="stop289" />
     </linearGradient>
     <linearGradient
-       id="linearGradient12112">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(-0.00528208,-207.68288,207.68288,-0.00528208,235.61347,259.06168)"
+       gradientUnits="userSpaceOnUse">
       <stop
+         stop-color="#b7b4b4"
          offset="0"
-         style="stop-color:#9f3d06;stop-opacity:1"
-         id="stop12108" />
+         id="stop282" />
       <stop
+         stop-color="#f1f1f1"
          offset="1"
-         style="stop-color:#e76428;stop-opacity:1"
-         id="stop12110" />
+         id="stop284" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
+       xlink:href="#b"
+       id="linearGradient407"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-41.734847,41.734847,0,428.1792,104.15247)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-5">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
+       xlink:href="#a"
+       id="linearGradient409"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00108471,-42.649162,42.649162,-0.00108471,361.17062,105.16445)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient3194"
-       x1="335.73108"
-       y1="62"
-       x2="352.26993"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
+       xlink:href="#b"
+       id="linearGradient419"
        gradientUnits="userSpaceOnUse"
-       y2="169.66859"
-       x2="4.4137931"
-       y1="386.30838"
-       x1="494.34482"
-       id="linearGradient4226-1"
-       xlink:href="#linearGradient4338"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.96286,268)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6646"
-       x="-0.01363613"
-       width="1.0272723"
-       y="-0.01071443"
-       height="1.0214289">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.0000135"
-         id="feGaussianBlur6648" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6668"
-       x="-0.054544518"
-       width="1.109089"
-       y="-0.042857721"
-       height="1.0857154">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.000054"
-         id="feGaussianBlur6670" />
-    </filter>
-    <linearGradient
-       id="linearGradient13214">
-      <stop
-         id="stop13216"
-         style="stop-color:#18a303;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop13218"
-         style="stop-color:#106802;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
+       gradientTransform="matrix(0,-27.218377,27.218377,0,390.89947,161.14291)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient4338">
-      <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
-         offset="0"
-         id="stop4340" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="1"
-         id="stop4342" />
-    </linearGradient>
+       xlink:href="#a"
+       id="linearGradient421"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-7.0741953e-4,-27.814669,27.814669,-7.0741953e-4,347.19822,161.8029)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient12112"
-       id="linearGradient18935"
-       x1="335.23141"
-       y1="60.997517"
-       x2="352.77151"
-       y2="106.5"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#b"
+       id="linearGradient431"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-19.960145,19.960145,0,372.25959,209.63814)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983-6">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985-0"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
+       xlink:href="#a"
+       id="linearGradient433"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.1877436e-4,-20.397426,20.397426,-5.1877436e-4,340.21199,210.12213)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971-6">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1311"
-       x1="327.99951"
-       y1="188"
-       x2="335.99951"
-       y2="212"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1309"
-       x1="332"
-       y1="236"
-       x2="324"
-       y2="252"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#b"
+       id="linearGradient443"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-12.701913,12.701913,0,353.61977,250.13337)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient7713"
-       id="linearGradient916"
+       xlink:href="#a"
+       id="linearGradient445"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05664062,-0.05663901,0,349.74506,214)"
-       x1="450.20694"
-       y1="386.30743"
-       x2="44.137936"
-       y2="240.29004" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient12112"
-       id="linearGradient920"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.03604403,-0.03604301,0,339.56482,252.90909)"
-       x1="455.25125"
-       y1="401.44119"
-       x2="39.093575"
-       y2="240.26906" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient12112"
-       id="linearGradient18935-0"
-       x1="334.86411"
-       y1="61.500103"
-       x2="352.89749"
-       y2="106.50614"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient4316"
-       x1="372"
-       y1="134"
-       x2="372"
-       y2="162"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-37.000489)" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient18935-0-8"
-       x1="336.64893"
-       y1="59.040947"
-       x2="348.54202"
-       y2="108.83411"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient15606-6">
-      <stop
-         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.588235;"
-         offset="0"
-         id="stop15608-8" />
-      <stop
-         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.862745;"
-         offset="1"
-         id="stop15610-7" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7723">
-      <stop
-         id="stop7721"
-         style="stop-color:#2e851b;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7715"
-         style="stop-color:#18a003;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient13791">
-      <stop
-         id="stop13793"
-         style="stop-color:#d36118;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop13795"
-         style="stop-color:#f09e6f;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient16134-3-1-8">
-      <stop
-         id="stop16136-6-3-7"
-         style="stop-color:#000000;stop-opacity:0.50196099"
-         offset="0" />
-      <stop
-         id="stop16138-4-6-2"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10286-8">
-      <stop
-         id="stop10288-2-1"
-         offset="0"
-         style="stop-color: rgb(179, 179, 179); stop-opacity: 1;" />
-      <stop
-         id="stop10290-6"
-         offset="1"
-         style="stop-color: rgb(230, 230, 230); stop-opacity: 1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7713">
-      <stop
-         id="stop7711"
-         style="stop-color:#993a03;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7709"
-         style="stop-color:#f0692c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(0,-4e-6)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient5578"
-       id="linearGradient18820-3"
-       x1="201.07812"
-       y1="269.99988"
-       x2="102.92188"
-       y2="45.999878"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3976">
-      <stop
-         offset="0"
-         style="stop-color:#626262;stop-opacity:1"
-         id="stop3972" />
-      <stop
-         offset="1"
-         style="stop-color:#4e4e4e;stop-opacity:1"
-         id="stop3974" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear28"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-80,80,0,201.005,501)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(211,97,24);stop-opacity:1"
-         id="stop534" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(240,158,111);stop-opacity:1"
-         id="stop536" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear29"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-80,80,0,210.004,501.003)">
-      <stop
-         offset="0"
-         style="stop-color:white;stop-opacity:0.58"
-         id="stop539" />
-      <stop
-         offset="1"
-         style="stop-color:white;stop-opacity:0.86"
-         id="stop541" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear30"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-30,30,0,176.007,486.001)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(179,179,179);stop-opacity:1"
-         id="stop544" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(230,230,230);stop-opacity:1"
-         id="stop546" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear31"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-30,30,0,176.006,485.997)">
-      <stop
-         offset="0"
-         style="stop-color:white;stop-opacity:0.58"
-         id="stop549" />
-      <stop
-         offset="1"
-         style="stop-color:white;stop-opacity:0.86"
-         id="stop551" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear32"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-16,16,0,366.8,387.001)">
-      <stop
-         offset="0"
-         style="stop-color:white;stop-opacity:0.58"
-         id="stop554" />
-      <stop
-         offset="1"
-         style="stop-color:white;stop-opacity:0.86"
-         id="stop556" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear33"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,65.035,-65.035,0,353,345.484)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(163,62,3);stop-opacity:1"
-         id="stop559" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(98,37,2);stop-opacity:1"
-         id="stop561" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear34"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,65.035,-65.035,0,353,348.484)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(163,62,3);stop-opacity:1"
-         id="stop564" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(98,37,2);stop-opacity:1"
-         id="stop566" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear35"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,65.035,-65.035,0,353,351.484)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(163,62,3);stop-opacity:1"
-         id="stop569" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(98,37,2);stop-opacity:1"
-         id="stop571" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear36"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-6,6,0,360.001,384.002)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(179,179,179);stop-opacity:1"
-         id="stop574" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(230,230,230);stop-opacity:1"
-         id="stop576" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear37"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-6,6,0,360,384.001)">
-      <stop
-         offset="0"
-         style="stop-color:white;stop-opacity:0.58"
-         id="stop579" />
-      <stop
-         offset="1"
-         style="stop-color:white;stop-opacity:0.86"
-         id="stop581" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear9"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-11.999,11.999,0,354.455,450.001)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(211,97,24);stop-opacity:1"
-         id="stop423" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(240,158,111);stop-opacity:1"
-         id="stop425" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear10"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.661,-10.983,10.983,-0.661,356,449)">
-      <stop
-         offset="0"
-         style="stop-color:white;stop-opacity:0.58"
-         id="stop428" />
-      <stop
-         offset="1"
-         style="stop-color:white;stop-opacity:0.86"
-         id="stop430" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear11"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,65.035,-65.035,0,348,411.484)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(163,62,3);stop-opacity:1"
-         id="stop433" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(98,37,2);stop-opacity:1"
-         id="stop435" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear12"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,65.035,-65.035,0,348,414.484)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(163,62,3);stop-opacity:1"
-         id="stop438" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(98,37,2);stop-opacity:1"
-         id="stop440" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear18"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-6,6,0,347.727,499.5)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(211,97,24);stop-opacity:1"
-         id="stop468" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(240,158,111);stop-opacity:1"
-         id="stop470" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear19"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-6,6,0,348.3,499.5)">
-      <stop
-         offset="0"
-         style="stop-color:white;stop-opacity:0.58"
-         id="stop473" />
-      <stop
-         offset="1"
-         style="stop-color:white;stop-opacity:0.86"
-         id="stop475" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear20"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,32.517,-32.517,0,344,478.242)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(163,62,3);stop-opacity:1"
-         id="stop478" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(98,37,2);stop-opacity:1"
-         id="stop480" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear21"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,32.518,-32.518,0,344,480.241)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(163,62,3);stop-opacity:1"
-         id="stop483" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(98,37,2);stop-opacity:1"
-         id="stop485" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear13"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,16.032,-16.032,0,342.254,529.005)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(163,62,3);stop-opacity:1"
-         id="stop443" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(98,37,2);stop-opacity:1"
-         id="stop445" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear14"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,16.032,-16.032,0,340.502,528.001)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(163,62,3);stop-opacity:1"
-         id="stop448" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(98,37,2);stop-opacity:1"
-         id="stop450" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear16"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,16.032,-16.032,0,339.752,528.001)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(163,62,3);stop-opacity:1"
-         id="stop458" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(98,37,2);stop-opacity:1"
-         id="stop460" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#_Linear16"
-       id="linearGradient1531"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,16.032,-16.032,0,339.752,528.001)"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#_Linear16"
-       id="linearGradient1533"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,16.032,-16.032,0,339.752,528.001)"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#_Linear14"
-       id="linearGradient1535"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,16.032,-16.032,0,340.502,528.001)"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#_Linear14"
-       id="linearGradient1537"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,16.032,-16.032,0,340.502,528.001)"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0" />
+       gradientTransform="matrix(-3.301292e-4,-12.980182,12.980182,-3.301292e-4,333.22584,250.44136)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -921,7 +275,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">libreoffice-impress</tspan></text>
+           id="tspan924">libreoffice-impress</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -956,771 +310,124 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.991584;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 342.28786,133.99591 c -0.0832,0 -0.1556,0.007 -0.2168,0.0156 l -0.0371,0.006 -0.0371,0.0117 c -1.02052,0.30458 -1.3544,1.66824 -0.54687,2.36914 0,0 0,0.002 0,0.002 l 5.08984,4.76563 0.006,0.004 c 0.44144,0.39204 1.03582,0.39851 1.50781,0.21874 0.47199,-0.17975 0.9171,-0.5946 0.94141,-1.18945 v -0.01 -1.35352 -0.002 c 0.006,-1.0363 0.0251,-1.82214 -0.0176,-2.45508 -0.0427,-0.63344 -0.14348,-1.14825 -0.47266,-1.55274 -0.32917,-0.40448 -0.82834,-0.59266 -1.42968,-0.68554 -0.60135,-0.0929 -1.35232,-0.1114 -2.36133,-0.13281 h -0.006 -2.26953 c -0.0478,-0.005 -0.0951,-0.0117 -0.15039,-0.0117 z m -7.25782,0.002 -4.95507,0.002 c -2.79936,0 -4.57517,0.10197 -5.71875,1.13282 -0.24259,0.21892 -0.43083,0.4754 -0.5879,0.74414 -0.0117,0.02 -0.0564,0.0782 -0.11132,0.1875 -0.0907,0.18027 -0.17065,0.37241 -0.23828,0.57617 -0.0671,0.20198 -0.12496,0.41859 -0.17383,0.65039 -0.0486,0.23023 -0.0869,0.47111 -0.11914,0.72851 v 0.002 c -0.0646,0.51578 -0.10015,1.09026 -0.11524,1.73633 -0.007,0.32198 -0.0116,0.66266 -0.01,1.02343 v 8.21875 8.22071 c -0.002,0.3594 0.002,0.69873 0.01,1.02148 0.0151,0.64603 0.0505,1.22236 0.11524,1.73828 0.0323,0.25754 0.0707,0.4986 0.11914,0.72852 0.0971,0.4603 0.23097,0.86702 0.41211,1.22656 0.18147,0.36018 0.41279,0.67544 0.69922,0.93359 0.14342,0.12929 0.30075,0.24284 0.46679,0.34375 0.33271,0.20222 0.70911,0.35057 1.12891,0.46094 v 0.002 c 1.04936,0.27537 2.37421,0.32422 4.12305,0.32422 h 11.85546 c 0.69562,0 1.32241,-0.0101 1.89063,-0.0371 h 0.002 c 0.23885,-0.0115 0.45772,-0.0289 0.66992,-0.0469 h 0.002 0.002 c 0.006,-5.4e-4 0.052,-0.004 0.0898,-0.006 h 0.0137 c 0.0155,-0.001 0.0141,-1.1e-4 0.0332,-0.002 h 0.002 c 0.51385,-0.0486 0.97388,-0.12251 1.38867,-0.23047 0.20576,-0.0536 0.4054,-0.11525 0.59571,-0.19141 0.18901,-0.0755 0.36479,-0.163 0.52929,-0.26172 0.1657,-0.0995 0.3216,-0.21271 0.46485,-0.33984 0.12928,-0.11465 0.24087,-0.23957 0.34179,-0.36524 0,2e-5 0.005,-0.005 0.006,-0.006 l 0.0215,-0.0215 0.0156,-0.0195 0.006,-0.008 0.002,-0.004 0.008,-0.008 0.008,-0.0137 c 4e-5,-7e-5 0.008,-0.016 0.0117,-0.0234 0.003,-0.004 0.009,-0.008 0.0117,-0.0117 -5.4e-4,7e-4 -0.007,0.003 -0.008,0.004 0.01,-0.0181 0.0172,-0.0306 0.0254,-0.0469 -0.006,0.0128 -0.01,0.0233 -0.0117,0.0273 0.095,-0.13149 0.18742,-0.26844 0.26562,-0.41992 0.0922,-0.17881 0.17175,-0.3686 0.24024,-0.56836 0.069,-0.20111 0.12594,-0.41283 0.17578,-0.63867 0.0501,-0.22709 0.0911,-0.46643 0.125,-0.71875 0.0307,-0.22912 0.0546,-0.4717 0.0742,-0.71875 l 0.002,-0.002 v -0.004 c -10e-4,0.0185 0.005,-0.009 0.01,-0.082 v -0.002 c 0.002,-0.0307 0.004,-0.0623 0,-0.006 v -0.002 -0.002 c 0.0411,-0.56466 0.0568,-1.18956 0.0586,-1.89062 v -0.004 -11.1875 c -0.007,-1.5618 -1.32097,-2.69049 -2.26758,-3.50391 l -0.01,-0.008 -0.002,-0.002 -6.71093,-6.47461 -0.008,-0.006 c -1.54333,-1.391 -2.79437,-2.15039 -4.97461,-2.15039 z"
-         id="path964-1-7-1"
-         inkscape:connector-curvature="0" />
+         d="m 247.78976,259.06168 -58.1689,-0.0674 V 51.545338 l 59.83431,-0.2166 c 10.39675,0.12515 15.59513,8.22114 15.59513,17.94885 V 240.27532 c 0.45245,10.68074 -6.60386,18.55532 -17.26054,18.78636 z"
+         fill="url(#a)"
+         id="path292"
+         style="display:inline;fill:url(#a);stroke-width:4.81331;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.135116;marker:none;enable-background:accumulate"
-         d="m 333.62305,134.67578 c -1.16382,-4.5e-4 -2.33575,0.0651 -3.47266,0.0117 -1.64123,0.15998 -3.68744,-0.31449 -5.04297,0.81641 -0.78193,3.91578 -0.31677,7.94974 -0.50195,11.93359 0.0805,4.11392 -0.25828,8.26593 0.28125,12.33203 0.48472,2.04266 2.94853,1.4066 4.44922,1.55078 5.50792,-0.0155 11.04331,0.20674 16.53515,-0.20508 1.71827,-0.77282 1.10061,-3.07205 1.32813,-4.56445 -0.01,-3.98163 0.30353,-8.09209 -0.12305,-12.0664 -3.08965,-3.38352 -6.42627,-6.58849 -10.03125,-9.41797 -1.10188,-0.32321 -2.25806,-0.39018 -3.42187,-0.39063 z"
-         id="rect4158-92-6-7-3"
-         inkscape:connector-curvature="0" />
+         d="m 155.74958,51.579038 79.47739,-7.45101 c 10.63261,-1.07337 15.27745,4.6304 15.35928,16.06202 L 249.91243,248.15471 C 249.7199,260.87149 244.03052,267.53311 232.81555,268 l -76.54613,-8.93832 H 74.520123 c -10.440075,0 -21.048615,-8.50031 -21.106375,-21.74655 V 72.589138 c 0.399505,-15.23894 6.753077,-20.98122 21.992024,-21.2604 z"
+         fill="url(#b)"
+         id="path294"
+         style="display:inline;fill:url(#b);stroke-width:4.81331;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.135116;marker:none;enable-background:accumulate"
-         d="m 342.43453,133.5 c -0.0499,0 -0.0992,0.005 -0.14846,0.0114 -0.63275,0.19268 -0.84778,1.10823 -0.35998,1.53887 l 5.15449,4.82872 c 0.52901,0.47937 1.38249,0.0699 1.41036,-0.62634 v -1.36063 c 0.0226,-4.21424 0.33006,-4.29412 -3.66401,-4.38062 h -2.24263 c -0.0493,-0.007 -0.0999,-0.0114 -0.14977,-0.0114 z m -12.63559,0.0804 c -5.53701,-3.3e-4 -6.32794,0.58227 -6.29884,6.26467 v 8.19515 8.19514 c -0.0291,5.68242 1.00827,6.26467 6.54528,6.26467 h 11.7978 c 5.49726,0 6.52858,-0.57993 6.54266,-6.15295 v -11.14923 c -0.006,-1.25658 -1.15546,-2.31787 -2.08629,-3.11916 l -0.008,-0.006 -6.70166,-6.47491 c -1.50985,-1.36345 -2.55339,-2.01695 -4.61908,-2.01707 z m 7.22852,2.4196 8.97205,8.99977 v 13.00023 c 0,0 -0.11213,1.17819 -0.44846,1.49951 -0.33633,0.32134 -1.56951,0.42847 -1.56951,0.42847 h -15.96407 c 0,0 -1.23318,-0.10713 -1.56951,-0.42847 -0.33632,-0.32132 -0.44845,-1.49951 -0.44845,-1.49951 l -0.018,-20.07203 c 0,0 0.11213,-1.17819 0.44845,-1.49951 0.33637,-0.32133 1.56955,-0.42846 1.56955,-0.42846 z"
-         id="rect4158-92-6-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="M 249.91243,248.15471 C 249.7199,260.87149 244.03052,267.53311 232.81555,268 l -77.41253,-9.0394 V 51.612728 l 79.82395,-7.4847 c 10.63261,-1.07337 15.27745,4.6304 15.35928,16.06202 z"
+         fill-opacity="0.15"
+         id="path296"
+         style="display:inline;stroke-width:4.81331;enable-background:new" />
       <path
-         style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 323.49951,148 v 0.041 8.19531 c -0.0291,5.68242 1.00791,6.26367 6.54492,6.26367 h 11.79883 c 5.49726,0 6.52889,-0.57932 6.54297,-6.15234 v -8.34764 z"
-         id="rect4398"
-         inkscape:connector-curvature="0" />
+         d="m 363.67111,105.16445 -11.9454,-0.0138 V 62.549487 l 12.28741,-0.04448 c 2.13504,0.0257 3.20257,1.688269 3.20257,3.685924 v 35.115609 c 0.0929,2.19336 -1.35615,3.81046 -3.54458,3.85791 z"
+         fill="url(#a)"
+         id="path399"
+         style="display:inline;fill:url(#linearGradient409);stroke-width:0.988448;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 353.50267,61.373185 c -0.13268,1.3e-4 -0.25604,0.01264 -0.36719,0.0293 l -0.0781,0.01172 -0.0762,0.02344 c -0.87574,0.279121 -1.39412,1.031903 -1.56445,1.792968 -0.1518,0.678132 0.0116,1.444638 0.51367,2.050782 l -0.36328,-0.363282 -0.01,-0.0078 -0.002,-0.0039 c 0,0 -0.002,0.0038 -0.002,0.0039 -0.28283,-0.267301 -0.55686,-0.524525 -0.83398,-0.767578 h -0.002 l -0.002,-0.0039 -0.002,-0.002 c 0,0 -0.006,-0.0019 -0.006,-0.002 -0.2711,-0.237536 -0.5406,-0.460957 -0.81055,-0.669923 0,0 -0.006,-0.0038 -0.006,-0.0039 -1.8e-4,-8.6e-5 -0.006,-0.0038 -0.006,-0.0039 -0.26922,-0.208011 -0.54257,-0.405967 -0.82617,-0.587891 h -0.002 l -0.002,-0.002 c 0,10e-7 -0.004,-0.0019 -0.004,-0.002 -0.27684,-0.177258 -0.55998,-0.341168 -0.85742,-0.488281 1e-5,0 -0.006,-0.0019 -0.006,-0.002 -0.29595,-0.146081 -0.60404,-0.275888 -0.92383,-0.386719 l -0.004,-0.002 h -0.002 -0.002 c -0.31787,-0.109783 -0.64897,-0.202793 -0.99414,-0.275391 0,-1e-6 -0.009,7.3e-5 -0.01,0 -0.34183,-0.07151 -0.69666,-0.126987 -1.07031,-0.162109 h -0.002 c -0.37669,-0.03533 -0.76878,-0.05072 -1.17774,-0.05078 h -0.002 -8.26738 c -4.1516,0 -6.86541,0.144562 -8.65234,1.832031 -0.89392,0.844181 -1.42053,2.015243 -1.71289,3.464843 -0.29235,1.449602 -0.3762,2.716182 -0.36524,4.956606 v 12.746094 12.751955 c -0.0108,2.23702 0.0732,4.00312 0.36524,5.45117 0.29236,1.44961 0.81896,2.62067 1.71289,3.46485 0.22046,0.20818 0.46372,0.3989 0.72656,0.5664 l 0.004,0.002 0.006,0.004 c 0,0 0.011,0.004 0.0117,0.004 0.24938,0.15738 0.51414,0.29744 0.79688,0.41797 l 0.006,0.002 c 10e-4,5.8e-4 0.003,0.003 0.004,0.004 h 0.002 c 0.001,2.9e-4 0.01,0.003 0.0117,0.004 0.28562,0.12045 0.58739,0.22665 0.90625,0.31446 h 0.002 0.002 c 0.31721,0.0872 0.65158,0.16192 1.00586,0.22265 h 0.004 0.002 0.002 c 0.35215,0.0602 0.71743,0.1063 1.10157,0.14453 2e-5,0 0.005,-1e-5 0.006,0 0.38435,0.0381 0.78775,0.0683 1.21289,0.0899 h 0.004 0.002 c 4.7e-4,1e-5 0.005,-1e-5 0.006,0 l 0.004,0.002 c 3.5e-4,1e-5 0.0746,-7e-5 0.0723,0 0.83602,0.0405 3.76301,0.0566 2.7539,0.0566 h 0.002 17.03691 c 4.12301,0 6.31689,-0.14175 8.10202,-1.80273 0.89298,-0.83017 1.42413,-1.9843 1.72461,-3.41016 0.30048,-1.42587 0.39703,-3.16132 0.40234,-5.35937 v -18.908211 -0.002 c -0.009,-1.901937 -1.18883,-3.38937 -2.32226,-4.541016 -0.37676,-0.382884 -0.75737,-0.733609 -1.10938,-1.050781 l -0.28515,-0.257813 h 0.0273 l -0.0117,-0.01172 h -0.002 l -0.0508,-0.05078 c 0.7203,0.562642 1.63962,0.613597 2.36523,0.31836 0.78035,-0.317514 1.50219,-1.045367 1.54102,-2.060547 v -0.01953 -2.13086 -0.0059 c 0.008,-1.627913 0.0362,-2.366723 -0.0274,-3.374573 -0.0638,-1.009375 -0.2058,-1.850441 -0.73633,-2.546875 -0.53053,-0.696434 -1.36221,-1.029213 -2.28515,-1.181641 -0.92293,-0.152428 -2.03533,-0.179157 -3.52344,-0.212891 h -0.0117 -2.84421 -0.002 c -0.073,-0.0069 -0.14393,-0.0174 -0.2207,-0.01758 z m -24.57206,43.876525 c 7.7e-4,4.2e-4 10e-4,0.002 0.002,0.002 -0.0334,0.003 -0.0689,0.006 -0.0684,0.006 5.2e-4,-8e-5 0.0335,-0.004 0.0664,-0.008 z m -0.0312,1.98438 c 0.005,2.6e-4 0.0335,0.004 0.0645,0.006 -0.0263,-10e-4 -0.0586,-0.004 -0.0586,-0.004 z"
-         id="path964-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccscccccccccccccccccccccccccccccccscsccccccccccccccccccsccccccccccccccc" />
+         d="m 344.77,62.556407 16.32125,-1.530118 c 2.18349,-0.220424 3.13734,0.950886 3.15414,3.298451 l -0.13837,38.59988 c -0.0395,2.61149 -1.20789,3.9795 -3.51097,4.07538 l -15.71929,-1.83555 h -16.7878 c -2.14395,0 -4.32249,-1.7456 -4.33435,-4.46581 V 66.870982 c 0.082,-3.129426 1.38679,-4.308644 4.51622,-4.365975 z"
+         fill="url(#b)"
+         id="path401"
+         style="display:inline;fill:url(#linearGradient407);stroke-width:0.988448;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6668);enable-background:accumulate"
-         d="m 102.92188,46 c -35.29673,0 -38.92188,3.625611 -38.92188,38.994141 v 71.005859 2 71.00586 c 0,15.47373 0.693319,24.87213 4.429688,30.54883 0.533765,0.81095 1.130124,1.54501 1.794921,2.21093 5.31838,5.32748 15.048901,6.23438 32.697271,6.23438 h 98.15624 c 2.05464,0 3.9874,-0.0148 5.83399,-0.0449 0.6589,-0.0108 1.26119,-0.0352 1.89453,-0.0508 1.14935,-0.0283 2.29189,-0.0591 3.35938,-0.10547 1.26994,-0.0552 2.50934,-0.11952 3.66796,-0.20508 0.47389,-0.035 0.93478,-0.0745 1.39063,-0.11523 0.22056,-0.0197 0.44963,-0.0375 0.66601,-0.0586 0.72759,-0.0709 1.43573,-0.14684 2.11719,-0.23437 0.66796,-0.0858 1.31051,-0.18193 1.93555,-0.28516 0.22197,-0.0367 0.43176,-0.0802 0.64844,-0.11914 0.39648,-0.0713 0.79087,-0.14326 1.16992,-0.22266 0.24847,-0.052 0.4874,-0.10842 0.72851,-0.16406 0.31951,-0.0737 0.63656,-0.15017 0.94336,-0.23047 0.25892,-0.0678 0.51169,-0.13834 0.76172,-0.21094 0.28349,-0.0823 0.56172,-0.16909 0.83399,-0.25781 0.22709,-0.074 0.45245,-0.1499 0.67187,-0.22851 0.28508,-0.10213 0.5616,-0.20821 0.83399,-0.31836 0.19615,-0.0793 0.39429,-0.15856 0.58398,-0.24219 0.27476,-0.12111 0.53736,-0.25048 0.79883,-0.38086 0.17443,-0.087 0.3548,-0.17048 0.52344,-0.26172 0.40967,-0.22161 0.80523,-0.45357 1.18164,-0.70117 0.40638,-0.26732 0.79483,-0.54837 1.16406,-0.84766 0.33966,-0.27532 0.65922,-0.56925 0.96875,-0.87304 0.0745,-0.0731 0.14592,-0.14979 0.21875,-0.22461 0.22962,-0.23599 0.45095,-0.48113 0.66406,-0.73438 0.077,-0.0915 0.15554,-0.18158 0.23047,-0.27539 0.54111,-0.67772 1.02765,-1.41677 1.46484,-2.2207 0.0553,-0.10155 0.10843,-0.20689 0.16211,-0.31055 0.15861,-0.30642 0.3098,-0.62208 0.45508,-0.94726 0.0614,-0.1373 0.12454,-0.27336 0.1836,-0.41407 0.1819,-0.4336 0.35679,-0.8789 0.51757,-1.3457 0.16052,-0.46603 0.30667,-0.95474 0.44727,-1.45508 0.0408,-0.14516 0.08,-0.29328 0.11914,-0.4414 0.0645,-0.24379 0.12339,-0.50007 0.18359,-0.75196 0.14384,-0.60169 0.27581,-1.22778 0.39649,-1.87695 0.0319,-0.17177 0.0674,-0.3385 0.0976,-0.51367 0.14069,-0.8111 0.26747,-1.65503 0.37696,-2.54102 0.022,-0.17777 0.0398,-0.36992 0.0605,-0.55078 0.0825,-0.71822 0.15576,-1.46049 0.22071,-2.22851 0.0255,-0.30185 0.0493,-0.60826 0.0723,-0.91797 0.057,-0.7684 0.10605,-1.56297 0.14844,-2.38086 0.0132,-0.25434 0.0311,-0.49859 0.043,-0.75782 0.007,-0.14749 0.009,-0.31184 0.0156,-0.46093 0.0622,-1.46308 0.10249,-3.01983 0.12891,-4.64063 0.007,-0.4186 0.0128,-0.84593 0.0176,-1.27539 0.0196,-1.77364 0.0291,-3.60559 0.0195,-5.57031 v -100.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67689,-10.56116 -18.05782,-15.619141 -32.66602,-15.619141 z m 96.98242,0.08984 c -2.16918,2.775877 -2.38539,7.403545 0.20898,9.912109 l 28.4961,30.386719 c 3.72376,3.695922 11.11845,0.568263 11.38085,-4.779297 -0.002,-0.42002 0.001,-0.861231 -0.002,-1.271484 -9e-4,-0.49135 -0.009,-0.953362 -0.0117,-1.431641 -0.36165,-27.253999 -4.96046,-32.190518 -31.3457,-32.816406 z"
-         id="path5316-1" />
+         d="m 364.10702,102.92462 c -0.0395,2.61149 -1.20789,3.9795 -3.51097,4.07538 l -15.89721,-1.85631 V 62.563326 l 16.39241,-1.537037 c 2.18349,-0.220424 3.13734,0.950886 3.15414,3.298451 z"
+         fill-opacity="0.15"
+         id="path403"
+         style="display:inline;stroke-width:0.988448;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6646);enable-background:accumulate"
-         d="m 102.92188,45 c -35.29673,0 -38.92188,3.625611 -38.92188,38.994141 v 72.005859 1 72.00586 c 0,15.47373 0.693319,24.87213 4.429688,30.54883 0.533765,0.81095 1.130124,1.54501 1.794921,2.21093 5.31838,5.32748 15.048901,6.23438 32.697271,6.23438 h 98.15624 c 2.05464,0 3.9874,-0.0148 5.83399,-0.0449 0.6589,-0.0108 1.26119,-0.0352 1.89453,-0.0508 1.14935,-0.0283 2.29189,-0.0591 3.35938,-0.10547 1.26994,-0.0552 2.50934,-0.11952 3.66796,-0.20508 0.47389,-0.035 0.93478,-0.0745 1.39063,-0.11523 0.22056,-0.0197 0.44963,-0.0375 0.66601,-0.0586 0.72759,-0.0709 1.43573,-0.14684 2.11719,-0.23437 0.66796,-0.0858 1.31051,-0.18193 1.93555,-0.28516 0.22197,-0.0367 0.43176,-0.0802 0.64844,-0.11914 0.39648,-0.0713 0.79087,-0.14326 1.16992,-0.22266 0.24847,-0.052 0.4874,-0.10842 0.72851,-0.16406 0.31951,-0.0737 0.63656,-0.15017 0.94336,-0.23047 0.25892,-0.0678 0.51169,-0.13834 0.76172,-0.21094 0.28349,-0.0823 0.56172,-0.16909 0.83399,-0.25781 0.22709,-0.074 0.45245,-0.1499 0.67187,-0.22851 0.28508,-0.10213 0.5616,-0.20821 0.83399,-0.31836 0.19615,-0.0793 0.39429,-0.15856 0.58398,-0.24219 0.27476,-0.12111 0.53736,-0.25048 0.79883,-0.38086 0.17443,-0.087 0.3548,-0.17048 0.52344,-0.26172 0.40967,-0.22161 0.80523,-0.45357 1.18164,-0.70117 0.40638,-0.26732 0.79483,-0.54837 1.16406,-0.84766 0.33966,-0.27532 0.65922,-0.56925 0.96875,-0.87304 0.0745,-0.0731 0.14592,-0.14979 0.21875,-0.22461 0.22962,-0.23599 0.45095,-0.48113 0.66406,-0.73438 0.077,-0.0915 0.15554,-0.18158 0.23047,-0.27539 0.54111,-0.67772 1.02765,-1.41677 1.46484,-2.2207 0.0553,-0.10155 0.10843,-0.20689 0.16211,-0.31055 0.15861,-0.30642 0.3098,-0.62208 0.45508,-0.94726 0.0614,-0.1373 0.12454,-0.27336 0.1836,-0.41407 0.1819,-0.4336 0.35679,-0.8789 0.51757,-1.3457 0.16052,-0.46603 0.30667,-0.95474 0.44727,-1.45508 0.0408,-0.14516 0.08,-0.29328 0.11914,-0.4414 0.0645,-0.24379 0.12339,-0.50007 0.18359,-0.75196 0.14384,-0.60169 0.27581,-1.22778 0.39649,-1.87695 0.0319,-0.17177 0.0674,-0.3385 0.0976,-0.51367 0.14069,-0.8111 0.26747,-1.65503 0.37696,-2.54102 0.022,-0.17777 0.0398,-0.36992 0.0605,-0.55078 0.0825,-0.71822 0.15576,-1.46049 0.22071,-2.22851 0.0255,-0.30185 0.0493,-0.60826 0.0723,-0.91797 0.057,-0.7684 0.10605,-1.56297 0.14844,-2.38086 0.0132,-0.25434 0.0311,-0.49859 0.043,-0.75782 0.007,-0.14749 0.009,-0.31184 0.0156,-0.46093 0.0622,-1.46308 0.10249,-3.01983 0.12891,-4.64063 0.007,-0.4186 0.0128,-0.84593 0.0176,-1.27539 0.0196,-1.77364 0.0291,-3.60559 0.0195,-5.57031 v -101.76563 c -0.044,-9.7329 -8.17907,-17.95561 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67689,-10.56116 -18.05782,-15.619141 -32.66602,-15.619141 z m 97.96874,0.08984 c -3.03973,2.502305 -3.72055,8.066242 -0.77734,10.912109 l 28.4961,30.386719 c 3.72891,3.701032 11.14177,0.560315 11.38476,-4.800781 -2.2e-4,-0.210853 -10e-4,-0.418504 -0.002,-0.626953 -1e-4,-1.198304 -0.0128,-2.328552 -0.0254,-3.451172 -0.40326,-26.889233 -5.08512,-31.797223 -31.33594,-32.419922 z"
-         id="path5316-84" />
+         d="m 348.82898,161.8029 -7.79048,-0.009 v -27.78336 l 8.01353,-0.029 c 1.39242,0.0168 2.08864,1.10104 2.08864,2.40386 v 22.90148 c 0.0606,1.43046 -0.88444,2.48509 -2.31169,2.51603 z"
+         fill="url(#a)"
+         id="path411"
+         style="display:inline;fill:url(#linearGradient421);stroke-width:0.64464;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -2.17574,0 -4.226351,0.01468 -6.167974,0.04883 -29.48187,0.527845 -32.667968,5.787316 -32.667968,38.945313 v 73.005857 73.00586 c 0,33.158 3.186098,38.41747 32.667968,38.94531 1.941623,0.0342 3.992234,0.0488 6.167974,0.0488 0.0303,10e-6 0.0556,0 0.0859,0 h 98.07031 c 2.05464,0 3.9874,-0.0148 5.83399,-0.0449 0.6589,-0.0108 1.26119,-0.0352 1.89453,-0.0508 1.14935,-0.0283 2.29189,-0.0591 3.35938,-0.10547 1.26994,-0.0552 2.50934,-0.11952 3.66796,-0.20508 0.47389,-0.035 0.93478,-0.0745 1.39063,-0.11523 0.22056,-0.0197 0.44963,-0.0375 0.66601,-0.0586 0.72759,-0.0709 1.43573,-0.14684 2.11719,-0.23437 0.66796,-0.0858 1.31051,-0.18193 1.93555,-0.28516 0.22197,-0.0367 0.43176,-0.0802 0.64844,-0.11914 0.39648,-0.0713 0.79087,-0.14326 1.16992,-0.22266 0.24847,-0.052 0.4874,-0.10842 0.72851,-0.16406 0.31951,-0.0737 0.63656,-0.15017 0.94336,-0.23047 0.25892,-0.0678 0.51169,-0.13834 0.76172,-0.21094 0.28349,-0.0823 0.56172,-0.16909 0.83399,-0.25781 0.22709,-0.074 0.45245,-0.1499 0.67187,-0.22851 0.28508,-0.10213 0.5616,-0.20821 0.83399,-0.31836 0.19615,-0.0793 0.39429,-0.15856 0.58398,-0.24219 0.27476,-0.12111 0.53736,-0.25048 0.79883,-0.38086 0.17443,-0.087 0.3548,-0.17048 0.52344,-0.26172 0.40967,-0.22161 0.80523,-0.45357 1.18164,-0.70117 0.40638,-0.26732 0.79483,-0.54837 1.16406,-0.84766 0.33966,-0.27532 0.65922,-0.56925 0.96875,-0.87304 0.0745,-0.0731 0.14592,-0.14979 0.21875,-0.22461 0.22962,-0.23599 0.45095,-0.48113 0.66406,-0.73438 0.077,-0.0915 0.15554,-0.18158 0.23047,-0.27539 0.54111,-0.67772 1.02765,-1.41677 1.46484,-2.2207 0.0553,-0.10155 0.10843,-0.20689 0.16211,-0.31055 0.15861,-0.30642 0.3098,-0.62208 0.45508,-0.94726 0.0614,-0.1373 0.12454,-0.27336 0.1836,-0.41407 0.1819,-0.4336 0.35679,-0.8789 0.51757,-1.3457 0.16052,-0.46603 0.30667,-0.95474 0.44727,-1.45508 0.0408,-0.14516 0.08,-0.29328 0.11914,-0.4414 0.0645,-0.24379 0.12339,-0.50007 0.18359,-0.75196 0.14384,-0.60169 0.27581,-1.22778 0.39649,-1.87695 0.0319,-0.17177 0.0674,-0.3385 0.0976,-0.51367 0.14069,-0.8111 0.26747,-1.65503 0.37696,-2.54102 0.022,-0.17777 0.0398,-0.36992 0.0605,-0.55078 0.0825,-0.71822 0.15576,-1.46049 0.22071,-2.22851 0.0255,-0.30185 0.0493,-0.60826 0.0723,-0.91797 0.057,-0.7684 0.10605,-1.56297 0.14844,-2.38086 0.0132,-0.25434 0.0311,-0.49859 0.043,-0.75782 0.007,-0.14749 0.009,-0.31184 0.0156,-0.46093 0.0622,-1.46308 0.10249,-3.01983 0.12891,-4.64063 0.007,-0.4186 0.0128,-0.84593 0.0176,-1.27539 0.0196,-1.77364 0.0291,-3.60559 0.0195,-5.57031 v -102.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408197 c -10.67684,-10.56116 -18.05782,-15.619141 -32.66602,-15.619141 z m 99.73242,0.08984 c -4.47461,1.4924 -5.99062,8.576599 -2.54102,11.912109 l 28.4961,30.386719 c 3.73355,3.705631 11.16128,0.552964 11.38671,-4.820313 0.0482,-31.329014 -3.55328,-36.818783 -31.36523,-37.478515 z"
-         id="path5316-3" />
+         d="m 336.50218,134.01505 10.64429,-0.9979 c 1.42402,-0.14376 2.04609,0.62014 2.05705,2.15116 l -0.0902,25.17383 c -0.0258,1.70315 -0.78776,2.59533 -2.28977,2.65786 l -10.25176,-1.1971 h -10.94855 c -1.39824,0 -2.81903,-1.13843 -2.82675,-2.91248 V 136.8289 c 0.0535,-2.04093 0.90442,-2.80998 2.94535,-2.84737 z"
+         fill="url(#b)"
+         id="path413"
+         style="display:inline;fill:url(#linearGradient419);stroke-width:0.64464;enable-background:new" />
       <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
+         d="m 349.11327,160.34214 c -0.0258,1.70315 -0.78776,2.59533 -2.28977,2.65786 l -10.36774,-1.21064 v -27.7698 l 10.6907,-1.00241 c 1.42402,-0.14376 2.04609,0.62014 2.05705,2.15116 z"
+         fill-opacity="0.15"
+         id="path415"
+         style="display:inline;stroke-width:0.64464;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44.000001 c -35.29672,0 -38.92188,3.62561 -38.92188,38.99414 v 73.005859 73.00586 c 0,35.36853 3.62516,38.99414 38.92188,38.99414 h 98.15625 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 v -102.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67686,-10.56118 -18.05785,-15.61912 -32.66605,-15.61912 z"
-         id="path5316"
-         inkscape:connector-curvature="0" />
+         d="m 341.40788,210.12213 -5.71301,-0.007 v -20.37447 l 5.87658,-0.0213 c 1.02111,0.0123 1.53167,0.80743 1.53167,1.76283 v 16.79442 c 0.0444,1.049 -0.64859,1.8224 -1.69524,1.84509 z"
+         fill="url(#a)"
+         id="path423"
+         style="display:inline;fill:url(#linearGradient433);stroke-width:0.472736;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 v 2.89258 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 0.0896,-0.53386 0.10352,-1.11551 0.10352,-1.83594 v -3.89844 -2.89844 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 -0.5334,-0.0898 -1.11494,-0.10352 -1.83398,-0.10352 z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
+         d="m 332.36823,189.74437 7.80581,-0.73179 c 1.04428,-0.10543 1.50047,0.45477 1.50851,1.57751 l -0.0661,18.46081 c -0.0189,1.24898 -0.57769,1.90325 -1.67916,1.9491 l -7.51796,-0.87787 h -8.02894 c -1.02538,0 -2.06729,-0.83485 -2.07295,-2.13582 v -16.17845 c 0.0392,-1.49668 0.66324,-2.06065 2.15992,-2.08807 z"
+         fill="url(#b)"
+         id="path425"
+         style="display:inline;fill:url(#linearGradient431);stroke-width:0.472736;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 337.5918,62.441406 c -3.18669,0.198842 -6.5234,-0.26023 -9.4336,1.251953 -1.93123,1.799721 -1.17054,4.776219 -1.42773,7.105469 -0.0895,10.346849 -0.0245,20.693861 -0.0449,31.041012 0.48752,1.58457 1.54822,3.11031 3.33984,3.27735 6.59857,0.51411 13.33932,0.13893 20.00977,0.21289 2.92787,-0.14459 5.94285,0.22534 8.8164,-0.40625 2.79248,-1.22133 2.45492,-4.84836 2.54688,-7.349611 0.11782,-6.565932 0.13479,-13.132658 0.20312,-19.699219 -1.39639,-2.905699 -4.00948,-4.889053 -6.15429,-7.277344 -2.64774,-2.502795 -5.08691,-5.336832 -8.13282,-7.353515 -3.07089,-1.166086 -6.50861,-0.681488 -9.72265,-0.802735 z"
-         id="path964"
-         inkscape:connector-curvature="0" />
+         d="m 341.61636,209.0509 c -0.0189,1.24898 -0.57769,1.90325 -1.67916,1.9491 l -7.60301,-0.8878 v -20.36452 l 7.83985,-0.7351 c 1.04428,-0.10543 1.50046,0.45477 1.5085,1.57751 z"
+         fill-opacity="0.15"
+         id="path427"
+         style="display:inline;stroke-width:0.472736;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.205504;marker:none;enable-background:accumulate"
-         d="m 353.5,61.375 c -0.0742,0 -0.1474,0.0066 -0.2207,0.01758 -0.94065,0.29981 -1.26034,1.724451 -0.53516,2.394531 l 7.51367,7.513672 c 0.78643,0.74591 2.35309,0.108771 2.39453,-0.974609 v -2.117188 c 0.0336,-6.55752 0.34204,-6.681806 -5.5957,-6.816406 h -3.33398 c -0.0733,-0.0113 -0.14848,-0.01758 -0.22266,-0.01758 z m -18.26953,0.125 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 v 12.751953 12.751953 c -0.0433,8.842037 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70563,-0.9024 9.72656,-9.574219 v -18.904297 c -0.009,-1.95527 -1.71775,-3.606675 -3.10156,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 c -2.24459,-2.121578 -3.79625,-3.138638 -6.8672,-3.138638 z m 11.26953,3.5 12.5,12.5 v 22.5 c 0,0 -0.1667,1.8333 -0.6667,2.3333 -0.5,0.5 -2.3333,0.6667 -2.3333,0.6667 h -24 c 0,0 -1.8333,-0.1667 -2.3333,-0.6667 -0.5,-0.5 -0.6667,-2.3333 -0.6667,-2.3333 v -32 c 0,0 0.1667,-1.8333 0.6667,-2.3333 0.5,-0.5 2.3333,-0.6667 2.3333,-0.6667 z"
-         id="rect4158-92-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 333.98685,250.44136 -3.63555,-0.004 v -12.96557 l 3.73964,-0.0135 c 0.6498,0.008 0.9747,0.51382 0.9747,1.1218 v 10.68736 c 0.0283,0.66754 -0.41274,1.15971 -1.07879,1.17415 z"
+         fill="url(#a)"
+         id="path435"
+         style="display:inline;fill:url(#linearGradient445);stroke-width:0.300832;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.90435,236.5 c 0.71048,0 1.27344,0.0154 1.75195,0.0957 0.47851,0.0803 0.89671,0.23728 1.20703,0.54688 0.31032,0.30959 0.46726,0.7261 0.54688,1.20508 0.0796,0.47897 0.0933,1.04352 0.0898,1.75586 v 3.89648 3.89844 c 0.003,0.71121 -0.0103,1.27546 -0.0898,1.7539 -0.0796,0.47898 -0.23655,0.89549 -0.54688,1.20508 -0.31033,0.3096 -0.72851,0.46655 -1.20703,0.54688 -0.47852,0.0803 -1.04147,0.0957 -1.75195,0.0957 h -5.8086 c -0.71048,0 -1.27236,-0.0153 -1.75,-0.0957 -0.47763,-0.0804 -0.89584,-0.23713 -1.20508,-0.54688 -0.30921,-0.30975 -0.46469,-0.72681 -0.54492,-1.20508 -0.0802,-0.47826 -0.0957,-1.04201 -0.0957,-1.7539 v -3.89844 -3.89844 c 0,-0.71189 0.0155,-1.27564 0.0957,-1.7539 0.0802,-0.47827 0.2357,-0.89533 0.54492,-1.20508 0.30924,-0.30975 0.72745,-0.4665 1.20508,-0.54688 0.47764,-0.0804 1.03952,-0.0957 1.75,-0.0957 z"
-         id="path918"
-         inkscape:connector-curvature="0" />
+         d="m 328.23435,237.47369 4.96733,-0.46568 c 0.66454,-0.0671 0.95486,0.2894 0.95997,1.00387 l -0.0421,11.74779 c -0.012,0.7948 -0.36762,1.21116 -1.06856,1.24033 l -4.78415,-0.55864 h -5.10933 c -0.65252,0 -1.31555,-0.53127 -1.31915,-1.35916 v -10.29538 c 0.025,-0.95243 0.42206,-1.31132 1.37449,-1.32877 z"
+         fill="url(#b)"
+         id="path437"
+         style="display:inline;fill:url(#linearGradient443);stroke-width:0.300832;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 336.13453,188.5 c 1.11158,0 1.98683,0.0256 2.70703,0.14648 0.72019,0.1209 1.3105,0.34863 1.74218,0.7793 0.43169,0.43067 0.65954,1.01974 0.7793,1.74024 0.11977,0.72049 0.14217,1.59669 0.13672,2.71093 v 6.12305 6.125 c 0.005,1.1131 -0.017,1.989 -0.13672,2.70898 -0.11976,0.72051 -0.3476,1.30957 -0.7793,1.74024 -0.43169,0.43067 -1.02199,0.6584 -1.74218,0.7793 -0.7202,0.12089 -1.59545,0.14648 -2.70703,0.14648 h -8.26954 c -1.11158,0 -1.98637,-0.0255 -2.70507,-0.14648 -0.7187,-0.12095 -1.30623,-0.34848 -1.73633,-0.7793 -0.4301,-0.43083 -0.6566,-1.01849 -0.77735,-1.73828 -0.12074,-0.71979 -0.14648,-1.59713 -0.14648,-2.71094 v -6.125 -6.125 c 0,-1.11381 0.0257,-1.99115 0.14648,-2.71094 0.12075,-0.71979 0.34725,-1.30745 0.77735,-1.73828 0.4301,-0.43082 1.01763,-0.65835 1.73633,-0.7793 0.7187,-0.12094 1.59349,-0.14648 2.70507,-0.14648 z"
-         id="path914"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1309);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0962,238 c -0.6888,0 -1.1839,0.0205 -1.5039,0.0742 -0.30449,0.0511 -0.38369,0.11806 -0.39649,0.13086 -0.0131,0.0131 -0.0746,0.0855 -0.125,0.38867 -0.0529,0.31839 -0.0733,0.81274 -0.0703,1.50195 v 0.004 3.90039 3.90234 0.002 c -0.003,0.68916 0.0176,1.18495 0.0703,1.50195 0.0504,0.30317 0.1119,0.37557 0.125,0.38867 0.0128,0.0128 0.0918,0.0798 0.39649,0.13086 0.32002,0.0537 0.8151,0.0742 1.5039,0.0742 h 5.8086 c 0.68894,0 1.18348,-0.0206 1.50195,-0.0742 0.30433,-0.0512 0.38043,-0.1186 0.39063,-0.1289 0.0112,-0.0112 0.0774,-0.0858 0.1289,-0.39258 0.0536,-0.31974 0.0742,-0.81575 0.0742,-1.50586 v -3.89855 -3 l -3,-3 z"
-         id="path1291" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1311);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86573,190 c -1.08855,0 -1.90034,0.0312 -2.45898,0.125 -0.54887,0.0921 -0.79683,0.22878 -0.93164,0.36328 -0.13436,0.13404 -0.26642,0.37645 -0.35742,0.92383 -0.0925,0.55627 -0.12219,1.36674 -0.11719,2.45703 v 0.004 6.12695 6.12891 0.002 c -0.005,1.0898 0.0249,1.9019 0.11719,2.45703 0.091,0.5474 0.22306,0.78979 0.35742,0.92383 0.13484,0.13452 0.38277,0.27118 0.93164,0.36328 0.55862,0.0938 1.37043,0.125 2.45898,0.125 h 8.26954 c 1.08864,0 1.90078,-0.0314 2.45703,-0.125 0.54703,-0.0921 0.78777,-0.227 0.92187,-0.36133 0.13429,-0.13451 0.26913,-0.37646 0.36133,-0.92578 0.0936,-0.55811 0.125,-1.37233 0.125,-2.46303 v -6.125 -3 l -7.0005,-7 z"
-         id="path1293"
-         sodipodi:nodetypes="scccccccccccsscccscccs" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 323.0005,200 v 6.125 c -0.0217,4.42101 0.45314,4.875 4.86523,4.875 h 8.26954 c 4.41209,0 4.86523,-0.45393 4.86523,-4.875 v -6.125 z"
-         id="path1007"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 322.0005,244 v 3.89844 c -0.0138,2.81337 0.28801,3.10156 3.0957,3.10156 h 5.8086 c 2.8077,0 3.0957,-0.28815 3.0957,-3.10156 v -3.89844 z"
-         id="path1016"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 325.50195,84 v 12.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 v -12.925781 z"
-         id="path964-0"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18820-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -12.133256,0 -20.524924,0.428807 -26.312505,2.427734 -2.103582,0.726592 -3.86351,1.661084 -5.333984,2.857422 -6.99e-4,5.68e-4 -0.0013,0.0014 -0.002,0.002 -1.102245,0.897465 -2.04362,1.942559 -2.84375,3.158203 -0.25536,0.38797 -0.493017,0.797219 -0.720704,1.220704 -0.05742,0.106782 -0.110296,0.220977 -0.166015,0.330078 -0.160525,0.314347 -0.31609,0.634772 -0.462891,0.96875 -0.07313,0.166359 -0.141108,0.340381 -0.210937,0.511718 -0.121003,0.2969 -0.240173,0.598017 -0.351563,0.910157 -0.07072,0.198194 -0.138107,0.401007 -0.205078,0.605469 -0.09969,0.304302 -0.195472,0.615147 -0.287109,0.933593 -0.06012,0.208926 -0.119021,0.41964 -0.175782,0.634766 -0.0932,0.353219 -0.18116,0.717644 -0.265625,1.087891 -0.04767,0.208948 -0.09564,0.414437 -0.140625,0.628906 -0.0813,0.387531 -0.155661,0.791385 -0.228515,1.197265 -0.03799,0.21171 -0.08141,0.416025 -0.117188,0.632813 -0.10327,0.625522 -0.197396,1.268747 -0.283203,1.9375 -8.5e-5,6.6e-4 8.5e-5,0.0013 0,0.002 -0.08424,0.656719 -0.159764,1.339307 -0.228515,2.039063 -0.02783,0.283412 -0.05073,0.582421 -0.07617,0.873046 -0.03812,0.435294 -0.0744,0.872494 -0.107422,1.324219 -0.08166,1.116973 -0.143662,2.302819 -0.197266,3.523438 -0.05039,1.146541 -0.08575,2.367502 -0.115234,3.609375 -0.01378,0.580741 -0.03511,1.124373 -0.04492,1.726562 -0.03028,1.853743 -0.04492,3.787114 -0.04492,5.851563 v 73.005855 73.00586 c 0,2.06445 0.01464,3.99782 0.04492,5.85156 0.0098,0.60219 0.03114,1.14582 0.04492,1.72656 0.02949,1.24188 0.06484,2.46284 0.115234,3.60938 0.0536,1.22062 0.115607,2.40646 0.197266,3.52344 0.03302,0.45172 0.0693,0.88892 0.107422,1.32422 0.02544,0.29062 0.04834,0.58963 0.07617,0.87304 0.06875,0.69976 0.144274,1.38235 0.228515,2.03906 8e-5,6.3e-4 -8e-5,10e-4 0,0.002 0.08581,0.66875 0.179933,1.31198 0.283203,1.9375 0.03578,0.21679 0.0792,0.4211 0.117188,0.63281 0.07285,0.40588 0.147218,0.80973 0.228515,1.19727 0.04498,0.21447 0.09296,0.41995 0.140625,0.6289 0.08446,0.37025 0.172428,0.73467 0.265625,1.08789 0.05676,0.21513 0.115665,0.42584 0.175782,0.63477 0.09164,0.31845 0.187417,0.62929 0.287109,0.93359 0.06697,0.20446 0.134353,0.40728 0.205078,0.60547 0.11139,0.31214 0.23056,0.61326 0.351563,0.91016 0.06983,0.17134 0.137808,0.34536 0.210937,0.51172 0.146801,0.33397 0.302366,0.6544 0.462891,0.96875 0.05572,0.1091 0.108595,0.22329 0.166015,0.33007 0.227687,0.42349 0.465344,0.83274 0.720704,1.22071 0.533766,0.81095 1.130124,1.545 1.794921,2.21093 0.332399,0.33297 0.681104,0.64798 1.048829,0.94727 7.16e-4,5.8e-4 0.0012,0.001 0.002,0.002 1.470474,1.19634 3.230402,2.13083 5.333984,2.85743 5.787581,1.99892 14.179249,2.42773 26.312505,2.42773 h 98.15624 c 2.05728,0 3.98527,-0.0147 5.83399,-0.0449 0.0115,-1.9e-4 0.0217,2e-4 0.0332,0 0.64544,-0.0111 1.23908,-0.0355 1.86133,-0.0508 0.45706,-0.0113 0.88533,-0.0281 1.33594,-0.041 0.67375,-0.0212 1.37929,-0.0364 2.02344,-0.0644 0.007,-3e-4 0.0127,-0.002 0.0195,-0.002 1.25269,-0.0546 2.47469,-0.11709 3.61914,-0.20118 0.01,-7.3e-4 0.0193,-10e-4 0.0293,-0.002 0.47389,-0.035 0.93478,-0.0745 1.39063,-0.11523 0.011,-9.8e-4 0.0222,-9.9e-4 0.0332,-0.002 0.21035,-0.0186 0.42719,-0.0366 0.63281,-0.0566 0.72759,-0.0709 1.43573,-0.14684 2.11719,-0.23437 0.66835,-0.0858 1.31017,-0.18189 1.93555,-0.28516 0.002,-3.4e-4 0.004,-0.002 0.006,-0.002 0.21969,-0.0365 0.42791,-0.0786 0.64258,-0.11719 0.39648,-0.0713 0.79087,-0.14326 1.16992,-0.22266 0.23853,-0.0499 0.4679,-0.10473 0.69922,-0.1582 0.01,-0.002 0.0195,-0.004 0.0293,-0.006 0.31951,-0.0737 0.63656,-0.15017 0.94336,-0.23047 0.25225,-0.0661 0.49847,-0.13446 0.74219,-0.20508 0.007,-0.002 0.0129,-0.004 0.0195,-0.006 0.28349,-0.0823 0.56172,-0.16909 0.83399,-0.25781 0.22709,-0.074 0.45245,-0.1499 0.67187,-0.22851 0.14966,-0.0536 0.29192,-0.11216 0.4375,-0.16797 0.13234,-0.0505 0.267,-0.098 0.39649,-0.15039 0.0111,-0.005 0.0221,-0.009 0.0332,-0.0137 0.18519,-0.0748 0.37186,-0.14964 0.55078,-0.22852 0.16735,-0.0738 0.32551,-0.15417 0.48633,-0.23242 0.10425,-0.0496 0.21026,-0.0975 0.3125,-0.14844 0.007,-0.004 0.0142,-0.008 0.0215,-0.0117 0.16707,-0.0828 0.33885,-0.16289 0.5,-0.25 5e-4,-2.7e-4 0.001,2.7e-4 0.002,0 0.40967,-0.22161 0.80523,-0.45357 1.18164,-0.70117 0.78027,-0.51326 1.48668,-1.08669 2.13281,-1.7207 0.001,-10e-4 0.003,-0.003 0.004,-0.004 0.0711,-0.07 0.13943,-0.14323 0.20898,-0.21484 0.002,-0.002 0.004,-0.004 0.006,-0.006 0.22962,-0.23599 0.45095,-0.48113 0.66406,-0.73438 0.077,-0.0915 0.15554,-0.18158 0.23047,-0.27539 0.54111,-0.67772 1.02765,-1.41677 1.46484,-2.2207 0.0553,-0.10155 0.10843,-0.20689 0.16211,-0.31055 0.15861,-0.30642 0.3098,-0.62208 0.45508,-0.94726 0.0608,-0.13598 0.12307,-0.27089 0.18164,-0.41016 5.5e-4,-10e-4 0.001,-0.003 0.002,-0.004 0.1819,-0.4336 0.35679,-0.8789 0.51757,-1.3457 0.16046,-0.46586 0.30672,-0.95495 0.44727,-1.45508 5.5e-4,-0.002 0.001,-0.004 0.002,-0.006 0.0402,-0.14328 0.0786,-0.28942 0.11719,-0.43554 0.036,-0.13607 0.0678,-0.27901 0.10156,-0.41993 0.0274,-0.10971 0.0554,-0.22073 0.082,-0.33203 6.1e-4,-0.003 10e-4,-0.005 0.002,-0.008 0.14313,-0.59937 0.27435,-1.22269 0.39453,-1.86914 0.0258,-0.13905 0.0523,-0.27642 0.0781,-0.41602 0.006,-0.0333 0.0137,-0.0642 0.0195,-0.0976 1.1e-4,-6.1e-4 -1e-4,-10e-4 0,-0.002 0.14057,-0.81053 0.26755,-1.65373 0.37696,-2.53906 0.006,-0.0479 0.0102,-0.099 0.0156,-0.14844 0.0159,-0.1309 0.0297,-0.26977 0.0449,-0.40234 0.002,-0.0201 0.004,-0.0423 0.006,-0.0625 0.079,-0.69309 0.15019,-1.40716 0.21289,-2.14648 5.5e-4,-0.006 0.001,-0.0131 0.002,-0.0195 0.0255,-0.30185 0.0493,-0.60826 0.0723,-0.91797 0.057,-0.7684 0.10605,-1.56297 0.14844,-2.38086 0.008,-0.15603 0.0182,-0.31062 0.0273,-0.46485 0.005,-0.0998 0.011,-0.19246 0.0156,-0.29297 4.1e-4,-0.009 -3.8e-4,-0.0185 0,-0.0273 0.006,-0.12849 0.009,-0.2663 0.0137,-0.39648 5e-4,-0.0117 0.001,-0.0254 0.002,-0.0371 0.0622,-1.46308 0.10249,-3.01983 0.12891,-4.64063 1.8e-4,-0.0109 -1.8e-4,-0.0223 0,-0.0332 0.007,-0.40814 0.0129,-0.82391 0.0176,-1.24219 0.0196,-1.77364 0.0291,-3.60559 0.0195,-5.57031 v -102.76563 c -0.008,-1.82491 -0.30087,-3.5971 -0.81445,-5.3125 -0.34239,-1.14359 -0.78284,-2.26106 -1.30274,-3.35351 -2.85943,-6.00849 -8.11896,-11.22913 -12.64453,-15.4961 l -0.0488,-0.0508 -40.52343,-42.408195 c -10.67695,-10.56113 -18.05782,-15.619141 -32.66602,-15.619141 z m 99.73242,0.08984 c -4.47461,1.4924 -5.99062,8.576599 -2.54102,11.912109 l 28.4961,30.386719 c 3.73355,3.705631 11.16128,0.552964 11.38671,-4.820313 0.003,-1.914857 -0.01,-3.726528 -0.0391,-5.453125 -0.003,-0.166807 -0.009,-0.319279 -0.0117,-0.484375 -0.0297,-1.557123 -0.0723,-3.047825 -0.13672,-4.457031 -0.0471,-1.032097 -0.1048,-2.024485 -0.17382,-2.980469 -1.15298,-15.945663 -5.54827,-21.536882 -19.66211,-23.361328 -1.29676,-0.167627 -2.6748,-0.302733 -4.14063,-0.412109 -0.70955,-0.05295 -1.44245,-0.09955 -2.19336,-0.140625 -0.009,-4.69e-4 -0.0187,-0.0015 -0.0273,-0.002 -1.56796,-0.085 -3.22479,-0.145853 -4.98047,-0.1875 z m -83.08789,11.855468 c 11.374,0.004 22.6305,0.04069 33.89843,0.246094 7.23783,-0.38505 13.8662,3.453873 18.85547,8.408203 16.10538,15.96283 31.4077,32.714023 47.27735,48.910165 3.41618,3.87653 8.26302,7.7632 8.17382,13.40039 0.36199,29.857 0.15427,59.71908 0.10547,89.57812 -0.26479,10.25015 0.39558,20.69609 -0.9082,30.96484 -0.54694,2.35759 -0.53276,6.03581 -3.5625,6.6504 -7.58888,1.84983 -15.51088,1.47 -23.26758,1.69726 -35.546,0.1779 -71.4284,0.29873 -106.976561,-0.13672 -4.70492,-0.41462 -9.87979,0.006 -14.11914,-2.38476 -2.82731,-3.81876 -2.108913,-9.00357 -2.445313,-13.48438 -0.58273,-48.6454 -0.702174,-97.30598 -0.583984,-145.972658 0.28307,-10.71667 -0.493631,-21.76848 1.568359,-32.4375 0.30831,-3.27336 3.855494,-4.007957 6.496094,-4.410157 11.78749,-1.12799 23.780885,-0.867606 35.488285,-1.029297 z"
-         id="rect4158-92-3" />
+         d="m 334.11952,249.75967 c -0.012,0.7948 -0.36762,1.21116 -1.06855,1.24033 l -4.83828,-0.56496 V 237.4758 l 4.98899,-0.46779 c 0.66454,-0.0671 0.95484,0.2894 0.95996,1.00387 z"
+         fill-opacity="0.15"
+         id="path439"
+         style="display:inline;stroke-width:0.300832;enable-background:new" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,156 v 73.00683 c -0.17299,35.36812 3.62515,38.99317 38.921885,38.99317 h 98.15624 c 35.29672,0 38.00361,-3.63655 38.92188,-38.99317 v -73.00683 z"
-         id="path4255"
-         sodipodi:nodetypes="ccssscc" />
+         d="M 89.566532,103.45692 H 209.6587 c 4.06725,0 7.34026,3.28268 7.34026,7.35474 v 75.3861 c 0,4.06725 -3.27301,7.3403 -7.34026,7.3403 h -50.96337 v 10.53153 h 13.742 v 9.92505 h -46.47734 v -9.92505 h 13.31362 V 193.53806 H 89.566532 c -4.06724,0 -7.340297,-3.27305 -7.340297,-7.3403 v -75.3861 c 0,-4.07206 3.273057,-7.35474 7.340297,-7.35474 z m 117.184878,84.84425 c 2.47891,0 4.46676,-1.98789 4.46676,-4.46675 v -70.51503 c 0,-2.47404 -1.98785,-4.47638 -4.46676,-4.47638 H 91.308952 c -2.47885,0 -4.46675,2.00234 -4.46675,4.47638 v 70.51503 c 0,2.47886 1.9879,4.46675 4.46675,4.46675 z m -82.03325,-28.8558 c 0.3995,-0.24548 1.38142,0.26473 1.38142,0.26473 2.61362,1.61246 10.77219,6.71457 13.39063,8.32703 0,0 0.94822,0.59685 0.93378,1.06855 -0.0192,0.38507 -0.8327,0.81827 -0.8327,0.81827 -2.61844,1.61246 -11.12356,6.91673 -13.74201,8.52437 0,0 -0.79419,0.51503 -1.13112,0.32731 -0.34175,-0.19735 -0.29843,-1.14076 -0.29843,-1.14076 v -17.14983 c 0,0 -0.01,-0.85195 0.29843,-1.03967 z m -27.329987,-0.0818 h 19.301377 v 18.92594 H 97.388173 Z m 82.634937,-23.66224 v 16.53372 h 16.53371 c 0,9.1453 -7.39804,16.53855 -16.53371,16.53855 -9.13566,0 -16.52891,-7.39325 -16.52891,-16.53855 0,-9.13566 7.39806,-16.53372 16.52891,-16.53372 z m -83.077767,7.75424 h 44.994847 v 5.37166 H 96.945343 Z m 87.727427,-12.24988 c 9.13083,0 16.53376,7.39325 16.53376,16.5241 h -16.53376 z m -87.794807,3.59555 H 141.8728 v 5.37165 H 96.877962 Z m -0.0481,-9.32339 h 44.994847 v 5.37166 H 96.829863 Z"
+         fill="#ffffff"
+         id="path298"
+         style="display:inline;enable-background:new;stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,227.00586 v 2 c -0.17299,35.36812 3.62515,38.99414 38.921885,38.99414 h 98.15624 c 35.29672,0 38.00361,-3.63752 38.92188,-38.99414 v -2 c -0.91827,35.35662 -3.62516,38.99414 -38.92188,38.99414 h -98.15624 c -35.296735,0 -39.094875,-3.62602 -38.921885,-38.99414 z"
-         id="path945"
-         inkscape:connector-curvature="0" />
+         d="m 331.17884,73.209901 h 24.66179 c 0.83524,0 1.50737,0.674122 1.50737,1.510348 v 15.481075 c 0,0.835239 -0.67213,1.507388 -1.50737,1.507388 h -10.46569 v 2.16272 h 2.82201 v 2.03818 h -9.54445 v -2.03818 h 2.73405 v -2.16272 h -10.20771 c -0.83523,0 -1.50738,-0.672149 -1.50738,-1.507388 V 74.720249 c 0,-0.836226 0.67215,-1.510348 1.50738,-1.510348 z m 24.06475,17.423373 c 0.50907,0 0.91729,-0.408227 0.91729,-0.917279 V 75.23523 c 0,-0.508062 -0.40822,-0.919257 -0.91729,-0.919257 h -23.70693 c -0.50905,0 -0.91728,0.411195 -0.91728,0.919257 v 14.480765 c 0,0.509052 0.40823,0.917279 0.91728,0.917279 z m -16.84611,-5.925745 c 0.082,-0.05041 0.28369,0.05436 0.28369,0.05436 0.53672,0.331131 2.21214,1.378885 2.74986,1.710016 0,0 0.19472,0.122567 0.19176,0.219434 -0.004,0.07908 -0.17101,0.168038 -0.17101,0.168038 -0.53771,0.33113 -2.2843,1.420399 -2.82202,1.75054 0,0 -0.16309,0.105765 -0.23228,0.06721 -0.0702,-0.04053 -0.0613,-0.234263 -0.0613,-0.234263 v -3.52184 c 0,0 -0.002,-0.174954 0.0613,-0.213504 z m -5.61241,-0.0168 h 3.96368 v 3.886577 h -3.96368 z m 16.96968,-4.85921 v 3.395318 h 3.39531 c 0,1.878052 -1.51924,3.396309 -3.39531,3.396309 -1.87608,0 -3.39433,-1.518257 -3.39433,-3.396309 0,-1.876074 1.51924,-3.395318 3.39433,-3.395318 z m -17.06062,1.592389 h 9.24002 v 1.103108 h -9.24002 z m 18.01546,-2.515601 c 1.87508,0 3.39532,1.518257 3.39532,3.393342 h -3.39532 z m -18.02929,0.738372 h 9.24001 v 1.103107 h -9.24001 z m -0.01,-1.914625 h 9.24001 v 1.103109 h -9.24001 z"
+         fill="#ffffff"
+         id="path405"
+         style="display:inline;enable-background:new;stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.08;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 180.0004,268 60,-60 v 22.48388 c -0.0523,33.99581 -3.80268,37.51612 -38.1741,37.51612 z"
-         id="path4254"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccsc" />
-      <g
-         transform="translate(-14.005,-292)"
-         id="g64"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 356,437.001 h -12 c -1.104,0 -2,0.895 -2,2 v 8.999 c 0,1.105 0.896,2 2,2 h 12 c 1.105,0 2,-0.895 2,-2 v -8.999 c 0,-1.105 -0.895,-2 -2,-2 z"
-           style="fill:#a33e03;fill-rule:nonzero"
-           id="path62" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g68"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 356,438.001 h -12 c -0.552,0 -1,0.448 -1,1 v 8.999 c 0,0.552 0.448,1 1,1 h 12 c 0.552,0 1,-0.448 1,-1 v -8.999 c 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:url(#_Linear9);fill-rule:nonzero"
-           id="path66" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g72"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 356,438.001 h -12 c -0.552,0 -1,0.448 -1,1 v 8.999 c 0,0.552 0.448,1 1,1 h 12 c 0.552,0 1,-0.448 1,-1 v -8.999 c 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:url(#_Linear10);fill-rule:nonzero"
-           id="path70" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g76"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 354,440.001 h -8 c -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 h 8 c 0.552,0 1,-0.448 1,-1 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:#d36118;fill-rule:nonzero"
-           id="path74" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g80"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 354,443.001 h -5 c -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 h 5 c 0.552,0 1,-0.448 1,-1 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:url(#_Linear11);fill-rule:nonzero"
-           id="path78" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g84"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 346,445 c 0.553,0 1,-0.447 1,-1 0,-0.552 -0.447,-1 -1,-1 -0.552,0 -1,0.448 -1,1 0,0.553 0.448,1 1,1 z"
-           style="fill:#d36118;fill-rule:nonzero"
-           id="path82" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g88"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 354,446.001 h -5 c -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 h 5 c 0.552,0 1,-0.448 1,-1 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:url(#_Linear12);fill-rule:nonzero"
-           id="path86" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g92"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 346,448 c 0.553,0 1,-0.447 1,-1 0,-0.552 -0.447,-1 -1,-1 -0.552,0 -1,0.448 -1,1 0,0.553 0.448,1 1,1 z"
-           style="fill:#d36118;fill-rule:nonzero"
-           id="path90" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g96"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 344,534 h -4 c -1.105,0 -2,0.896 -2,2 v 3 c 0,1.105 0.895,2 2,2 h 4 c 1.105,0 2,-0.895 2,-2 v -3 c 0,-1.104 -0.895,-2 -2,-2 z"
-           style="fill:#f9cfb5;fill-rule:nonzero"
-           id="path94" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g100"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 339.004,534.006 c -0.554,0 -1.004,0.448 -1.004,1.002 v 4.996 c 0,0.552 0.448,1 1,1 h 6 c 0.552,0 1,-0.447 1,-1 10e-4,-1.26 10e-4,-3.452 0.002,-5.007 0,-0.55 -0.444,-0.996 -0.995,-0.997 -1.867,-0.002 -4.135,0.008 -6.003,0.006 z m -0.002,1.499 c -0.001,-0.277 0.224,-0.501 0.501,-0.5 l 5,0.011 c 0.276,0.001 0.499,0.225 0.499,0.5 v 4.001 c 0,0.277 -0.224,0.5 -0.5,0.5 h -4.997 c -0.277,0 -0.502,-0.225 -0.501,-0.502 0.004,-1.295 0,-3.134 -0.002,-4.01 z"
-           style="fill:url(#_Linear13);fill-rule:nonzero"
-           id="path98" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g104"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="342.00201"
-           y="536.00098"
-           width="2"
-           height="1"
-           style="fill:url(#linearGradient1537);fill-rule:nonzero"
-           id="rect102" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g108"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="342.00201"
-           y="538.00098"
-           width="2"
-           height="1"
-           style="fill:url(#linearGradient1535);fill-rule:nonzero"
-           id="rect106" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g112"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="340.00201"
-           y="536.00098"
-           width="1"
-           height="1"
-           style="fill:url(#linearGradient1533);fill-rule:nonzero"
-           id="rect110" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g116"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="340.00201"
-           y="538.00098"
-           width="1"
-           height="1"
-           style="fill:url(#linearGradient1531);fill-rule:nonzero"
-           id="rect114" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g120"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="344.00201"
-           y="536.00098"
-           width="1"
-           height="1"
-           style="fill:#f09e6f;fill-rule:nonzero"
-           id="rect118" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g124"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="344.00201"
-           y="538.00098"
-           width="1"
-           height="1"
-           style="fill:#f09e6f;fill-rule:nonzero"
-           id="rect122" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g128"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 350,490 h -8 c -1.104,0 -2,0.895 -2,2 v 6 c 0,1.104 0.896,2 2,2 h 8 c 1.105,0 2,-0.896 2,-2 v -6 c 0,-1.105 -0.895,-2 -2,-2 z"
-           style="fill:#a33e03;fill-rule:nonzero"
-           id="path126" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g132"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 350,491 h -8 c -0.552,0 -1,0.448 -1,1 v 6 c 0,0.552 0.448,1 1,1 h 8 c 0.552,0 1,-0.448 1,-1 v -6 c 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:url(#_Linear18);fill-rule:nonzero"
-           id="path130" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g136"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 350,491 h -8 c -0.552,0 -1,0.448 -1,1 v 6 c 0,0.552 0.448,1 1,1 h 8 c 0.552,0 1,-0.448 1,-1 v -6 c 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:url(#_Linear19);fill-rule:nonzero"
-           id="path134" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g140"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 349.5,492 h -7 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 7 c 0.276,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.224,-0.5 -0.5,-0.5 z"
-           style="fill:#d36118;fill-rule:nonzero"
-           id="path138" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g144"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 349.5,494 h -5 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 5 c 0.276,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.224,-0.5 -0.5,-0.5 z"
-           style="fill:url(#_Linear20);fill-rule:nonzero"
-           id="path142" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g148"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 342.5,495 c 0.276,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.224,-0.5 -0.5,-0.5 -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 z"
-           style="fill:#d36118;fill-rule:nonzero"
-           id="path146" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g152"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 349.5,496 h -5 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 5 c 0.276,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.224,-0.5 -0.5,-0.5 z"
-           style="fill:url(#_Linear21);fill-rule:nonzero"
-           id="path150" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g156"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 342.5,497 c 0.276,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.224,-0.5 -0.5,-0.5 -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 z"
-           style="fill:#d36118;fill-rule:nonzero"
-           id="path154" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g252"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 169.8,497.256 -32.837,25.156 c -1.517,1.162 -0.695,3.588 1.216,3.588 h 4.194 c 2.927,0 5.753,-1.071 7.947,-3.009 l 29.116,-25.735 z"
-           style="fill:#a33e03;fill-rule:nonzero"
-           id="path250" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g256"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 162.209,497.256 32.837,25.156 c 1.518,1.162 0.695,3.588 -1.216,3.588 h -4.193 c -2.928,0 -5.754,-1.071 -7.948,-3.009 l -29.115,-25.735 z"
-           style="fill:#a33e03;fill-rule:nonzero"
-           id="path254" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g260"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="156.005"
-           y="506"
-           width="19.999001"
-           height="4.9990001"
-           style="fill:#a33e03;fill-rule:nonzero"
-           id="rect258" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g264"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 226.005,433 c 0,-9.383 -7.617,-17 -17,-17 h -86 c -9.383,0 -17,7.617 -17,17 v 56 c 0,9.383 7.617,17 17,17 h 86 c 9.383,0 17,-7.617 17,-17 z"
-           style="fill:#a33e03"
-           id="path262" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g268"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 221.005,434 c 0,-7.175 -5.825,-13 -13,-13 h -84 c -7.175,0 -13,5.825 -13,13 v 54 c 0,7.175 5.825,13 13,13 h 84 c 7.175,0 13,-5.825 13,-13 z"
-           style="fill:url(#_Linear28)"
-           id="path266" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g272"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 221.005,434 c 0,-7.175 -5.825,-13 -13,-13 h -84 c -7.175,0 -13,5.825 -13,13 v 54 c 0,7.175 5.825,13 13,13 h 84 c 7.175,0 13,-5.825 13,-13 z"
-           style="fill:url(#_Linear29)"
-           id="path270" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g276"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 206.004,431 h -79.999 c -2.762,0 -5,2.239 -5,5 0,2.761 2.238,5 5,5 h 79.999 c 2.762,0 5,-2.239 5,-5 0,-2.761 -2.238,-5 -5,-5 z"
-           style="fill:#d36118;fill-rule:nonzero"
-           id="path274" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g280"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 161.005,451 h -15 c -2.762,0 -5,2.239 -5,5 0,2.761 2.238,5 5,5 h 15 c 2.761,0 5,-2.239 5,-5 0,-2.761 -2.239,-5 -5,-5 z"
-           style="fill:#b2470f;fill-rule:nonzero"
-           id="path278" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g284"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 126.006,460.997 c 2.761,0 5,-2.238 5,-4.999 0,-2.762 -2.239,-5 -5,-5 -2.761,0 -5,2.238 -5,5 0,2.761 2.239,4.999 5,4.999 z"
-           style="fill:#e3713b;fill-rule:nonzero"
-           id="path282" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g288"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 161.005,466 h -15 c -2.762,0 -5,2.239 -5,5 0,2.761 2.238,5 5,5 h 15 c 2.761,0 5,-2.239 5,-5 0,-2.761 -2.239,-5 -5,-5 z"
-           style="fill:#b2470f;fill-rule:nonzero"
-           id="path286" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g292"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 126.006,475.997 c 2.761,0 5,-2.238 5,-4.999 0,-2.762 -2.239,-5 -5,-5 -2.761,0 -5,2.238 -5,5 0,2.761 2.239,4.999 5,4.999 z"
-           style="fill:#e3713b;fill-rule:nonzero"
-           id="path290" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g296"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 161.005,481 h -15 c -2.762,0 -5,2.238 -5,4.999 0,2.762 2.238,5 5,5 h 15 c 2.761,0 5,-2.238 5,-5 0,-2.761 -2.239,-4.999 -5,-4.999 z"
-           style="fill:#b2470f;fill-rule:nonzero"
-           id="path294" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g300"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 126.006,490.997 c 2.761,0 5,-2.238 5,-4.999 0,-2.762 -2.239,-5 -5,-5 -2.761,0 -5,2.238 -5,5 0,2.761 2.239,4.999 5,4.999 z"
-           style="fill:#e3713b;fill-rule:nonzero"
-           id="path298" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g304"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 202.004,451 h -21.999 c -4.971,0 -9,4.029 -9,9 v 22 c 0,4.97 4.029,9 9,9 h 21.999 c 4.971,0 9,-4.03 9,-9 v -22 c 0,-4.971 -4.029,-9 -9,-9 z"
-           style="fill:#e5723c;fill-rule:nonzero"
-           id="path302" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g308"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 201.004,456 h -19.999 c -2.762,0 -5,2.239 -5,5 v 20 c 0,2.761 2.238,5 5,5 h 19.999 c 2.762,0 5,-2.239 5,-5 v -20 c 0,-2.761 -2.238,-5 -5,-5 z"
-           style="fill:url(#_Linear30);fill-rule:nonzero"
-           id="path306" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g312"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 201.004,456 h -19.999 c -2.762,0 -5,2.239 -5,5 v 20 c 0,2.761 2.238,5 5,5 h 19.999 c 2.762,0 5,-2.239 5,-5 v -20 c 0,-2.761 -2.238,-5 -5,-5 z"
-           style="fill:url(#_Linear31);fill-rule:nonzero"
-           id="path310" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g316"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 178.505,483.5 7.499,-15 10,5 7.5,-15"
-           style="fill:none;fill-rule:nonzero;stroke:#b44910;stroke-width:5px;stroke-linecap:round;stroke-linejoin:round"
-           id="path314" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g320"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 358.759,386.253 -6.567,5.031 c -0.304,0.232 -0.139,0.717 0.243,0.717 h 0.99 c 0.488,0 0.959,-0.178 1.325,-0.501 l 5.936,-5.247 z"
-           style="fill:#a33e03;fill-rule:nonzero"
-           id="path318" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g324"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 357.241,386.253 6.567,5.031 c 0.304,0.232 0.14,0.717 -0.243,0.717 h -0.99 c -0.488,0 -0.959,-0.178 -1.324,-0.501 l -5.937,-5.247 z"
-           style="fill:#a33e03;fill-rule:nonzero"
-           id="path322" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g328"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <rect
-           x="356"
-           y="388.00101"
-           width="4"
-           height="1"
-           style="fill:#a33e03;fill-rule:nonzero"
-           id="rect326" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g332"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 370,373 c 0,-1.656 -1.344,-3 -3,-3 h -18 c -1.656,0 -3,1.344 -3,3 v 12 c 0,1.656 1.344,3 3,3 h 18 c 1.656,0 3,-1.344 3,-3 z"
-           style="fill:#a33e03"
-           id="path330" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g336"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 369,373 c 0,-1.104 -0.896,-2 -2,-2 h -18 c -1.104,0 -2,0.896 -2,2 v 12 c 0,1.104 0.896,2 2,2 h 18 c 1.104,0 2,-0.896 2,-2 z"
-           style="fill:url(#_Linear32)"
-           id="path334" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g340"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 366,373.001 h -16 c -0.552,0 -1,0.448 -1,1 0,0.553 0.448,1 1,1 h 16 c 0.552,0 1,-0.447 1,-1 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:#d36118;fill-rule:nonzero"
-           id="path338" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g344"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 357,377.001 h -3 c -0.552,0 -1,0.448 -1,1 0,0.553 0.448,1 1,1 h 3 c 0.552,0 1,-0.447 1,-1 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:url(#_Linear33);fill-rule:nonzero"
-           id="path342" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g348"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 350,379.001 c 0.553,0 1,-0.448 1,-1 0,-0.552 -0.447,-1 -1,-1 -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 z"
-           style="fill:#d36118;fill-rule:nonzero"
-           id="path346" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g352"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 357,380.001 h -3 c -0.552,0 -1,0.448 -1,1 0,0.553 0.448,1 1,1 h 3 c 0.552,0 1,-0.447 1,-1 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:url(#_Linear34);fill-rule:nonzero"
-           id="path350" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g356"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 350,382.001 c 0.553,0 1,-0.448 1,-1 0,-0.552 -0.447,-1 -1,-1 -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 z"
-           style="fill:#d36118;fill-rule:nonzero"
-           id="path354" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g360"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 357,383.001 h -3 c -0.552,0 -1,0.448 -1,1 0,0.553 0.448,1 1,1 h 3 c 0.552,0 1,-0.447 1,-1 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:url(#_Linear35);fill-rule:nonzero"
-           id="path358" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g364"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 350,385.001 c 0.553,0 1,-0.448 1,-1 0,-0.552 -0.447,-1 -1,-1 -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 z"
-           style="fill:#d36118;fill-rule:nonzero"
-           id="path362" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g368"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 365,377.001 h -4 c -1.104,0 -2,0.896 -2,2 v 4 c 0,1.105 0.896,2 2,2 h 4 c 1.105,0 2,-0.895 2,-2 v -4 c 0,-1.104 -0.895,-2 -2,-2 z"
-           style="fill:#e5723c;fill-rule:nonzero"
-           id="path366" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g372"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 365,378.001 h -4 c -0.552,0 -1,0.448 -1,1 v 4 c 0,0.553 0.448,1 1,1 h 4 c 0.552,0 1,-0.447 1,-1 v -4 c 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:url(#_Linear36);fill-rule:nonzero"
-           id="path370" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g376"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 365,378.001 h -4 c -0.552,0 -1,0.448 -1,1 v 4 c 0,0.553 0.448,1 1,1 h 4 c 0.552,0 1,-0.447 1,-1 v -4 c 0,-0.552 -0.448,-1 -1,-1 z"
-           style="fill:url(#_Linear37);fill-rule:nonzero"
-           id="path374" />
-      </g>
-      <g
-         transform="translate(-14.005,-292)"
-         id="g380"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 360.5,383.501 1.5,-3 2,1 1.5,-3"
-           style="fill:none;fill-rule:nonzero;stroke:#b44910;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round"
-           id="path378" />
-      </g>
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline">
+         d="m 327.63837,140.96298 h 16.08377 c 0.54474,0 0.98307,0.43965 0.98307,0.98501 v 10.09635 c 0,0.54472 -0.43833,0.98308 -0.98307,0.98308 h -6.82544 v 1.41047 h 1.84044 v 1.32925 h -6.22465 v -1.32925 h 1.78308 v -1.41047 h -6.6572 c -0.54472,0 -0.98307,-0.43836 -0.98307,-0.98308 v -10.09635 c 0,-0.54536 0.43835,-0.98501 0.98307,-0.98501 z m 15.6944,11.36307 c 0.332,0 0.59823,-0.26624 0.59823,-0.59823 v -9.44397 c 0,-0.33135 -0.26623,-0.59952 -0.59823,-0.59952 h -15.46104 c -0.33199,0 -0.59823,0.26817 -0.59823,0.59952 v 9.44397 c 0,0.33199 0.26624,0.59823 0.59823,0.59823 z m -10.98659,-3.86462 c 0.0535,-0.0329 0.18501,0.0354 0.18501,0.0354 0.35004,0.21596 1.4427,0.89927 1.79339,1.11523 0,0 0.12699,0.0799 0.12506,0.14311 -0.003,0.0516 -0.11153,0.10959 -0.11153,0.10959 -0.35068,0.21595 -1.48976,0.92635 -1.84045,1.14166 0,0 -0.10636,0.069 -0.15148,0.0438 -0.0458,-0.0264 -0.04,-0.15279 -0.04,-0.15279 v -2.29685 c 0,0 -10e-4,-0.1141 0.04,-0.13924 z m -3.66027,-0.011 h 2.58501 v 2.53473 h -2.58501 z m 11.06718,-3.16905 v 2.21434 h 2.21433 c 0,1.22482 -0.99079,2.21498 -2.21433,2.21498 -1.22353,0 -2.21369,-0.99016 -2.21369,-2.21498 0,-1.22353 0.99081,-2.21434 2.21369,-2.21434 z m -11.12649,1.03852 h 6.0261 v 0.71942 h -6.0261 z m 11.74921,-1.64061 c 1.22288,0 2.21434,0.99017 2.21434,2.21305 h -2.21434 z m -11.75823,0.48154 h 6.0261 v 0.71942 h -6.0261 z m -0.007,-1.24866 h 6.02609 v 0.71942 h -6.02609 z"
+         fill="#ffffff"
+         id="path417"
+         style="display:inline;enable-background:new;stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23242,61.5 c -4.11577,0 -6.55968,0.226752 -7.96875,1.558594 -0.28725,0.271486 -0.52183,0.601863 -0.72851,0.972656 -0.0468,0.08393 -0.10154,0.156606 -0.14454,0.246094 -2.5e-4,5.28e-4 2.6e-4,0.0014 0,0.002 -0.11616,0.241982 -0.2184,0.50414 -0.30859,0.789062 -0.0904,0.285534 -0.16955,0.593694 -0.23633,0.925782 -0.0668,0.332095 -0.1223,0.688232 -0.16797,1.070312 -0.0913,0.764147 -0.1422,1.632501 -0.16406,2.617188 -0.0109,0.492345 -0.0144,1.013779 -0.0117,1.566406 v 12.751906 12.751953 c -0.003,0.552627 8e-4,1.074061 0.0117,1.566406 0.0219,0.984686 0.0727,1.853041 0.16406,2.617191 0.0457,0.38208 0.1012,0.73821 0.16797,1.07031 0.13356,0.66417 0.31198,1.23197 0.54492,1.7168 0.23295,0.48482 0.52078,0.88581 0.87305,1.21875 0.17614,0.16648 0.36842,0.31556 0.57813,0.44921 0.41895,0.26701 0.90872,0.47238 1.47656,0.62891 6.2e-4,1.7e-4 0.001,-1.7e-4 0.002,0 1.42142,0.39113 3.3408,0.48047 5.91211,0.48047 h 17.53906 c 1.02156,0 1.93959,-0.015 2.76368,-0.0566 0.34097,-0.0172 0.65525,-0.0427 0.96484,-0.0703 0.0645,-0.006 0.13795,-0.007 0.20117,-0.0137 0.001,-1.4e-4 0.003,1.3e-4 0.004,0 0.73118,-0.0725 1.37505,-0.17995 1.93945,-0.33399 0.28273,-0.0772 0.54639,-0.16492 0.79102,-0.26758 0.24462,-0.10265 0.47066,-0.22006 0.67968,-0.35156 0.20903,-0.1315 0.40024,-0.27771 0.57618,-0.44141 0.15581,-0.14498 0.29602,-0.30775 0.42773,-0.48046 0.017,-0.0223 0.0381,-0.0397 0.0547,-0.0625 0.001,-0.002 0.003,-0.004 0.004,-0.006 0.14374,-0.19776 0.2725,-0.41443 0.38868,-0.6504 0.11725,-0.23815 0.22082,-0.49693 0.3125,-0.77734 0.0917,-0.28041 0.17164,-0.58218 0.24023,-0.9082 0.0686,-0.32602 0.12581,-0.6758 0.17383,-1.05078 0.0428,-0.33417 0.0752,-0.6967 0.10351,-1.072269 0.003,-0.04534 0.0104,-0.0849 0.0137,-0.130859 4.2e-4,-0.0061 -4.3e-4,-0.01341 0,-0.01953 0.059,-0.850021 0.0853,-1.80463 0.0879,-2.88086 v -18.904178 c -0.009,-1.95527 -1.71776,-3.606675 -3.10157,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 c -2.24485,-2.121612 -3.79653,-3.138638 -6.86748,-3.138638 z"
-         id="path964-1"
-         inkscape:connector-curvature="0" />
+         d="m 325.86811,194.83952 h 11.79476 c 0.39947,0 0.72092,0.32241 0.72092,0.72234 v 7.40399 c 0,0.39946 -0.32145,0.72093 -0.72092,0.72093 h -5.00533 v 1.03434 h 1.34966 v 0.97478 h -4.56473 v -0.97478 h 1.30759 v -1.03434 h -4.88195 c -0.39946,0 -0.72092,-0.32147 -0.72092,-0.72093 v -7.40399 c 0,-0.39993 0.32146,-0.72234 0.72092,-0.72234 z m 11.50923,8.33292 c 0.24347,0 0.43869,-0.19524 0.43869,-0.4387 v -6.92558 c 0,-0.24299 -0.19522,-0.43965 -0.43869,-0.43965 h -11.3381 c -0.24347,0 -0.4387,0.19666 -0.4387,0.43965 v 6.92558 c 0,0.24346 0.19524,0.4387 0.4387,0.4387 z m -8.05683,-2.83406 c 0.0392,-0.0241 0.13567,0.026 0.13567,0.026 0.2567,0.15837 1.05798,0.65947 1.31515,0.81784 0,0 0.0931,0.0586 0.0917,0.10495 -0.002,0.0378 -0.0818,0.0804 -0.0818,0.0804 -0.25716,0.15837 -1.09249,0.67933 -1.34967,0.83722 0,0 -0.078,0.0506 -0.11108,0.0321 -0.0336,-0.0194 -0.0293,-0.11205 -0.0293,-0.11205 v -1.68435 c 0,0 -7.2e-4,-0.0837 0.0293,-0.10211 z m -2.6842,-0.008 h 1.89567 v 1.8588 h -1.89567 z m 8.11593,-2.32397 v 1.62385 h 1.62384 c 0,0.8982 -0.72659,1.62431 -1.62384,1.62431 -0.89725,0 -1.62337,-0.72611 -1.62337,-1.62431 0,-0.89726 0.72658,-1.62385 1.62337,-1.62385 z m -8.15943,0.76158 h 4.41915 v 0.52757 h -4.41915 z m 8.61609,-1.20312 c 0.89678,0 1.62385,0.72613 1.62385,1.62291 h -1.62385 z m -8.6227,0.35313 h 4.41914 v 0.52758 h -4.41914 z m -0.005,-0.91568 h 4.41913 v 0.52757 h -4.41913 z"
+         fill="#ffffff"
+         id="path429"
+         style="display:inline;enable-background:new;stroke-width:0.472736" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -2.50815,0 -4.811706,0.02551 -7.011724,0.07227 -1.569123,0.03333 -3.085758,0.07665 -4.505859,0.142578 -0.892728,0.04133 -1.761123,0.08803 -2.597656,0.144531 -0.07361,0.005 -0.155337,0.0086 -0.228516,0.01367 -0.03977,0.0028 -0.07364,0.0069 -0.113281,0.0098 -1.116046,0.0793 -2.169724,0.179402 -3.1875,0.291016 -0.281404,0.03076 -0.565732,0.06033 -0.839844,0.09375 -0.275699,0.03373 -0.547991,0.06893 -0.816406,0.105469 -0.386448,0.05241 -0.763169,0.107586 -1.134766,0.166015 -0.245075,0.0387 -0.493706,0.07575 -0.732422,0.117188 -0.386715,0.06683 -0.756638,0.14255 -1.126953,0.216797 -0.50787,0.102283 -1.000729,0.211021 -1.478515,0.328125 -0.190937,0.04659 -0.386033,0.09158 -0.572266,0.140625 -0.3252,0.08602 -0.638123,0.17771 -0.949219,0.271484 -0.174107,0.05225 -0.347813,0.105409 -0.517578,0.160157 -0.32699,0.105899 -0.647816,0.216555 -0.958984,0.332031 -0.09794,0.0362 -0.19267,0.07416 -0.289063,0.111328 -1.533658,0.593687 -2.876219,1.308506 -4.044922,2.173828 -0.01464,0.01084 -0.03034,0.02036 -0.04492,0.03125 -4.841904,3.613548 -6.740009,9.796263 -7.419922,20.238281 -0.01716,0.264046 -0.02929,0.544903 -0.04492,0.814453 -0.06629,1.140594 -0.126494,2.305415 -0.167969,3.546875 -9.88e-4,0.02958 -9.78e-4,0.06216 -0.002,0.0918 -0.04738,1.439614 -0.07924,2.944486 -0.09961,4.525391 0.472511,-28.9634 6.027958,-32.138712 38.884815,-32.138712 h 62.52929 c -0.85989,-0.295464 -1.74582,-0.553137 -2.65429,-0.783203 -0.15701,-0.03958 -0.31205,-0.08153 -0.47071,-0.119141 -0.38771,-0.0924 -0.78156,-0.17709 -1.17969,-0.257812 -0.28362,-0.0571 -0.57205,-0.108999 -0.86132,-0.160156 -0.33217,-0.05924 -0.66192,-0.122415 -1.00196,-0.173829 -0.61547,-0.09216 -1.24344,-0.171652 -1.88672,-0.238281 -0.25531,-0.02678 -0.51929,-0.04563 -0.77929,-0.06836 -0.49344,-0.04258 -0.99476,-0.07925 -1.50586,-0.107422 -0.26087,-0.01459 -0.52138,-0.03022 -0.78711,-0.04102 -0.75738,-0.03032 -1.52534,-0.05078 -2.32422,-0.05078 z"
-         id="path7790" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 202.6543,44.089844 c -1.07122,0.357279 -1.96732,1.040077 -2.67188,1.910156 h 1.0957 c 34.15108,4e-6 38.64021,3.484765 38.89649,35.740234 0.003,-0.03712 0.0117,-0.07204 0.0137,-0.109375 -0.0536,-17.671398 -1.15787,-27.178174 -7.08008,-32.177734 -0.31691,-0.265045 -0.64554,-0.519153 -0.99023,-0.759766 -1.34338,-0.937742 -2.91268,-1.68853 -4.71875,-2.296875 -0.14212,-0.04772 -0.27668,-0.09862 -0.42188,-0.144531 -0.31902,-0.101184 -0.65609,-0.192499 -0.99023,-0.285156 -0.25795,-0.07131 -0.51412,-0.144507 -0.78125,-0.210938 -0.32384,-0.08078 -0.65655,-0.156631 -0.99414,-0.230468 -0.32254,-0.07033 -0.65294,-0.136909 -0.98828,-0.201172 -0.32063,-0.06164 -0.64012,-0.123397 -0.97266,-0.179688 -0.46228,-0.07802 -0.94194,-0.148582 -1.42773,-0.216797 -0.21622,-0.03046 -0.42163,-0.06516 -0.64258,-0.09375 -0.003,-3.28e-4 -0.005,-0.0016 -0.008,-0.002 -0.70741,-0.09114 -1.44413,-0.170948 -2.20118,-0.24414 -0.30752,-0.02983 -0.6294,-0.05499 -0.94531,-0.08203 -0.52075,-0.04445 -1.04787,-0.08768 -1.59179,-0.125 -0.34138,-0.02349 -0.68841,-0.04362 -1.03907,-0.06445 -0.36733,-0.02177 -0.74929,-0.04154 -1.12695,-0.06055 -1.40861,-0.07105 -2.86508,-0.128967 -4.42188,-0.166015 -0.006,-1.28e-4 -0.0105,5e-6 -0.0156,0 h -0.004 z"
-         id="path7788" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.011719,81.421875 c -0.0019,0.539192 -0.01172,1.017567 -0.01172,1.572266 v 2 c -0.0062,-1.260292 0.0066,-2.391311 0.01172,-3.572266 z"
-         id="path5316-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.005859,227.00586 v 2 c -0.0022,0.44238 0.0048,0.82141 0.0039,1.25391 0.0013,0.45945 0.007,0.88359 0.0098,1.33203 -0.01134,-1.48776 -0.02159,-2.96803 -0.01367,-4.58594 z m 175.994141,0.75195 c -0.0555,34.63219 -3.88404,38.24219 -38.91602,38.24219 h -98.15625 c -32.934263,0 -38.440959,-3.18029 -38.890621,-32.33398 0.304544,24.87428 3.489356,31.9654 22.175782,33.76562 0.0033,3.2e-4 0.0064,-3.2e-4 0.0098,0 0.761225,0.073 1.548247,0.13868 2.361328,0.19531 0.002,1.4e-4 0.0039,-1.4e-4 0.0059,0 0.814659,0.0567 1.655065,0.10648 2.523437,0.14844 6.7e-4,3e-5 0.0013,-3e-5 0.002,0 0.579873,0.028 1.24712,0.0365 1.851563,0.0586 1.208255,0.0442 2.391096,0.0937 3.701172,0.11719 0.0014,3e-5 0.0025,-2e-5 0.0039,0 1.964377,0.0351 4.045339,0.0488 6.250009,0.0488 0.002,0 0.004,0 0.006,0 h 98.15039 c 3.67649,0 6.93682,-0.0556 9.96094,-0.16602 2.42031,-0.0885 4.71577,-0.20623 6.75196,-0.40234 19.49586,-1.8777 22.12352,-9.49921 22.20507,-37.08398 -8.2e-4,-0.46208 0.006,-0.86842 0.004,-1.3418 z"
-         id="path5316-8"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 353.49905,61.375285 c -0.0742,0 -0.14719,0.007 -0.22049,0.018 -0.94065,0.29981 -1.25935,1.72298 -0.53417,2.39306 l 7.51333,7.51498 c 0.78643,0.74591 2.35311,0.10873 2.39455,-0.97465 v -2.118 c 0.0336,-6.55752 0.34308,-6.68079 -5.59466,-6.81539 h -3.33561 c -0.0733,-0.0113 -0.14877,-0.018 -0.22295,-0.018 z"
-         id="rect4158-92-6-6"
-         sodipodi:nodetypes="scccccccs" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1004);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         clip-path="url(#clipPath994-5)"
-         d="m 335.23242,61.5 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 v 12.751953 12.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 v -17.903968 c -0.006,-1.214011 -0.66655,-2.310001 -1.49805,-3.265625 v 8.243812 12.251953 c 0,2.193451 -0.0614,3.870697 -0.26562,5.087887 -0.20419,1.2172 -0.52867,1.92435 -0.99805,2.39454 -0.46938,0.47016 -1.17436,0.79564 -2.38867,1 -1.21432,0.20434 -2.8892,0.26562 -5.07813,0.26562 h -16.53906 c -2.18893,0 -3.86589,-0.0612 -5.08399,-0.26562 -1.21809,-0.20448 -1.92877,-0.5295 -2.40039,-1 -0.47161,-0.47052 -0.79596,-1.17682 -0.99804,-2.39258 -0.20209,-1.21576 -0.25879,-2.893414 -0.24805,-5.085941 v -0.002 -12.253859 -12.253906 -0.002 c -0.0107,-2.192528 0.046,-3.870175 0.24805,-5.085938 0.20209,-1.215763 0.52643,-1.922078 0.99804,-2.392578 0.47161,-0.4705 1.18426,-0.79553 2.40235,-1 1.21809,-0.204376 2.8931,-0.265578 5.08203,-0.265578 h 12.26953 c -1.40176,-1.001118 -3.79892,-1.5 -5.922,-1.5 z"
-         id="path990"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssccccscccsscccccccccscscss" />
-      <path
-         inkscape:connector-curvature="0"
-         style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0441942;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 353.35547,61.876953 -0.14453,0.121094 c -0.28875,0.242959 -0.43321,0.748579 -0.31836,1.111328 0.007,0.0217 0.07,0.0936 0.11523,0.150391 0.056,-0.101219 0.12158,-0.193105 0.20313,-0.261719 l 0.14453,-0.121094 2.71875,0.02539 c 2.70745,0.02522 3.50936,0.05935 4.26562,0.185547 1.36683,0.228076 1.67801,0.658049 1.79102,2.474609 0.0245,0.393967 0.0317,1.552688 0.0352,2.636719 0.007,-1.466927 -5.4e-4,-3.080545 -0.0352,-3.636719 -0.11301,-1.81656 -0.42419,-2.246533 -1.79102,-2.474609 -0.75626,-0.126199 -1.55817,-0.160327 -4.26562,-0.185547 z"
-         id="path7025" />
-      <path
-         transform="translate(4.9980746e-4)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 v 6.12581 6.12581 c -0.0217,4.42101 0.45311,4.87419 4.8652,4.87419 h 8.2696 c 4.41209,0 4.8652,-0.45312 4.8652,-4.87419 v -6.12581 -6.12581 c 0,-4.42106 -0.45312,-4.87419 -4.86521,-4.87419 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971-6)" />
-      <path
-         id="path1085"
-         d="m 327.86573,188.5 c -1.11158,0 -1.98683,0.0256 -2.70703,0.14648 -0.72019,0.1209 -1.3105,0.34863 -1.74218,0.7793 -0.43169,0.43067 -0.65954,1.01974 -0.7793,1.74024 -0.11977,0.72049 -0.14217,1.59669 -0.13672,2.71093 v 6.12305 6.125 c -0.005,1.1131 0.017,1.989 0.13672,2.70898 0.11976,0.72051 0.3476,1.30957 0.7793,1.74024 0.43169,0.43067 1.02199,0.6584 1.74218,0.7793 0.7202,0.12089 1.59545,0.14648 2.70703,0.14648 h 8.26954 c 1.11158,0 1.98637,-0.0255 2.70507,-0.14648 0.7187,-0.12095 1.30623,-0.34848 1.73633,-0.7793 0.4301,-0.43083 0.6566,-1.01849 0.77735,-1.73828 0.12074,-0.71979 0.14648,-1.59713 0.14648,-2.71094 v -6.125 -6.125 c 0,-1.11381 -0.0257,-1.99115 -0.14648,-2.71094 -0.12075,-0.71979 -0.34725,-1.30745 -0.77735,-1.73828 -0.4301,-0.43082 -1.01763,-0.65835 -1.73633,-0.7793 -0.7187,-0.12094 -1.59349,-0.14648 -2.70507,-0.14648 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path1087"
-         d="m 325.0962,236.5 c -0.71048,0 -1.27344,0.0154 -1.75195,0.0957 -0.47851,0.0803 -0.89671,0.23728 -1.20703,0.54688 -0.31032,0.30959 -0.46726,0.7261 -0.54688,1.20508 -0.0796,0.47897 -0.0933,1.04352 -0.0898,1.75586 v 3.89648 3.89844 c -0.003,0.71121 0.0103,1.27546 0.0898,1.7539 0.0796,0.47898 0.23655,0.89549 0.54688,1.20508 0.31033,0.3096 0.72851,0.46655 1.20703,0.54688 0.47852,0.0803 1.04147,0.0957 1.75195,0.0957 h 5.8086 c 0.71048,0 1.27236,-0.0153 1.75,-0.0957 0.47763,-0.0804 0.89584,-0.23713 1.20508,-0.54688 0.30921,-0.30975 0.46469,-0.72681 0.54492,-1.20508 0.0802,-0.47826 0.0957,-1.04201 0.0957,-1.7539 v -3.89844 -3.89844 c 0,-0.71189 -0.0155,-1.27564 -0.0957,-1.7539 -0.0802,-0.47827 -0.2357,-0.89533 -0.54492,-1.20508 -0.30924,-0.30975 -0.72745,-0.4665 -1.20508,-0.54688 -0.47764,-0.0804 -1.03952,-0.0957 -1.75,-0.0957 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         transform="translate(4.9980746e-4)"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 v 3.89824 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 c 2.8077,0 3.09604,-0.28835 3.09604,-3.10176 v -3.89824 -3.89824 c 0,-2.8134 -0.28835,-3.10176 -3.09604,-3.10176 z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983-6)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.991584;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 342.28662,133.49219 c -0.0504,0 -0.10067,0.005 -0.15039,0.0117 -0.63831,0.19051 -0.85538,1.0957 -0.36328,1.52148 l 5.09961,4.77344 c 0.53367,0.47395 1.59687,0.0693 1.625,-0.61914 v -1.34571 c 0.0228,-4.16669 0.23241,-4.24454 -3.79688,-4.33007 h -2.26367 c -0.0498,-0.007 -0.10004,-0.0117 -0.15039,-0.0117 z m -12.21289,0.004 c -2.78209,0 -4.43425,0.14534 -5.38672,1.00391 -0.19416,0.175 -0.35249,0.38793 -0.49219,0.62695 -0.0316,0.054 -0.0686,0.10247 -0.0976,0.16016 -0.0785,0.156 -0.14802,0.3261 -0.20899,0.50977 -0.0611,0.18405 -0.11501,0.38162 -0.16015,0.5957 -0.0452,0.21409 -0.0824,0.44315 -0.11329,0.68945 -0.0617,0.49261 -0.0965,1.05274 -0.11132,1.6875 -0.007,0.31739 -0.01,0.65353 -0.008,1.00977 v 8.2206 8.2207 c -0.002,0.35623 3.5e-4,0.69239 0.008,1.00977 0.0148,0.63477 0.0495,1.19491 0.11132,1.6875 0.0309,0.24631 0.0682,0.47537 0.11329,0.68945 0.0903,0.42816 0.21168,0.79292 0.36914,1.10547 0.15746,0.31252 0.35171,0.57249 0.58984,0.78711 0.11906,0.10732 0.24887,0.20291 0.39062,0.28906 0.28319,0.17212 0.61423,0.30534 0.99805,0.40625 0.96081,0.25213 2.25995,0.3086 3.99805,0.3086 h 11.85547 c 0.69054,0 1.31013,-0.0106 1.86719,-0.0371 0.23047,-0.0111 0.44308,-0.0272 0.65234,-0.0449 0.0436,-0.004 0.094,-0.004 0.13672,-0.008 h 0.002 c 0.49424,-0.0467 0.92903,-0.11749 1.31055,-0.21679 0.19111,-0.0498 0.36981,-0.10571 0.53515,-0.17188 0.16536,-0.0661 0.31771,-0.14178 0.45899,-0.22656 0.14129,-0.0848 0.2717,-0.17962 0.39062,-0.28516 0.10532,-0.0934 0.20005,-0.19727 0.28907,-0.30859 0.0115,-0.0144 0.0259,-0.0264 0.0371,-0.041 6.7e-4,-0.001 9.5e-4,-0.003 0.002,-0.004 0.0971,-0.12749 0.18514,-0.26586 0.26367,-0.41797 0.0792,-0.15352 0.14897,-0.32121 0.21094,-0.50196 0.062,-0.18077 0.11573,-0.37576 0.16211,-0.58593 0.0464,-0.21016 0.0847,-0.43601 0.11718,-0.67774 0.0289,-0.21541 0.0511,-0.44929 0.0703,-0.6914 0.002,-0.0292 0.008,-0.0543 0.01,-0.084 2.9e-4,-0.004 -2.9e-4,-0.008 0,-0.0117 0.0399,-0.54795 0.0568,-1.16365 0.0586,-1.85742 v -11.18578 c -0.006,-1.26044 -1.16032,-2.32513 -2.09571,-3.1289 l -0.008,-0.006 -6.72986,-6.49196 c -1.51744,-1.36767 -2.56676,-2.02344 -4.64258,-2.02344 z"
-         id="path964-1-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccccccccccccccccsscccccccccccccccccccccccss" />
-      <path
-         style="opacity:0.3;fill:url(#linearGradient4316);fill-opacity:1;stroke:none;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 343.16802,134.07487 c -0.99147,0.035 -1.02734,0.0465 -1.02734,0.33594 0,0.10178 0.15173,0.31016 0.45898,0.64648 h 2.87891 c 0.15931,0 0.30929,0.0306 0.45312,0.0762 0.32342,0.02 0.64497,0.0487 0.96485,0.10352 0.0264,0.32124 0.0306,0.64828 0.0371,0.97461 0.0263,0.11154 0.0449,0.2259 0.0449,0.3457 v 2.61719 c 0.25501,0.21272 0.45277,0.36813 0.49023,0.36914 0.45172,0.0121 0.5059,-0.28833 0.46289,-2.54883 -0.0534,-2.80528 0.043,-2.67754 -2.15624,-2.83984 -0.86922,-0.0642 -2.04216,-0.1 -2.60743,-0.0801 z m -10.83984,0.0371 c -5.16676,0.002 -5.89229,0.0632 -6.90234,0.57617 -0.60351,0.30649 -1.03843,1.06517 -1.2461,2.17187 -0.24355,1.30043 -0.239,21.42491 0.006,22.5 0.4115,1.80781 1.06039,2.3312 3.18555,2.56446 0.49142,0.054 4.63516,0.0862 9.20703,0.0723 7.44102,-0.0226 8.39113,-0.0477 9.0625,-0.24023 1.20765,-0.3464 1.67604,-0.80148 2.02539,-1.96289 0.17841,-0.59326 0.21211,-1.68489 0.25391,-8.28321 0.0479,-7.5564 0.0468,-6.60393 -0.21875,-7.15257 -0.0736,-0.15205 -0.33859,-0.46265 -0.72266,-0.875 v 4.07422 c 0,0.12416 -0.0206,0.24218 -0.0488,0.35742 0.0246,3.83198 -0.0428,6.67596 -0.12305,10.47289 0.094,0.98908 -0.26416,2.20979 -1.37304,2.42969 -4.17852,0.21246 -8.39772,0.16055 -12.60547,0.18945 -2.09316,-0.0712 -4.2187,0.13385 -6.29102,-0.20117 -1.20786,-0.09 -1.37139,-1.432 -1.46679,-2.37696 -0.1751,-6.57883 -0.13104,-13.28191 -0.041,-19.88867 0.0853,-1.09208 -0.0376,-2.65795 1.18164,-3.16406 2.366,-0.42229 4.785,-0.2218 7.17578,-0.3125 0.61114,0.0344 0.29054,0.0147 0.94202,0.0117 0.059,-0.007 0.11677,-0.0176 0.17773,-0.0176 h 3.5918 c -0.42688,-0.30915 -0.78914,-0.52782 -1.16797,-0.68359 -0.60974,-0.25114 0.12581,-0.26372 -4.60217,-0.26172 z"
-         id="path4296"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cscscccscccccccccccccccccsccccccccccscccc" />
+         d="m 324.09791,240.71606 h 7.50576 c 0.2542,0 0.45876,0.20517 0.45876,0.45967 v 4.71163 c 0,0.2542 -0.20456,0.45878 -0.45876,0.45878 h -3.18522 v 0.65821 h 0.85888 v 0.62032 h -2.90483 v -0.62032 h 0.8321 v -0.65821 h -3.10669 c -0.2542,0 -0.45877,-0.20458 -0.45877,-0.45878 v -4.71163 c 0,-0.2545 0.20457,-0.45967 0.45877,-0.45967 z m 7.32405,5.30277 c 0.15494,0 0.27917,-0.12425 0.27917,-0.27917 v -4.40719 c 0,-0.15463 -0.12423,-0.27978 -0.27917,-0.27978 h -7.21515 c -0.15494,0 -0.27917,0.12515 -0.27917,0.27978 v 4.40719 c 0,0.15492 0.12424,0.27917 0.27917,0.27917 z m -5.12707,-1.80349 c 0.0249,-0.0153 0.0863,0.0165 0.0863,0.0165 0.16335,0.10078 0.67326,0.41966 0.83691,0.52044 0,0 0.0592,0.0373 0.0584,0.0668 -10e-4,0.0241 -0.0521,0.0512 -0.0521,0.0512 -0.16365,0.10079 -0.69522,0.43231 -0.85888,0.53278 0,0 -0.0496,0.0322 -0.0707,0.0204 -0.0214,-0.0123 -0.0186,-0.0713 -0.0186,-0.0713 v -1.07186 c 0,0 -4.6e-4,-0.0533 0.0186,-0.065 z m -1.70813,-0.005 h 1.20634 v 1.18288 h -1.20634 z m 5.16469,-1.47889 v 1.03336 h 1.03335 c 0,0.57159 -0.46238,1.03366 -1.03335,1.03366 -0.57098,0 -1.03306,-0.46207 -1.03306,-1.03366 0,-0.57098 0.46237,-1.03336 1.03306,-1.03336 z m -5.19237,0.48465 h 2.81219 v 0.33572 h -2.81219 z m 5.48297,-0.76563 c 0.57068,0 1.03337,0.46209 1.03337,1.03277 h -1.03337 z m -5.48718,0.22472 h 2.81218 v 0.33574 h -2.81218 z m -0.003,-0.5827 h 2.81218 v 0.33572 h -2.81218 z"
+         fill="#ffffff"
+         id="path441"
+         style="display:inline;enable-background:new;stroke-width:0.300832" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/libreoffice-main.svg
+++ b/icons/src/fullcolor/default/apps/libreoffice-main.svg
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="libreoffice-main.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
      id="base"
-     pagecolor="#828282"
+     pagecolor="#ffffff"
      bordercolor="#000000"
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="-62.89192"
-     inkscape:cy="165.50649"
-     inkscape:current-layer="layer5"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="315.01607"
+     inkscape:cy="129.40054"
+     inkscape:current-layer="layer2"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -50,7 +50,7 @@
      gridtolerance="10000"
      inkscape:object-nodes="true"
      inkscape:snap-grids="true"
-     showguides="false"
+     showguides="true"
      inkscape:guide-bbox="true"
      inkscape:window-maximized="1"
      inkscape:bbox-paths="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,239 +93,131 @@
   <defs
      id="defs3">
     <linearGradient
-       id="linearGradient3976">
+       id="c"
+       x2="1"
+       gradientTransform="matrix(41.668027,0,0,41.668027,62.334975,844.16648)"
+       gradientUnits="userSpaceOnUse">
       <stop
+         stop-color="#f6fbff"
          offset="0"
-         style="stop-color:#626262;stop-opacity:1"
-         id="stop3972" />
+         id="stop12" />
       <stop
+         stop-color="#eaeff2"
          offset="1"
-         style="stop-color:#4e4e4e;stop-opacity:1"
-         id="stop3974" />
+         id="stop14" />
+    </linearGradient>
+    <linearGradient
+       id="b"
+       x2="1"
+       gradientTransform="matrix(0,-203.23056,203.23056,0,561.59845,253.0975)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#656b77"
+         offset="0"
+         id="stop7" />
+      <stop
+         stop-color="#9da5ae"
+         offset="1"
+         id="stop9" />
+    </linearGradient>
+    <linearGradient
+       id="a"
+       x2="1"
+       gradientTransform="matrix(-0.00528208,-207.68288,207.68288,-0.00528208,235.29581,258.02538)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#b7b4b4"
+         offset="0"
+         id="stop2" />
+      <stop
+         stop-color="#f1f1f1"
+         offset="1"
+         id="stop4" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-5">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient3194"
-       x1="335.73108"
-       y1="62"
-       x2="352.26993"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
+       xlink:href="#c"
+       id="linearGradient520"
        gradientUnits="userSpaceOnUse"
-       y2="169.66859"
-       x2="4.4137931"
-       y1="386.30838"
-       x1="494.34482"
-       id="linearGradient4226-1"
-       xlink:href="#linearGradient4338"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.96286,268)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6646"
-       x="-0.01363613"
-       width="1.0272723"
-       y="-0.01071443"
-       height="1.0214289">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.0000135"
-         id="feGaussianBlur6648" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6668"
-       x="-0.054544518"
-       width="1.109089"
-       y="-0.042857721"
-       height="1.0857154">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.000054"
-         id="feGaussianBlur6670" />
-    </filter>
+       gradientTransform="matrix(8.5568269,0,0,8.5568269,325.58665,225.3199)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient4338">
-      <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
-         offset="0"
-         id="stop4340" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="1"
-         id="stop4342" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3976"
-       id="linearGradient18935"
-       x1="352.77151"
-       y1="106.5"
-       x2="335.23242"
-       y2="61.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983-6">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985-0"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971-6">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1311"
-       x1="327.99951"
-       y1="188"
-       x2="335.99951"
-       y2="212"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1309"
-       x1="332"
-       y1="236"
-       x2="324"
-       y2="252"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3976"
-       id="linearGradient916"
+       xlink:href="#b"
+       id="linearGradient522"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05664062,-0.05663901,0,349.74506,214)"
-       x1="44.137936"
-       y1="240.29004"
-       x2="450.20694"
-       y2="386.29437" />
+       gradientTransform="matrix(0,-41.734847,41.734847,0,428.11396,103.93967)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3976"
-       id="linearGradient920"
+       xlink:href="#a"
+       id="linearGradient524"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.03604403,-0.03604301,0,339.56482,252.90909)"
-       x1="39.093575"
-       y1="240.26906"
-       x2="455.25125"
-       y2="401.58029" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient3976"
-       id="linearGradient18935-0"
-       x1="352.89749"
-       y1="106.50614"
-       x2="334.86411"
-       y2="61.500103"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="matrix(-0.00108471,-42.649162,42.649162,-0.00108471,361.10539,104.95164)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient4316"
-       x1="372"
-       y1="134"
-       x2="372"
-       y2="162"
+       xlink:href="#c"
+       id="linearGradient534"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-37.000489)" />
+       gradientTransform="matrix(5.5805392,0,0,5.5805392,323.9913,240.16515)"
+       x2="1" />
     <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
        inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient18935-0-8"
-       x1="336.64893"
-       y1="59.040947"
-       x2="348.54202"
-       y2="108.83411"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#b"
+       id="linearGradient536"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-27.218378,27.218378,0,390.85692,161.00413)"
+       x2="1" />
     <linearGradient
-       gradientTransform="translate(0,-4e-6)"
        inkscape:collect="always"
-       xlink:href="#linearGradient3976"
-       id="linearGradient18820-3"
-       x1="201.07812"
-       y1="269.99988"
-       x2="102.92188"
-       y2="45.999878"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#a"
+       id="linearGradient538"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-7.0741955e-4,-27.81467,27.81467,-7.0741955e-4,347.15568,161.66411)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient548"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.0923957,0,0,4.0923957,323.22481,267.68956)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient550"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-19.960145,19.960145,0,372.25961,209.63814)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient552"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.1877438e-4,-20.397426,20.397426,-5.1877438e-4,340.21203,210.12213)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient562"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6042523,0,0,2.6042523,322.41578,287.07519)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient564"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-12.701913,12.701913,0,353.61975,250.13337)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient566"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.3012921e-4,-12.980182,12.980182,-3.3012921e-4,333.22583,250.44136)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -424,7 +317,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">libreoffice-main</tspan></text>
+           id="tspan924">libreoffice-main</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -459,234 +352,124 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99158418;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 342.28786,133.99591 c -0.0832,0 -0.1556,0.007 -0.2168,0.0156 l -0.0371,0.006 -0.0371,0.0117 c -1.02052,0.30458 -1.3544,1.66824 -0.54687,2.36914 0,0 0,0.002 0,0.002 l 5.08984,4.76563 0.006,0.004 c 0.44144,0.39204 1.03582,0.39851 1.50781,0.21874 0.47199,-0.17975 0.9171,-0.5946 0.94141,-1.18945 v -0.01 -1.35352 -0.002 c 0.006,-1.0363 0.0251,-1.82214 -0.0176,-2.45508 -0.0427,-0.63344 -0.14348,-1.14825 -0.47266,-1.55274 -0.32917,-0.40448 -0.82834,-0.59266 -1.42968,-0.68554 -0.60135,-0.0929 -1.35232,-0.1114 -2.36133,-0.13281 h -0.006 -2.26953 c -0.0478,-0.005 -0.0951,-0.0117 -0.15039,-0.0117 z m -7.25782,0.002 -4.95507,0.002 c -2.79936,0 -4.57517,0.10197 -5.71875,1.13282 -0.24259,0.21892 -0.43083,0.4754 -0.5879,0.74414 -0.0117,0.02 -0.0564,0.0782 -0.11132,0.1875 -0.0907,0.18027 -0.17065,0.37241 -0.23828,0.57617 -0.0671,0.20198 -0.12496,0.41859 -0.17383,0.65039 -0.0486,0.23023 -0.0869,0.47111 -0.11914,0.72851 v 0.002 c -0.0646,0.51578 -0.10015,1.09026 -0.11524,1.73633 -0.007,0.32198 -0.0116,0.66266 -0.01,1.02343 v 8.21875 8.22071 c -0.002,0.3594 0.002,0.69873 0.01,1.02148 0.0151,0.64603 0.0505,1.22236 0.11524,1.73828 0.0323,0.25754 0.0707,0.4986 0.11914,0.72852 0.0971,0.4603 0.23097,0.86702 0.41211,1.22656 0.18147,0.36018 0.41279,0.67544 0.69922,0.93359 0.14342,0.12929 0.30075,0.24284 0.46679,0.34375 0.33271,0.20222 0.70911,0.35057 1.12891,0.46094 v 0.002 c 1.04936,0.27537 2.37421,0.32422 4.12305,0.32422 h 11.85546 c 0.69562,0 1.32241,-0.0101 1.89063,-0.0371 h 0.002 c 0.23885,-0.0115 0.45772,-0.0289 0.66992,-0.0469 h 0.002 0.002 c 0.006,-5.4e-4 0.052,-0.004 0.0898,-0.006 h 0.0137 c 0.0155,-0.001 0.0141,-1.1e-4 0.0332,-0.002 h 0.002 c 0.51385,-0.0486 0.97388,-0.12251 1.38867,-0.23047 0.20576,-0.0536 0.4054,-0.11525 0.59571,-0.19141 0.18901,-0.0755 0.36479,-0.163 0.52929,-0.26172 0.1657,-0.0995 0.3216,-0.21271 0.46485,-0.33984 0.12928,-0.11465 0.24087,-0.23957 0.34179,-0.36524 0,2e-5 0.005,-0.005 0.006,-0.006 l 0.0215,-0.0215 0.0156,-0.0195 0.006,-0.008 0.002,-0.004 0.008,-0.008 0.008,-0.0137 c 4e-5,-7e-5 0.008,-0.016 0.0117,-0.0234 0.003,-0.004 0.009,-0.008 0.0117,-0.0117 -5.4e-4,7e-4 -0.007,0.003 -0.008,0.004 0.01,-0.0181 0.0172,-0.0306 0.0254,-0.0469 -0.006,0.0128 -0.01,0.0233 -0.0117,0.0273 0.095,-0.13149 0.18742,-0.26844 0.26562,-0.41992 0.0922,-0.17881 0.17175,-0.3686 0.24024,-0.56836 0.069,-0.20111 0.12594,-0.41283 0.17578,-0.63867 0.0501,-0.22709 0.0911,-0.46643 0.125,-0.71875 0.0307,-0.22912 0.0546,-0.4717 0.0742,-0.71875 l 0.002,-0.002 v -0.004 c -10e-4,0.0185 0.005,-0.009 0.01,-0.082 v -0.002 c 0.002,-0.0307 0.004,-0.0623 0,-0.006 v -0.002 -0.002 c 0.0411,-0.56466 0.0568,-1.18956 0.0586,-1.89062 v -0.004 -11.1875 c -0.007,-1.5618 -1.32097,-2.69049 -2.26758,-3.50391 l -0.01,-0.008 -0.002,-0.002 -6.71093,-6.47461 -0.008,-0.006 c -1.54333,-1.391 -2.79437,-2.15039 -4.97461,-2.15039 z"
-         id="path964-1-7-1"
-         inkscape:connector-curvature="0" />
+         d="m 247.47204,258.02538 -58.16888,-0.0674 V 50.509035 l 59.83429,-0.2166 c 10.39676,0.12515 15.59513,8.22114 15.59513,17.94885 V 239.23902 c 0.45245,10.68074 -6.60386,18.55532 -17.26054,18.78636 z"
+         fill="url(#a)"
+         id="path17"
+         style="display:inline;enable-background:new;fill:url(#a);stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.13511628;marker:none;enable-background:accumulate"
-         d="m 334.25586,134.71289 c -0.45236,0.0121 -0.90224,0.0272 -1.33594,0.006 -2.52549,0.19734 -5.18742,-0.29143 -7.57031,0.5625 -1.22203,1.79732 -0.53543,4.18481 -0.77344,6.22656 0.0816,5.97656 -0.25479,11.9827 0.23438,17.94141 0.31504,2.23143 2.92802,1.8499 4.54297,1.88476 5.47813,-0.0313 10.98834,0.22939 16.44726,-0.22656 1.82302,-0.71065 1.25717,-3.16493 1.46875,-4.67383 0.0755,-3.85966 0.0248,-7.72188 0.0391,-11.58203 -2.69482,-3.40969 -6.0967,-6.20501 -9.31836,-9.10351 -1.00037,-1.08075 -2.37728,-1.07153 -3.73437,-1.03516 z"
-         id="rect4158-92-6-7-3"
-         inkscape:connector-curvature="0" />
+         d="m 155.43189,50.542735 79.47742,-7.45101 c 10.63261,-1.07337 15.27744,4.6304 15.35928,16.06202 L 249.59473,247.1184 c -0.19254,12.71678 -5.88187,19.3784 -17.09689,19.84529 l -76.54611,-8.93832 H 74.202425 c -10.44007,0 -21.04861,-8.50031 -21.10637,-21.74655 V 71.552835 c 0.3995,-15.23894 6.75308,-20.98122 21.99202,-21.2604 z"
+         fill="url(#b)"
+         id="path19"
+         style="display:inline;enable-background:new;fill:url(#b);stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.13511628;marker:none;enable-background:accumulate"
-         d="m 342.43453,133.5 c -0.0499,0 -0.0992,0.005 -0.14846,0.0114 -0.63275,0.19268 -0.84778,1.10823 -0.35998,1.53887 l 5.15449,4.82872 c 0.52901,0.47937 1.38249,0.0699 1.41036,-0.62634 v -1.36063 c 0.0226,-4.21424 0.33006,-4.29412 -3.66401,-4.38062 h -2.24263 c -0.0493,-0.007 -0.0999,-0.0114 -0.14977,-0.0114 z m -12.63559,0.0804 c -5.53701,-3.3e-4 -6.32794,0.58227 -6.29884,6.26467 v 8.19515 8.19514 c -0.0291,5.68242 1.00827,6.26467 6.54528,6.26467 h 11.7978 c 5.49726,0 6.52858,-0.57993 6.54266,-6.15295 v -11.14923 c -0.006,-1.25658 -1.15546,-2.31787 -2.08629,-3.11916 l -0.008,-0.006 -6.70166,-6.47491 c -1.50985,-1.36345 -2.55339,-2.01695 -4.61908,-2.01707 z m 7.22852,2.4196 8.97205,8.99977 V 158 c 0,0 -0.11213,1.17819 -0.44846,1.49951 -0.33633,0.32134 -1.56951,0.42847 -1.56951,0.42847 h -15.96407 c 0,0 -1.23318,-0.10713 -1.56951,-0.42847 C 326.11164,159.17819 325.99951,158 325.99951,158 l -0.018,-20.07203 c 0,0 0.11213,-1.17819 0.44845,-1.49951 C 326.76633,136.10713 327.99951,136 327.99951,136 Z"
-         id="rect4158-92-6-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 249.59472,247.11841 c -0.19254,12.71678 -5.88187,19.37839 -17.09689,19.84529 l -77.41249,-9.0394 V 50.576425 l 79.82397,-7.4847 c 10.63261,-1.07337 15.27744,4.6304 15.35928,16.06202 z"
+         fill-opacity="0.15"
+         id="path21"
+         style="display:inline;enable-background:new;stroke-width:4.81331" />
       <path
-         style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 323.49951,148 v 0.041 8.19531 c -0.0291,5.68242 1.00791,6.26367 6.54492,6.26367 h 11.79883 c 5.49726,0 6.52889,-0.57932 6.54297,-6.15234 V 148 Z"
-         id="rect4398"
-         inkscape:connector-curvature="0" />
+         d="m 363.60587,104.95164 -11.9454,-0.0138 V 62.336678 l 12.2874,-0.04448 c 2.13505,0.0257 3.20257,1.68827 3.20257,3.685925 v 35.115607 c 0.0929,2.19337 -1.35616,3.81047 -3.54457,3.85791 z"
+         fill="url(#a)"
+         id="path512"
+         style="display:inline;enable-background:new;fill:url(#linearGradient524);stroke-width:0.988448" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 353.50267,61.372958 c -0.13268,1.31e-4 -0.25604,0.01264 -0.36719,0.0293 l -0.0781,0.01172 -0.0762,0.02344 c -0.87574,0.279121 -1.39412,1.031903 -1.56445,1.792968 -0.1518,0.678132 0.0116,1.444638 0.51367,2.050782 l -0.36328,-0.363282 -0.01,-0.0078 -0.002,-0.0039 c 0,0 -0.002,0.0038 -0.002,0.0039 -0.28283,-0.2673 -0.55686,-0.524524 -0.83398,-0.767578 h -0.002 l -0.002,-0.0039 -0.002,-0.002 c 0,0 -0.006,-0.0019 -0.006,-0.002 -0.2711,-0.237536 -0.5406,-0.460957 -0.81055,-0.669922 0,0 -0.006,-0.0038 -0.006,-0.0039 -1.8e-4,-8.7e-5 -0.006,-0.0038 -0.006,-0.0039 -0.26922,-0.208011 -0.54257,-0.405967 -0.82617,-0.587891 h -0.002 l -0.002,-0.002 c 0,10e-7 -0.004,-0.0019 -0.004,-0.002 -0.27684,-0.177258 -0.55998,-0.341168 -0.85742,-0.488281 1e-5,0 -0.006,-0.0019 -0.006,-0.002 -0.29595,-0.146081 -0.60404,-0.275888 -0.92383,-0.386719 l -0.004,-0.002 h -0.002 -0.002 c -0.31787,-0.109783 -0.64897,-0.202793 -0.99414,-0.275391 0,-10e-7 -0.009,7.3e-5 -0.01,0 -0.34183,-0.07151 -0.69666,-0.126987 -1.07031,-0.162109 h -0.002 c -0.37669,-0.03533 -0.76878,-0.05072 -1.17774,-0.05078 h -0.002 -8.26738 c -4.1516,0 -6.86541,0.144562 -8.65234,1.832031 -0.89392,0.844181 -1.42053,2.015243 -1.71289,3.464843 -0.29235,1.449602 -0.3762,2.716408 -0.36524,4.956832 V 84.497515 97.24947 c -0.0108,2.23702 0.0732,4.00312 0.36524,5.45117 0.29236,1.44961 0.81896,2.62067 1.71289,3.46485 0.22046,0.20818 0.46372,0.3989 0.72656,0.5664 l 0.004,0.002 0.006,0.004 c 0,0 0.011,0.004 0.0117,0.004 0.24938,0.15738 0.51414,0.29744 0.79688,0.41797 l 0.006,0.002 c 10e-4,5.8e-4 0.003,0.003 0.004,0.004 h 0.002 c 0.001,2.9e-4 0.01,0.003 0.0117,0.004 0.28562,0.12045 0.58739,0.22665 0.90625,0.31446 h 0.002 0.002 c 0.31721,0.0872 0.65158,0.16192 1.00586,0.22265 h 0.004 0.002 0.002 c 0.35215,0.0602 0.71743,0.1063 1.10157,0.14453 2e-5,0 0.005,-1e-5 0.006,0 0.38435,0.0381 0.78775,0.0683 1.21289,0.0899 h 0.004 0.002 c 4.7e-4,1e-5 0.005,-1e-5 0.006,0 l 0.004,0.002 c 3.5e-4,1e-5 0.0746,-7e-5 0.0723,0 0.83602,0.0405 3.76301,0.0566 2.7539,0.0566 h 0.002 17.03691 c 4.12301,0 6.31689,-0.14175 8.10202,-1.80273 0.89298,-0.83017 1.42413,-1.9843 1.72461,-3.41016 0.30048,-1.42587 0.39703,-3.16132 0.40234,-5.35937 v -18.908211 -0.002 c -0.009,-1.901937 -1.18883,-3.38937 -2.32226,-4.541016 -0.37676,-0.382884 -0.75737,-0.733609 -1.10938,-1.050781 l -0.28515,-0.257813 h 0.0273 l -0.0117,-0.01172 h -0.002 l -0.0508,-0.05078 c 0.7203,0.562642 1.63962,0.613597 2.36523,0.31836 0.78035,-0.317514 1.50219,-1.045367 1.54102,-2.060547 v -0.01953 -1.63066 -0.0059 c 0.008,-1.627913 0.0362,-2.86715 -0.0274,-3.875 -0.0638,-1.009375 -0.2058,-1.850441 -0.73633,-2.546875 -0.53053,-0.696434 -1.36221,-1.029213 -2.28515,-1.181641 -0.92293,-0.152428 -2.03533,-0.179157 -3.52344,-0.21289 h -0.0117 -2.84421 -0.002 c -0.073,-0.0069 -0.14393,-0.0174 -0.2207,-0.01758 z m -24.57206,43.876752 c 7.7e-4,4.2e-4 10e-4,0.002 0.002,0.002 -0.0334,0.003 -0.0689,0.006 -0.0684,0.006 5.2e-4,-8e-5 0.0335,-0.004 0.0664,-0.008 z m -0.0312,1.98438 c 0.005,2.6e-4 0.0335,0.004 0.0645,0.006 -0.0263,-10e-4 -0.0586,-0.004 -0.0586,-0.004 z"
-         id="path964-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccscccccccccccccccccccccccccccccccscsccccccccccccccccccsccccccccccccccc" />
+         d="m 344.70476,62.343598 16.32126,-1.530118 c 2.18347,-0.220424 3.13733,0.950886 3.15414,3.298451 l -0.1384,38.599889 c -0.0395,2.61148 -1.20788,3.97949 -3.51096,4.07537 l -15.71929,-1.83555 H 328.0237 c -2.14393,0 -4.32247,-1.7456 -4.33434,-4.46581 V 66.658173 c 0.082,-3.129425 1.3868,-4.308643 4.51622,-4.365976 z"
+         fill="url(#b)"
+         id="path514"
+         style="display:inline;enable-background:new;fill:url(#linearGradient522);stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6668);enable-background:accumulate"
-         d="M 102.92188 46 C 67.62515 46 64 49.625611 64 84.994141 L 64 156 L 64 158 L 64 229.00586 C 64 244.47959 64.693319 253.87799 68.429688 259.55469 C 68.963453 260.36564 69.559812 261.0997 70.224609 261.76562 C 75.542989 267.0931 85.27351 268 102.92188 268 L 201.07812 268 C 203.13276 268 205.06552 267.98518 206.91211 267.95508 C 207.57101 267.94428 208.1733 267.9199 208.80664 267.9043 C 209.95599 267.876 211.09853 267.8452 212.16602 267.79883 C 213.43596 267.74363 214.67536 267.67931 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.44517 267.45882 217.67424 267.44102 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67577 267.09975 221.31832 267.00362 221.94336 266.90039 C 222.16533 266.86369 222.37512 266.82019 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.01019 266.50659 224.24912 266.45017 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.69251 266.09626 225.94528 266.02572 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.98625 265.36467 228.26277 265.25859 228.53516 265.14844 C 228.73131 265.06914 228.92945 264.98988 229.11914 264.90625 C 229.3939 264.78514 229.6565 264.65577 229.91797 264.52539 C 230.0924 264.43839 230.27277 264.35491 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.02943 263.29518 232.41788 263.01413 232.78711 262.71484 C 233.12677 262.43952 233.44633 262.14559 233.75586 261.8418 C 233.83036 261.7687 233.90178 261.69201 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01257 256.99161 237.07571 256.85555 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.81286 254.90311 237.95901 254.4144 238.09961 253.91406 C 238.14041 253.7689 238.17961 253.62078 238.21875 253.47266 C 238.28325 253.22887 238.34214 252.97259 238.40234 252.7207 C 238.54618 252.11901 238.67815 251.49292 238.79883 250.84375 C 238.83073 250.67198 238.86618 250.50525 238.89648 250.33008 C 239.03717 249.51898 239.16395 248.67505 239.27344 247.78906 C 239.29544 247.61129 239.31328 247.41914 239.33398 247.23828 C 239.41648 246.52006 239.48974 245.77779 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78859 241.4566 239.80646 241.21235 239.81836 240.95312 C 239.82536 240.80563 239.82738 240.64128 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96989 235.43296 239.97567 235.00563 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 128.24023 C 239.956 118.50733 231.82093 110.28461 225.23828 104.07812 L 225.18945 104.02734 L 184.66602 61.619141 C 173.98913 51.057981 166.6082 46 152 46 L 102.92188 46 z M 199.9043 46.089844 C 197.73512 48.865721 197.51891 53.493389 200.11328 56.001953 L 228.60938 86.388672 C 232.33314 90.084594 239.72783 86.956935 239.99023 81.609375 C 239.9886 81.189355 239.99156 80.748144 239.98828 80.337891 C 239.98738 79.846541 239.97958 79.384529 239.97656 78.90625 C 239.61491 51.652251 235.0161 46.715732 208.63086 46.089844 L 199.9043 46.089844 z "
-         id="path5316-1" />
+         d="m 364.04177,102.71182 c -0.0395,2.61148 -1.20788,3.97949 -3.51097,4.07537 l -15.8972,-1.85631 V 62.350517 l 16.39242,-1.537037 c 2.18348,-0.220424 3.13733,0.950886 3.15414,3.298451 z"
+         fill-opacity="0.15"
+         id="path516"
+         style="display:inline;enable-background:new;stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6646);enable-background:accumulate"
-         d="M 102.92188 45 C 67.62515 45 64 48.625611 64 83.994141 L 64 156 L 64 157 L 64 229.00586 C 64 244.47959 64.693319 253.87799 68.429688 259.55469 C 68.963453 260.36564 69.559812 261.0997 70.224609 261.76562 C 75.542989 267.0931 85.27351 268 102.92188 268 L 201.07812 268 C 203.13276 268 205.06552 267.98518 206.91211 267.95508 C 207.57101 267.94428 208.1733 267.9199 208.80664 267.9043 C 209.95599 267.876 211.09853 267.8452 212.16602 267.79883 C 213.43596 267.74363 214.67536 267.67931 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.44517 267.45882 217.67424 267.44102 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67577 267.09975 221.31832 267.00362 221.94336 266.90039 C 222.16533 266.86369 222.37512 266.82019 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.01019 266.50659 224.24912 266.45017 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.69251 266.09626 225.94528 266.02572 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.98625 265.36467 228.26277 265.25859 228.53516 265.14844 C 228.73131 265.06914 228.92945 264.98988 229.11914 264.90625 C 229.3939 264.78514 229.6565 264.65577 229.91797 264.52539 C 230.0924 264.43839 230.27277 264.35491 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.02943 263.29518 232.41788 263.01413 232.78711 262.71484 C 233.12677 262.43952 233.44633 262.14559 233.75586 261.8418 C 233.83036 261.7687 233.90178 261.69201 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01257 256.99161 237.07571 256.85555 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.81286 254.90311 237.95901 254.4144 238.09961 253.91406 C 238.14041 253.7689 238.17961 253.62078 238.21875 253.47266 C 238.28325 253.22887 238.34214 252.97259 238.40234 252.7207 C 238.54618 252.11901 238.67815 251.49292 238.79883 250.84375 C 238.83073 250.67198 238.86618 250.50525 238.89648 250.33008 C 239.03717 249.51898 239.16395 248.67505 239.27344 247.78906 C 239.29544 247.61129 239.31328 247.41914 239.33398 247.23828 C 239.41648 246.52006 239.48974 245.77779 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78859 241.4566 239.80646 241.21235 239.81836 240.95312 C 239.82536 240.80563 239.82738 240.64128 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96989 235.43296 239.97567 235.00563 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 127.24023 C 239.956 117.50733 231.82093 109.28462 225.23828 103.07812 L 225.18945 103.02734 L 184.66602 60.619141 C 173.98913 50.057981 166.6082 45 152 45 L 102.92188 45 z M 200.89062 45.089844 C 197.85089 47.592149 197.17007 53.156086 200.11328 56.001953 L 228.60938 86.388672 C 232.33829 90.089704 239.75115 86.948987 239.99414 81.587891 C 239.99392 81.377038 239.99278 81.169387 239.99219 80.960938 C 239.99209 79.762634 239.97942 78.632386 239.9668 77.509766 C 239.56354 50.620533 234.88168 45.712543 208.63086 45.089844 L 200.89062 45.089844 z "
-         id="path5316-84" />
+         d="m 348.78644,161.66411 -7.79048,-0.009 v -27.78336 l 8.01352,-0.029 c 1.39242,0.0168 2.08863,1.10104 2.08863,2.40386 v 22.90148 c 0.0606,1.43046 -0.88445,2.48509 -2.31167,2.51603 z"
+         fill="url(#a)"
+         id="path526"
+         style="display:inline;enable-background:new;fill:url(#linearGradient538);stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="M 102.92188 44 C 100.74614 44 98.695529 44.014677 96.753906 44.048828 C 67.272036 44.576673 64.085938 49.836144 64.085938 82.994141 L 64.085938 156 L 64.085938 229.00586 C 64.085938 262.16386 67.272036 267.42333 96.753906 267.95117 C 98.695529 267.98532 100.74614 268 102.92188 268 C 102.95214 268.00001 102.9775 268 103.00781 268 L 201.07812 268 C 203.13276 268 205.06552 267.98518 206.91211 267.95508 C 207.57101 267.94428 208.1733 267.9199 208.80664 267.9043 C 209.95599 267.876 211.09853 267.8452 212.16602 267.79883 C 213.43596 267.74363 214.67536 267.67931 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.44517 267.45882 217.67424 267.44102 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67577 267.09975 221.31832 267.00362 221.94336 266.90039 C 222.16533 266.86369 222.37512 266.82019 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.01019 266.50659 224.24912 266.45017 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.69251 266.09626 225.94528 266.02572 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.98625 265.36467 228.26277 265.25859 228.53516 265.14844 C 228.73131 265.06914 228.92945 264.98988 229.11914 264.90625 C 229.3939 264.78514 229.6565 264.65577 229.91797 264.52539 C 230.0924 264.43839 230.27277 264.35491 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.02943 263.29518 232.41788 263.01413 232.78711 262.71484 C 233.12677 262.43952 233.44633 262.14559 233.75586 261.8418 C 233.83036 261.7687 233.90178 261.69201 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01257 256.99161 237.07571 256.85555 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.81286 254.90311 237.95901 254.4144 238.09961 253.91406 C 238.14041 253.7689 238.17961 253.62078 238.21875 253.47266 C 238.28325 253.22887 238.34214 252.97259 238.40234 252.7207 C 238.54618 252.11901 238.67815 251.49292 238.79883 250.84375 C 238.83073 250.67198 238.86618 250.50525 238.89648 250.33008 C 239.03717 249.51898 239.16395 248.67505 239.27344 247.78906 C 239.29544 247.61129 239.31328 247.41914 239.33398 247.23828 C 239.41648 246.52006 239.48974 245.77779 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78859 241.4566 239.80646 241.21235 239.81836 240.95312 C 239.82536 240.80563 239.82738 240.64128 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96989 235.43296 239.97567 235.00563 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 126.24023 C 239.956 116.50733 231.82093 108.28461 225.23828 102.07812 L 225.18945 102.02734 L 184.66602 59.619141 C 173.98918 49.057981 166.6082 44 152 44 L 102.92188 44 z M 202.6543 44.089844 C 198.17969 45.582244 196.66368 52.666443 200.11328 56.001953 L 228.60938 86.388672 C 232.34293 90.094303 239.77066 86.941636 239.99609 81.568359 C 240.04429 50.239345 236.44281 44.749576 208.63086 44.089844 L 202.6543 44.089844 z "
-         id="path5316-3" />
+         d="m 336.45963,133.87626 10.64429,-0.9979 c 1.424,-0.14376 2.04609,0.62014 2.05704,2.15116 l -0.0903,25.17384 c -0.0258,1.70314 -0.78775,2.59532 -2.28975,2.65785 l -10.25167,-1.1971 h -10.94858 c -1.39821,0 -2.819,-1.13843 -2.82673,-2.91248 v -22.06152 c 0.0535,-2.04093 0.90443,-2.80998 2.94536,-2.84737 z"
+         fill="url(#b)"
+         id="path528"
+         style="display:inline;enable-background:new;fill:url(#linearGradient536);stroke-width:0.64464" />
       <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
+         d="m 349.07071,160.20336 c -0.0258,1.70314 -0.78775,2.59532 -2.28976,2.65785 l -10.36773,-1.21064 v -27.7698 l 10.69071,-1.00241 c 1.424,-0.14376 2.04608,0.62014 2.05704,2.15116 z"
+         fill-opacity="0.15"
+         id="path530"
+         style="display:inline;enable-background:new;stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188,44.000001 C 67.62516,44.000001 64,47.625611 64,82.994141 V 156 229.00586 C 64,264.37439 67.62516,268 102.92188,268 h 98.15625 C 236.37486,268 240.17299,264.37398 240,229.00586 V 126.24023 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 C 173.98919,49.057941 166.6082,44.000001 152,44.000001 Z"
-         id="path5316"
-         inkscape:connector-curvature="0" />
+         d="m 341.40792,210.12213 -5.71302,-0.007 v -20.37447 l 5.87658,-0.0213 c 1.02111,0.0123 1.53166,0.80743 1.53166,1.76283 v 16.79442 c 0.0444,1.049 -0.64859,1.8224 -1.69522,1.84509 z"
+         fill="url(#a)"
+         id="path540"
+         style="display:inline;enable-background:new;fill:url(#linearGradient552);stroke-width:0.472736" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
+         d="m 332.36826,189.74437 7.80581,-0.73179 c 1.04427,-0.10543 1.50047,0.45477 1.5085,1.57751 l -0.0662,18.46082 c -0.0189,1.24897 -0.57769,1.90324 -1.67915,1.94909 l -7.5179,-0.87787 h -8.02895 c -1.02536,0 -2.06727,-0.83485 -2.07294,-2.13582 v -16.17845 c 0.0392,-1.49668 0.66325,-2.06065 2.15993,-2.08807 z"
+         fill="url(#b)"
+         id="path542"
+         style="display:inline;enable-background:new;fill:url(#linearGradient550);stroke-width:0.472736" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.5,62.558594 c -2.56739,0.197545 -5.5956,-0.248988 -7.71484,1.501953 -1.61265,2.60175 -1.03276,5.900036 -1.25782,8.810547 -0.0569,9.221434 -0.24244,18.470385 0.19922,27.664066 0.0895,2.14893 1.2461,4.53645 3.67383,4.66015 6.74091,0.43986 13.59594,0.16181 20.38281,0.19141 2.87871,-0.17687 5.86199,0.25414 8.63282,-0.70508 2.29464,-1.50171 1.65229,-4.5939 1.875,-6.929687 0.0177,-6.805603 0.31687,-13.702294 -0.0352,-20.529297 -0.80743,-1.843671 -2.64468,-3.112144 -3.91406,-4.638672 -3.22271,-3.095747 -6.137,-6.592984 -9.78125,-9.205078 -2.23017,-1.377899 -4.99737,-0.515898 -7.48828,-0.802734 -1.52414,-0.01856 -3.04804,-0.03334 -4.57227,-0.01758 z"
-         id="path964"
-         inkscape:connector-curvature="0" />
+         d="m 341.61638,209.05091 c -0.0189,1.24897 -0.57768,1.90324 -1.67915,1.94909 l -7.60301,-0.8878 v -20.36452 l 7.83986,-0.7351 c 1.04426,-0.10543 1.50046,0.45477 1.50849,1.57751 z"
+         fill-opacity="0.15"
+         id="path544"
+         style="display:inline;enable-background:new;stroke-width:0.472736" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.20550393;marker:none;enable-background:accumulate"
-         d="m 353.5,61.375 c -0.0742,0 -0.1474,0.0066 -0.2207,0.01758 -0.94065,0.29981 -1.26034,1.724451 -0.53516,2.394531 l 7.51367,7.513672 c 0.78643,0.74591 2.35309,0.108771 2.39453,-0.974609 v -2.117188 c 0.0336,-6.55752 0.34204,-6.681806 -5.5957,-6.816406 h -3.33398 C 353.64936,61.381278 353.57418,61.375 353.5,61.375 Z M 335.23047,61.5 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 V 84 96.751953 c -0.0433,8.842037 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70563,-0.9024 9.72656,-9.574219 V 78.021484 c -0.009,-1.95527 -1.71775,-3.606675 -3.10156,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 C 348.62066,62.51706 347.069,61.5 343.99805,61.5 Z M 346.5,65 359,77.5 V 100 c 0,0 -0.1667,1.8333 -0.6667,2.3333 C 357.8333,102.8333 356,103 356,103 h -24 c 0,0 -1.8333,-0.1667 -2.3333,-0.6667 C 329.1667,101.8333 329,100 329,100 V 68 c 0,0 0.1667,-1.8333 0.6667,-2.3333 C 330.1667,65.1667 332,65 332,65 Z"
-         id="rect4158-92-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 333.98686,250.44136 -3.63556,-0.004 v -12.96557 l 3.73964,-0.0135 c 0.6498,0.008 0.97469,0.51382 0.97469,1.1218 v 10.68736 c 0.0283,0.66754 -0.41274,1.15971 -1.07877,1.17415 z"
+         fill="url(#a)"
+         id="path554"
+         style="display:inline;enable-background:new;fill:url(#linearGradient566);stroke-width:0.300832" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.90435,236.5 c 0.71048,0 1.27344,0.0154 1.75195,0.0957 0.47851,0.0803 0.89671,0.23728 1.20703,0.54688 0.31032,0.30959 0.46726,0.7261 0.54688,1.20508 0.0796,0.47897 0.0933,1.04352 0.0898,1.75586 V 244 v 3.89844 c 0.003,0.71121 -0.0103,1.27546 -0.0898,1.7539 -0.0796,0.47898 -0.23655,0.89549 -0.54688,1.20508 -0.31033,0.3096 -0.72851,0.46655 -1.20703,0.54688 -0.47852,0.0803 -1.04147,0.0957 -1.75195,0.0957 h -5.8086 c -0.71048,0 -1.27236,-0.0153 -1.75,-0.0957 -0.47763,-0.0804 -0.89584,-0.23713 -1.20508,-0.54688 -0.30921,-0.30975 -0.46469,-0.72681 -0.54492,-1.20508 -0.0802,-0.47826 -0.0957,-1.04201 -0.0957,-1.7539 V 244 240.10156 c 0,-0.71189 0.0155,-1.27564 0.0957,-1.7539 0.0802,-0.47827 0.2357,-0.89533 0.54492,-1.20508 0.30924,-0.30975 0.72745,-0.4665 1.20508,-0.54688 0.47764,-0.0804 1.03952,-0.0957 1.75,-0.0957 z"
-         id="path918"
-         inkscape:connector-curvature="0" />
+         d="m 328.23434,237.47369 4.96734,-0.46568 c 0.66453,-0.0671 0.95484,0.2894 0.95995,1.00387 l -0.0421,11.74779 c -0.012,0.7948 -0.36763,1.21116 -1.06855,1.24033 l -4.78411,-0.55864 h -5.10934 c -0.6525,0 -1.31553,-0.53127 -1.31914,-1.35916 v -10.29538 c 0.0249,-0.95243 0.42207,-1.31132 1.3745,-1.32877 z"
+         fill="url(#b)"
+         id="path556"
+         style="display:inline;enable-background:new;fill:url(#linearGradient564);stroke-width:0.300832" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 336.13453,188.5 c 1.11158,0 1.98683,0.0256 2.70703,0.14648 0.72019,0.1209 1.3105,0.34863 1.74218,0.7793 0.43169,0.43067 0.65954,1.01974 0.7793,1.74024 0.11977,0.72049 0.14217,1.59669 0.13672,2.71093 V 200 v 6.125 c 0.005,1.1131 -0.017,1.989 -0.13672,2.70898 -0.11976,0.72051 -0.3476,1.30957 -0.7793,1.74024 -0.43169,0.43067 -1.02199,0.6584 -1.74218,0.7793 -0.7202,0.12089 -1.59545,0.14648 -2.70703,0.14648 h -8.26954 c -1.11158,0 -1.98637,-0.0255 -2.70507,-0.14648 -0.7187,-0.12095 -1.30623,-0.34848 -1.73633,-0.7793 -0.4301,-0.43083 -0.6566,-1.01849 -0.77735,-1.73828 -0.12074,-0.71979 -0.14648,-1.59713 -0.14648,-2.71094 V 200 193.875 c 0,-1.11381 0.0257,-1.99115 0.14648,-2.71094 0.12075,-0.71979 0.34725,-1.30745 0.77735,-1.73828 0.4301,-0.43082 1.01763,-0.65835 1.73633,-0.7793 0.7187,-0.12094 1.59349,-0.14648 2.70507,-0.14648 z"
-         id="path914"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1309);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0962,238 c -0.6888,0 -1.1839,0.0205 -1.5039,0.0742 -0.30449,0.0511 -0.38369,0.11806 -0.39649,0.13086 -0.0131,0.0131 -0.0746,0.0855 -0.125,0.38867 -0.0529,0.31839 -0.0733,0.81274 -0.0703,1.50195 v 0.004 3.90039 3.90234 0.002 c -0.003,0.68916 0.0176,1.18495 0.0703,1.50195 0.0504,0.30317 0.1119,0.37557 0.125,0.38867 0.0128,0.0128 0.0918,0.0798 0.39649,0.13086 0.32002,0.0537 0.8151,0.0742 1.5039,0.0742 h 5.8086 c 0.68894,0 1.18348,-0.0206 1.50195,-0.0742 0.30433,-0.0512 0.38043,-0.1186 0.39063,-0.1289 0.0112,-0.0112 0.0774,-0.0858 0.1289,-0.39258 0.0536,-0.31974 0.0742,-0.81575 0.0742,-1.50586 V 244 241 l -3,-3 z"
-         id="path1291" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1311);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86573,190 c -1.08855,0 -1.90034,0.0312 -2.45898,0.125 -0.54887,0.0921 -0.79683,0.22878 -0.93164,0.36328 -0.13436,0.13404 -0.26642,0.37645 -0.35742,0.92383 -0.0925,0.55627 -0.12219,1.36674 -0.11719,2.45703 v 0.004 6.12695 6.12891 0.002 c -0.005,1.0898 0.0249,1.9019 0.11719,2.45703 0.091,0.5474 0.22306,0.78979 0.35742,0.92383 0.13484,0.13452 0.38277,0.27118 0.93164,0.36328 0.55862,0.0938 1.37043,0.125 2.45898,0.125 h 8.26954 c 1.08864,0 1.90078,-0.0314 2.45703,-0.125 0.54703,-0.0921 0.78777,-0.227 0.92187,-0.36133 0.13429,-0.13451 0.26913,-0.37646 0.36133,-0.92578 0.0936,-0.55811 0.125,-1.37233 0.125,-2.46303 V 200 197 L 333,190 Z"
-         id="path1293"
-         sodipodi:nodetypes="scccccccccccsscccscccs" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 323.0005,200 v 6.125 c -0.0217,4.42101 0.45314,4.875 4.86523,4.875 h 8.26954 c 4.41209,0 4.86523,-0.45393 4.86523,-4.875 V 200 Z"
-         id="path1007"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 322.0005,244 v 3.89844 C 321.9867,250.71181 322.28851,251 325.0962,251 h 5.8086 c 2.8077,0 3.0957,-0.28815 3.0957,-3.10156 V 244 Z"
-         id="path1016"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 325.50195,84 v 12.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 V 84 Z"
-         id="path964-0"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18820-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188 44 C 90.788624 44 82.396956 44.428807 76.609375 46.427734 C 74.505793 47.154326 72.745865 48.088818 71.275391 49.285156 C 71.274692 49.285724 71.274136 49.286541 71.273438 49.287109 C 70.171193 50.184574 69.229818 51.229668 68.429688 52.445312 C 68.174328 52.833282 67.936671 53.242531 67.708984 53.666016 C 67.651564 53.772798 67.598688 53.886993 67.542969 53.996094 C 67.382444 54.310441 67.226879 54.630866 67.080078 54.964844 C 67.006949 55.131203 66.93897 55.305225 66.869141 55.476562 C 66.748138 55.773462 66.628968 56.074579 66.517578 56.386719 C 66.446853 56.584913 66.379471 56.787726 66.3125 56.992188 C 66.212808 57.29649 66.117028 57.607335 66.025391 57.925781 C 65.965274 58.134707 65.90637 58.345421 65.849609 58.560547 C 65.756412 58.913766 65.668449 59.278191 65.583984 59.648438 C 65.536317 59.857386 65.488342 60.062875 65.443359 60.277344 C 65.362062 60.664875 65.287698 61.068729 65.214844 61.474609 C 65.176853 61.686319 65.133436 61.890634 65.097656 62.107422 C 64.994386 62.732944 64.90026 63.376169 64.814453 64.044922 C 64.814368 64.045582 64.814538 64.046215 64.814453 64.046875 C 64.730212 64.703594 64.654689 65.386182 64.585938 66.085938 C 64.558109 66.36935 64.535208 66.668359 64.509766 66.958984 C 64.471641 67.394278 64.435363 67.831478 64.402344 68.283203 C 64.320685 69.400176 64.258682 70.586022 64.205078 71.806641 C 64.154684 72.953182 64.119332 74.174143 64.089844 75.416016 C 64.07606 75.996757 64.054735 76.540389 64.044922 77.142578 C 64.014642 78.996321 64 80.929692 64 82.994141 L 64 156 L 64 229.00586 C 64 231.07031 64.014642 233.00368 64.044922 234.85742 C 64.054735 235.45961 64.07606 236.00324 64.089844 236.58398 C 64.119332 237.82586 64.154684 239.04682 64.205078 240.19336 C 64.258682 241.41398 64.320685 242.59982 64.402344 243.7168 C 64.435363 244.16852 64.471641 244.60572 64.509766 245.04102 C 64.535208 245.33164 64.558109 245.63065 64.585938 245.91406 C 64.654689 246.61382 64.730212 247.29641 64.814453 247.95312 C 64.814533 247.95375 64.814373 247.95445 64.814453 247.95508 C 64.90026 248.62383 64.994386 249.26706 65.097656 249.89258 C 65.133436 250.10937 65.176853 250.31368 65.214844 250.52539 C 65.287698 250.93127 65.362062 251.33512 65.443359 251.72266 C 65.488342 251.93713 65.536317 252.14261 65.583984 252.35156 C 65.668449 252.72181 65.756412 253.08623 65.849609 253.43945 C 65.90637 253.65458 65.965274 253.86529 66.025391 254.07422 C 66.117028 254.39267 66.212808 254.70351 66.3125 255.00781 C 66.379471 255.21227 66.446853 255.41509 66.517578 255.61328 C 66.628968 255.92542 66.748138 256.22654 66.869141 256.52344 C 66.93897 256.69478 67.006949 256.8688 67.080078 257.03516 C 67.226879 257.36913 67.382444 257.68956 67.542969 258.00391 C 67.598688 258.11301 67.651564 258.2272 67.708984 258.33398 C 67.936671 258.75747 68.174328 259.16672 68.429688 259.55469 C 68.963454 260.36564 69.559812 261.09969 70.224609 261.76562 C 70.557008 262.09859 70.905713 262.4136 71.273438 262.71289 C 71.274154 262.71347 71.274674 262.71426 71.275391 262.71484 C 72.745865 263.91118 74.505793 264.84567 76.609375 265.57227 C 82.396956 267.57119 90.788624 268 102.92188 268 L 201.07812 268 C 203.1354 268 205.06339 267.98528 206.91211 267.95508 C 206.92365 267.95489 206.93381 267.95528 206.94531 267.95508 C 207.59075 267.94401 208.18439 267.91962 208.80664 267.9043 C 209.2637 267.89304 209.69197 267.87615 210.14258 267.86328 C 210.81633 267.8421 211.52187 267.82684 212.16602 267.79883 C 212.17279 267.79853 212.17877 267.79717 212.18555 267.79688 C 213.43824 267.74231 214.66024 267.67979 215.80469 267.5957 C 215.81466 267.59497 215.82402 267.59449 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.23558 267.47754 217.24681 267.47753 217.25781 267.47656 C 217.46816 267.45801 217.685 267.43997 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67616 267.09973 221.31798 267.00366 221.94336 266.90039 C 221.94542 266.90005 221.94716 266.89878 221.94922 266.89844 C 222.16891 266.86195 222.37713 266.81983 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.00025 266.50867 224.22962 266.45386 224.46094 266.40039 C 224.47079 266.39813 224.4804 266.3968 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.68584 266.09801 225.93206 266.0296 226.17578 265.95898 C 226.18242 265.95706 226.18868 265.95505 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.85083 265.41318 227.99309 265.35464 228.13867 265.29883 C 228.27101 265.24829 228.40567 265.20081 228.53516 265.14844 C 228.5463 265.14393 228.55721 265.13927 228.56836 265.13477 C 228.75355 265.05996 228.94022 264.98513 229.11914 264.90625 C 229.28649 264.83249 229.44465 264.75208 229.60547 264.67383 C 229.70972 264.62427 229.81573 264.57638 229.91797 264.52539 C 229.92526 264.52175 229.93214 264.5173 229.93945 264.51367 C 230.10652 264.43083 230.2783 264.35078 230.43945 264.26367 C 230.43995 264.2634 230.44091 264.26394 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.40332 263.04924 233.10973 262.47581 233.75586 261.8418 C 233.75717 261.84051 233.75845 261.83918 233.75977 261.83789 C 233.83088 261.76789 233.8992 261.69466 233.96875 261.62305 C 233.97067 261.62108 233.97269 261.61916 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01198 256.99293 237.07424 256.85802 237.13281 256.71875 C 237.13336 256.71744 237.13422 256.71615 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.8128 254.90328 237.95906 254.41419 238.09961 253.91406 C 238.10016 253.9121 238.10101 253.91016 238.10156 253.9082 C 238.14177 253.76492 238.18014 253.61878 238.21875 253.47266 C 238.25475 253.33659 238.2866 253.19365 238.32031 253.05273 C 238.34775 252.94302 238.37574 252.832 238.40234 252.7207 C 238.40295 252.71818 238.40369 252.71542 238.4043 252.71289 C 238.54743 252.11352 238.67865 251.4902 238.79883 250.84375 C 238.82465 250.7047 238.8511 250.56733 238.87695 250.42773 C 238.88281 250.39444 238.89069 250.3635 238.89648 250.33008 C 238.89659 250.32947 238.89638 250.32874 238.89648 250.32812 C 239.03705 249.51759 239.16403 248.67439 239.27344 247.78906 C 239.27936 247.74118 239.28361 247.6901 239.28906 247.64062 C 239.30493 247.50972 239.31875 247.37085 239.33398 247.23828 C 239.3363 247.21815 239.33755 247.19595 239.33984 247.17578 C 239.41881 246.48269 239.49003 245.76862 239.55273 245.0293 C 239.55328 245.02286 239.55414 245.0162 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78349 241.55491 239.79357 241.40032 239.80273 241.24609 C 239.80753 241.14632 239.81376 241.05363 239.81836 240.95312 C 239.81877 240.94439 239.81798 240.93463 239.81836 240.92578 C 239.8239 240.79729 239.82694 240.65948 239.83203 240.5293 C 239.83253 240.51759 239.83349 240.5039 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96307 235.84067 239.96271 235.82927 239.96289 235.81836 C 239.96965 235.41022 239.97579 234.99445 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 126.24023 C 239.99175 124.41532 239.69913 122.64313 239.18555 120.92773 C 238.84316 119.78414 238.40271 118.66667 237.88281 117.57422 C 235.02338 111.56573 229.76385 106.34509 225.23828 102.07812 L 225.18945 102.02734 L 184.66602 59.619141 C 173.98907 49.058011 166.6082 44 152 44 L 102.92188 44 z M 202.6543 44.089844 C 198.17969 45.582244 196.66368 52.666443 200.11328 56.001953 L 228.60938 86.388672 C 232.34293 90.094303 239.77066 86.941636 239.99609 81.568359 C 239.99904 79.653502 239.98605 77.841831 239.95703 76.115234 C 239.95423 75.948427 239.94846 75.795955 239.94531 75.630859 C 239.91561 74.073736 239.87303 72.583034 239.80859 71.173828 C 239.76149 70.141731 239.70379 69.149343 239.63477 68.193359 C 238.48179 52.247696 234.0865 46.656477 219.97266 44.832031 C 218.6759 44.664404 217.29786 44.529298 215.83203 44.419922 C 215.12248 44.366977 214.38958 44.320376 213.63867 44.279297 C 213.63006 44.278828 213.61995 44.277811 213.61133 44.277344 C 212.04337 44.192346 210.38654 44.131491 208.63086 44.089844 L 202.6543 44.089844 z M 119.56641 55.945312 C 130.94041 55.949312 142.19691 55.986006 153.46484 56.191406 C 160.70267 55.806356 167.33104 59.645279 172.32031 64.599609 C 188.42569 80.562439 203.72801 97.313632 219.59766 113.50977 C 223.01384 117.3863 227.86068 121.27297 227.77148 126.91016 C 228.13347 156.76716 227.92575 186.62924 227.87695 216.48828 C 227.61216 226.73843 228.27253 237.18437 226.96875 247.45312 C 226.42181 249.81071 226.43599 253.48893 223.40625 254.10352 C 215.81737 255.95335 207.89537 255.57352 200.13867 255.80078 C 164.59267 255.97868 128.71027 256.09951 93.162109 255.66406 C 88.457189 255.24944 83.282319 255.67006 79.042969 253.2793 C 76.215659 249.46054 76.934056 244.27573 76.597656 239.79492 C 76.014926 191.14952 75.895482 142.48894 76.013672 93.822266 C 76.296742 83.105596 75.520041 72.053786 77.582031 61.384766 C 77.890341 58.111406 81.437525 57.376809 84.078125 56.974609 C 95.865615 55.846619 107.85901 56.107003 119.56641 55.945312 z "
-         id="rect4158-92-3" />
+         d="m 334.11951,249.75967 c -0.012,0.7948 -0.36761,1.21116 -1.06855,1.24033 l -4.83828,-0.56496 V 237.4758 l 4.989,-0.46779 c 0.66453,-0.0671 0.95484,0.2894 0.95995,1.00387 z"
+         fill-opacity="0.15"
+         id="path558"
+         style="display:inline;enable-background:new;stroke-width:0.300832" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,156 v 73.00683 C 63.827405,264.37495 67.625545,268 102.92228,268 h 98.15624 c 35.29672,0 38.00361,-3.63655 38.92188,-38.99317 V 156 Z"
-         id="path4255"
-         sodipodi:nodetypes="ccssscc" />
+         d="m 117.27677,117.41889 h 69.44647 v 77.16221 h -69.44647 z"
+         fill="url(#c)"
+         id="path23"
+         style="display:inline;enable-background:new;fill:url(#c);stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,227.00586 v 2 C 63.827405,264.37398 67.625545,268 102.92228,268 h 98.15624 c 35.29672,0 38.00361,-3.63752 38.92188,-38.99414 v -2 C 239.08213,262.36248 236.37524,266 201.07852,266 h -98.15624 c -35.296735,0 -39.094875,-3.62602 -38.921885,-38.99414 z"
-         id="path945"
-         inkscape:connector-curvature="0" />
+         d="m 336.86934,76.077094 h 14.26133 v 15.845811 h -14.26133 z"
+         fill="url(#c)"
+         id="path518"
+         style="display:inline;enable-background:new;fill:url(#linearGradient520);stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07999998;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:7.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 180.0004,268 60,-60 v 22.48388 C 239.9481,264.47969 236.19772,268 201.8263,268 Z"
-         id="path4254"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccsc" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline">
+         d="m 331.34957,142.83289 h 9.30087 v 10.33422 h -9.30087 z"
+         fill="url(#c)"
+         id="path532"
+         style="display:inline;enable-background:new;fill:url(#linearGradient534);stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23242,61.5 c -4.11577,0 -6.55968,0.226752 -7.96875,1.558594 -0.28725,0.271486 -0.52183,0.601863 -0.72851,0.972656 -0.0468,0.08393 -0.10154,0.156606 -0.14454,0.246094 -2.5e-4,5.28e-4 2.6e-4,0.0014 0,0.002 -0.11616,0.241982 -0.2184,0.50414 -0.30859,0.789062 -0.0904,0.285534 -0.16955,0.593694 -0.23633,0.925782 -0.0668,0.332095 -0.1223,0.688232 -0.16797,1.070312 -0.0913,0.764147 -0.1422,1.632501 -0.16406,2.617188 -0.0109,0.492345 -0.0144,1.013779 -0.0117,1.566406 V 84 96.751953 c -0.003,0.552627 8e-4,1.074061 0.0117,1.566406 0.0219,0.984686 0.0727,1.853041 0.16406,2.617191 0.0457,0.38208 0.1012,0.73821 0.16797,1.07031 0.13356,0.66417 0.31198,1.23197 0.54492,1.7168 0.23295,0.48482 0.52078,0.88581 0.87305,1.21875 0.17614,0.16648 0.36842,0.31556 0.57813,0.44921 0.41895,0.26701 0.90872,0.47238 1.47656,0.62891 6.2e-4,1.7e-4 0.001,-1.7e-4 0.002,0 1.42142,0.39113 3.3408,0.48047 5.91211,0.48047 h 17.53906 c 1.02156,0 1.93959,-0.015 2.76368,-0.0566 0.34097,-0.0172 0.65525,-0.0427 0.96484,-0.0703 0.0645,-0.006 0.13795,-0.007 0.20117,-0.0137 0.001,-1.4e-4 0.003,1.3e-4 0.004,0 0.73118,-0.0725 1.37505,-0.17995 1.93945,-0.33399 0.28273,-0.0772 0.54639,-0.16492 0.79102,-0.26758 0.24462,-0.10265 0.47066,-0.22006 0.67968,-0.35156 0.20903,-0.1315 0.40024,-0.27771 0.57618,-0.44141 0.15581,-0.14498 0.29602,-0.30775 0.42773,-0.48046 0.017,-0.0223 0.0381,-0.0397 0.0547,-0.0625 0.001,-0.002 0.003,-0.004 0.004,-0.006 0.14374,-0.19776 0.2725,-0.41443 0.38868,-0.6504 0.11725,-0.23815 0.22082,-0.49693 0.3125,-0.77734 0.0917,-0.28041 0.17164,-0.58218 0.24023,-0.9082 0.0686,-0.32602 0.12581,-0.6758 0.17383,-1.05078 0.0428,-0.33417 0.0752,-0.6967 0.10351,-1.072269 0.003,-0.04534 0.0104,-0.0849 0.0137,-0.130859 4.2e-4,-0.0061 -4.3e-4,-0.01341 0,-0.01953 0.059,-0.850021 0.0853,-1.80463 0.0879,-2.88086 V 78.021484 c -0.009,-1.95527 -1.71776,-3.606675 -3.10157,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 C 348.62263,62.517026 347.07095,61.5 344,61.5 Z"
-         id="path964-1"
-         inkscape:connector-curvature="0" />
+         d="m 328.62088,196.31257 h 6.82064 v 7.57843 h -6.82064 z"
+         fill="url(#c)"
+         id="path546"
+         style="display:inline;enable-background:new;fill:url(#linearGradient548);stroke-width:0.472736" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -2.50815,0 -4.811706,0.02551 -7.011724,0.07227 -1.569123,0.03333 -3.085758,0.07665 -4.505859,0.142578 -0.892728,0.04133 -1.761123,0.08803 -2.597656,0.144531 -0.07361,0.005 -0.155337,0.0086 -0.228516,0.01367 -0.03977,0.0028 -0.07364,0.0069 -0.113281,0.0098 -1.116046,0.0793 -2.169724,0.179402 -3.1875,0.291016 -0.281404,0.03076 -0.565732,0.06033 -0.839844,0.09375 -0.275699,0.03373 -0.547991,0.06893 -0.816406,0.105469 -0.386448,0.05241 -0.763169,0.107586 -1.134766,0.166015 -0.245075,0.0387 -0.493706,0.07575 -0.732422,0.117188 -0.386715,0.06683 -0.756638,0.14255 -1.126953,0.216797 -0.50787,0.102283 -1.000729,0.211021 -1.478515,0.328125 -0.190937,0.04659 -0.386033,0.09158 -0.572266,0.140625 -0.3252,0.08602 -0.638123,0.17771 -0.949219,0.271484 -0.174107,0.05225 -0.347813,0.105409 -0.517578,0.160157 -0.32699,0.105899 -0.647816,0.216555 -0.958984,0.332031 -0.09794,0.0362 -0.19267,0.07416 -0.289063,0.111328 -1.533658,0.593687 -2.876219,1.308506 -4.044922,2.173828 -0.01464,0.01084 -0.03034,0.02036 -0.04492,0.03125 -4.841904,3.613548 -6.740009,9.796263 -7.419922,20.238281 -0.01716,0.264046 -0.02929,0.544903 -0.04492,0.814453 -0.06629,1.140594 -0.126494,2.305415 -0.167969,3.546875 -9.88e-4,0.02958 -9.78e-4,0.06216 -0.002,0.0918 -0.04738,1.439614 -0.07924,2.944486 -0.09961,4.525391 C 64.509576,49.175312 70.065023,46 102.92188,46 h 62.52929 c -0.85989,-0.295464 -1.74582,-0.553137 -2.65429,-0.783203 -0.15701,-0.03958 -0.31205,-0.08153 -0.47071,-0.119141 -0.38771,-0.0924 -0.78156,-0.17709 -1.17969,-0.257812 -0.28362,-0.0571 -0.57205,-0.108999 -0.86132,-0.160156 -0.33217,-0.05924 -0.66192,-0.122415 -1.00196,-0.173829 -0.61547,-0.09216 -1.24344,-0.171652 -1.88672,-0.238281 -0.25531,-0.02678 -0.51929,-0.04563 -0.77929,-0.06836 -0.49344,-0.04258 -0.99476,-0.07925 -1.50586,-0.107422 -0.26087,-0.01459 -0.52138,-0.03022 -0.78711,-0.04102 C 153.56684,44.020455 152.79888,44 152,44 Z"
-         id="path7796" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 202.6543,44.089844 C 201.58308,44.447123 200.68698,45.129921 199.98242,46 h 1.0957 c 34.15108,4e-6 38.64021,3.484765 38.89649,35.740234 0.003,-0.03712 0.0117,-0.07204 0.0137,-0.109375 -0.0536,-17.671398 -1.15787,-27.178174 -7.08008,-32.177734 -0.31691,-0.265045 -0.64554,-0.519153 -0.99023,-0.759766 -1.34338,-0.937742 -2.91268,-1.68853 -4.71875,-2.296875 -0.14212,-0.04772 -0.27668,-0.09862 -0.42188,-0.144531 -0.31902,-0.101184 -0.65609,-0.192499 -0.99023,-0.285156 -0.25795,-0.07131 -0.51412,-0.144507 -0.78125,-0.210938 -0.32384,-0.08078 -0.65655,-0.156631 -0.99414,-0.230468 -0.32254,-0.07033 -0.65294,-0.136909 -0.98828,-0.201172 -0.32063,-0.06164 -0.64012,-0.123397 -0.97266,-0.179688 -0.46228,-0.07802 -0.94194,-0.148582 -1.42773,-0.216797 -0.21622,-0.03046 -0.42163,-0.06516 -0.64258,-0.09375 -0.003,-3.28e-4 -0.005,-0.0016 -0.008,-0.002 -0.70741,-0.09114 -1.44413,-0.170948 -2.20118,-0.24414 -0.30752,-0.02983 -0.6294,-0.05499 -0.94531,-0.08203 -0.52075,-0.04445 -1.04787,-0.08768 -1.59179,-0.125 -0.34138,-0.02349 -0.68841,-0.04362 -1.03907,-0.06445 -0.36733,-0.02177 -0.74929,-0.04154 -1.12695,-0.06055 -1.40861,-0.07105 -2.86508,-0.128967 -4.42188,-0.166015 -0.006,-1.28e-4 -0.0105,5e-6 -0.0156,0 h -0.004 z"
-         id="path7794" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 64.011719,81.421875 C 64.009827,81.961067 64,82.439442 64,82.994141 v 2 c -0.0062,-1.260292 0.0066,-2.391311 0.01172,-3.572266 z"
-         id="path5316-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.005859,227.00586 v 2 c -0.0022,0.44238 0.0048,0.82141 0.0039,1.25391 0.0013,0.45945 0.007,0.88359 0.0098,1.33203 -0.01134,-1.48776 -0.02159,-2.96803 -0.01367,-4.58594 z M 240,227.75781 C 239.94446,262.39 236.11596,266 201.08398,266 h -98.15625 c -32.934263,0 -38.440959,-3.18029 -38.890621,-32.33398 0.304544,24.87428 3.489356,31.9654 22.175782,33.76562 0.0033,3.2e-4 0.0064,-3.2e-4 0.0098,0 0.761225,0.073 1.548247,0.13868 2.361328,0.19531 0.002,1.4e-4 0.0039,-1.4e-4 0.0059,0 0.814659,0.0567 1.655065,0.10648 2.523437,0.14844 6.7e-4,3e-5 0.0013,-3e-5 0.002,0 0.579873,0.028 1.24712,0.0365 1.851563,0.0586 1.208255,0.0442 2.391096,0.0937 3.701172,0.11719 0.0014,3e-5 0.0025,-2e-5 0.0039,0 1.964377,0.0351 4.045339,0.0488 6.250009,0.0488 0.002,0 0.004,0 0.006,0 h 98.15039 c 3.67649,0 6.93682,-0.0556 9.96094,-0.16602 2.42031,-0.0885 4.71577,-0.20623 6.75196,-0.40234 19.49586,-1.8777 22.12352,-9.49921 22.20507,-37.08398 -8.2e-4,-0.46208 0.006,-0.86842 0.004,-1.3418 z"
-         id="path5316-8"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 353.49905,61.375285 c -0.0742,0 -0.14719,0.007 -0.22049,0.018 -0.94065,0.29981 -1.25935,1.72298 -0.53417,2.39306 l 7.51333,7.51498 c 0.78643,0.74591 2.35311,0.10873 2.39455,-0.97465 v -2.118 c 0.0336,-6.55752 0.34308,-6.68079 -5.59466,-6.81539 H 353.722 c -0.0733,-0.0113 -0.14877,-0.018 -0.22295,-0.018 z"
-         id="rect4158-92-6-6"
-         sodipodi:nodetypes="scccccccs" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1004);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         clip-path="url(#clipPath994-5)"
-         d="m 335.23242,61.5 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 V 84 96.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 V 79.021813 C 362.49246,77.807802 361.8315,76.711812 361,75.756188 V 84 96.251953 c 0,2.193451 -0.0614,3.870697 -0.26562,5.087887 -0.20419,1.2172 -0.52867,1.92435 -0.99805,2.39454 -0.46938,0.47016 -1.17436,0.79564 -2.38867,1 -1.21432,0.20434 -2.8892,0.26562 -5.07813,0.26562 h -16.53906 c -2.18893,0 -3.86589,-0.0612 -5.08399,-0.26562 -1.21809,-0.20448 -1.92877,-0.5295 -2.40039,-1 -0.47161,-0.47052 -0.79596,-1.17682 -0.99804,-2.39258 -0.20209,-1.21576 -0.25879,-2.893414 -0.24805,-5.085941 v -0.002 V 84 71.746094 v -0.002 c -0.0107,-2.192528 0.046,-3.870175 0.24805,-5.085938 0.20209,-1.215763 0.52643,-1.922078 0.99804,-2.392578 0.47161,-0.4705 1.18426,-0.79553 2.40235,-1 C 331.86653,63.061202 333.54154,63 335.73047,63 H 348 c -1.40176,-1.001118 -3.79892,-1.5 -5.922,-1.5 z"
-         id="path990"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssccccscccsscccccccccscscss" />
-      <path
-         inkscape:connector-curvature="0"
-         style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04419417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 353.35547,61.876953 -0.14453,0.121094 c -0.28875,0.242959 -0.43321,0.748579 -0.31836,1.111328 0.007,0.0217 0.07,0.0936 0.11523,0.150391 0.056,-0.101219 0.12158,-0.193105 0.20313,-0.261719 l 0.14453,-0.121094 2.71875,0.02539 c 2.70745,0.02522 3.50936,0.05935 4.26562,0.185547 1.36683,0.228076 1.67801,0.658049 1.79102,2.474609 0.0245,0.393967 0.0317,1.552688 0.0352,2.636719 0.007,-1.466927 -5.4e-4,-3.080545 -0.0352,-3.636719 -0.11301,-1.81656 -0.42419,-2.246533 -1.79102,-2.474609 -0.75626,-0.126199 -1.55817,-0.160327 -4.26562,-0.185547 z"
-         id="path7025" />
-      <path
-         transform="translate(4.9980746e-4)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971-6)" />
-      <path
-         id="path1085"
-         d="m 327.86573,188.5 c -1.11158,0 -1.98683,0.0256 -2.70703,0.14648 -0.72019,0.1209 -1.3105,0.34863 -1.74218,0.7793 -0.43169,0.43067 -0.65954,1.01974 -0.7793,1.74024 -0.11977,0.72049 -0.14217,1.59669 -0.13672,2.71093 V 200 v 6.125 c -0.005,1.1131 0.017,1.989 0.13672,2.70898 0.11976,0.72051 0.3476,1.30957 0.7793,1.74024 0.43169,0.43067 1.02199,0.6584 1.74218,0.7793 0.7202,0.12089 1.59545,0.14648 2.70703,0.14648 h 8.26954 c 1.11158,0 1.98637,-0.0255 2.70507,-0.14648 0.7187,-0.12095 1.30623,-0.34848 1.73633,-0.7793 0.4301,-0.43083 0.6566,-1.01849 0.77735,-1.73828 0.12074,-0.71979 0.14648,-1.59713 0.14648,-2.71094 V 200 193.875 c 0,-1.11381 -0.0257,-1.99115 -0.14648,-2.71094 -0.12075,-0.71979 -0.34725,-1.30745 -0.77735,-1.73828 -0.4301,-0.43082 -1.01763,-0.65835 -1.73633,-0.7793 -0.7187,-0.12094 -1.59349,-0.14648 -2.70507,-0.14648 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path1087"
-         d="m 325.0962,236.5 c -0.71048,0 -1.27344,0.0154 -1.75195,0.0957 -0.47851,0.0803 -0.89671,0.23728 -1.20703,0.54688 -0.31032,0.30959 -0.46726,0.7261 -0.54688,1.20508 -0.0796,0.47897 -0.0933,1.04352 -0.0898,1.75586 V 244 v 3.89844 c -0.003,0.71121 0.0103,1.27546 0.0898,1.7539 0.0796,0.47898 0.23655,0.89549 0.54688,1.20508 0.31033,0.3096 0.72851,0.46655 1.20703,0.54688 0.47852,0.0803 1.04147,0.0957 1.75195,0.0957 h 5.8086 c 0.71048,0 1.27236,-0.0153 1.75,-0.0957 0.47763,-0.0804 0.89584,-0.23713 1.20508,-0.54688 0.30921,-0.30975 0.46469,-0.72681 0.54492,-1.20508 0.0802,-0.47826 0.0957,-1.04201 0.0957,-1.7539 V 244 240.10156 c 0,-0.71189 -0.0155,-1.27564 -0.0957,-1.7539 -0.0802,-0.47827 -0.2357,-0.89533 -0.54492,-1.20508 -0.30924,-0.30975 -0.72745,-0.4665 -1.20508,-0.54688 -0.47764,-0.0804 -1.03952,-0.0957 -1.75,-0.0957 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         transform="translate(4.9980746e-4)"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983-6)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99158418;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 342.28662,133.49219 c -0.0504,0 -0.10067,0.005 -0.15039,0.0117 -0.63831,0.19051 -0.85538,1.0957 -0.36328,1.52148 l 5.09961,4.77344 c 0.53367,0.47395 1.59687,0.0693 1.625,-0.61914 v -1.34571 c 0.0228,-4.16669 0.23241,-4.24454 -3.79688,-4.33007 h -2.26367 c -0.0498,-0.007 -0.10004,-0.0117 -0.15039,-0.0117 z m -12.21289,0.004 c -2.78209,0 -4.43425,0.14534 -5.38672,1.00391 -0.19416,0.175 -0.35249,0.38793 -0.49219,0.62695 -0.0316,0.054 -0.0686,0.10247 -0.0976,0.16016 -0.0785,0.156 -0.14802,0.3261 -0.20899,0.50977 -0.0611,0.18405 -0.11501,0.38162 -0.16015,0.5957 -0.0452,0.21409 -0.0824,0.44315 -0.11329,0.68945 -0.0617,0.49261 -0.0965,1.05274 -0.11132,1.6875 -0.007,0.31739 -0.01,0.65353 -0.008,1.00977 V 148 v 8.2207 c -0.002,0.35623 3.5e-4,0.69239 0.008,1.00977 0.0148,0.63477 0.0495,1.19491 0.11132,1.6875 0.0309,0.24631 0.0682,0.47537 0.11329,0.68945 0.0903,0.42816 0.21168,0.79292 0.36914,1.10547 0.15746,0.31252 0.35171,0.57249 0.58984,0.78711 0.11906,0.10732 0.24887,0.20291 0.39062,0.28906 0.28319,0.17212 0.61423,0.30534 0.99805,0.40625 0.96081,0.25213 2.25995,0.3086 3.99805,0.3086 h 11.85547 c 0.69054,0 1.31013,-0.0106 1.86719,-0.0371 0.23047,-0.0111 0.44308,-0.0272 0.65234,-0.0449 0.0436,-0.004 0.094,-0.004 0.13672,-0.008 h 0.002 c 0.49424,-0.0467 0.92903,-0.11749 1.31055,-0.21679 0.19111,-0.0498 0.36981,-0.10571 0.53515,-0.17188 0.16536,-0.0661 0.31771,-0.14178 0.45899,-0.22656 0.14129,-0.0848 0.2717,-0.17962 0.39062,-0.28516 0.10532,-0.0934 0.20005,-0.19727 0.28907,-0.30859 0.0115,-0.0144 0.0259,-0.0264 0.0371,-0.041 6.7e-4,-0.001 9.5e-4,-0.003 0.002,-0.004 0.0971,-0.12749 0.18514,-0.26586 0.26367,-0.41797 0.0792,-0.15352 0.14897,-0.32121 0.21094,-0.50196 0.062,-0.18077 0.11573,-0.37576 0.16211,-0.58593 0.0464,-0.21016 0.0847,-0.43601 0.11718,-0.67774 0.0289,-0.21541 0.0511,-0.44929 0.0703,-0.6914 0.002,-0.0292 0.008,-0.0543 0.01,-0.084 2.9e-4,-0.004 -2.9e-4,-0.008 0,-0.0117 0.0399,-0.54795 0.0568,-1.16365 0.0586,-1.85742 v -11.18578 c -0.006,-1.26044 -1.16032,-2.32513 -2.09571,-3.1289 l -0.008,-0.006 -6.72986,-6.49196 c -1.51744,-1.36767 -2.56676,-2.02344 -4.64258,-2.02344 z"
-         id="path964-1-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccccccccccccccccsscccccccccccccccccccccccss" />
-      <path
-         style="opacity:0.3;fill:url(#linearGradient4316);fill-opacity:1;stroke:none;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 343.16802,134.07487 c -0.99147,0.035 -1.02734,0.0465 -1.02734,0.33594 0,0.10178 0.15173,0.31016 0.45898,0.64648 h 2.87891 c 0.15931,0 0.30929,0.0306 0.45312,0.0762 0.32342,0.02 0.64497,0.0487 0.96485,0.10352 0.0264,0.32124 0.0306,0.64828 0.0371,0.97461 0.0263,0.11154 0.0449,0.2259 0.0449,0.3457 v 2.61719 c 0.25501,0.21272 0.45277,0.36813 0.49023,0.36914 0.45172,0.0121 0.5059,-0.28833 0.46289,-2.54883 -0.0534,-2.80528 0.043,-2.67754 -2.15624,-2.83984 -0.86922,-0.0642 -2.04216,-0.1 -2.60743,-0.0801 z m -10.83984,0.0371 c -5.16676,0.002 -5.89229,0.0632 -6.90234,0.57617 -0.60351,0.30649 -1.03843,1.06517 -1.2461,2.17187 -0.24355,1.30043 -0.239,21.42491 0.006,22.5 0.4115,1.80781 1.06039,2.3312 3.18555,2.56446 0.49142,0.054 4.63516,0.0862 9.20703,0.0723 7.44102,-0.0226 8.39113,-0.0477 9.0625,-0.24023 1.20765,-0.3464 1.67604,-0.80148 2.02539,-1.96289 0.17841,-0.59326 0.21211,-1.68489 0.25391,-8.28321 0.0479,-7.5564 0.0468,-6.60393 -0.21875,-7.15257 -0.0736,-0.15205 -0.33859,-0.46265 -0.72266,-0.875 v 4.07422 c 0,0.12416 -0.0206,0.24218 -0.0488,0.35742 0.0246,3.83198 -0.0428,6.67596 -0.12305,10.47289 0.094,0.98908 -0.26416,2.20979 -1.37304,2.42969 -4.17852,0.21246 -8.39772,0.16055 -12.60547,0.18945 -2.09316,-0.0712 -4.2187,0.13385 -6.29102,-0.20117 -1.20786,-0.09 -1.37139,-1.432 -1.46679,-2.37696 -0.1751,-6.57883 -0.13104,-13.28191 -0.041,-19.88867 0.0853,-1.09208 -0.0376,-2.65795 1.18164,-3.16406 2.366,-0.42229 4.785,-0.2218 7.17578,-0.3125 0.61114,0.0344 0.29054,0.0147 0.94202,0.0117 0.059,-0.007 0.11677,-0.0176 0.17773,-0.0176 h 3.5918 c -0.42688,-0.30915 -0.78914,-0.52782 -1.16797,-0.68359 -0.60974,-0.25114 0.12581,-0.26372 -4.60217,-0.26172 z"
-         id="path4296"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cscscccscccccccccccccccccsccccccccccscccc" />
+         d="m 325.84964,241.65346 h 4.34042 v 4.82263 h -4.34042 z"
+         fill="url(#c)"
+         id="path560"
+         style="display:inline;enable-background:new;fill:url(#linearGradient562);stroke-width:0.300832" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/libreoffice-math.svg
+++ b/icons/src/fullcolor/default/apps/libreoffice-math.svg
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="libreoffice-math.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
      id="base"
-     pagecolor="#8d8d8d"
+     pagecolor="#ffffff"
      bordercolor="#000000"
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.0000001"
-     inkscape:cx="186.21218"
-     inkscape:cy="161.95295"
+     inkscape:zoom="2"
+     inkscape:cx="301.5"
+     inkscape:cy="151.5"
      inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -50,7 +50,7 @@
      gridtolerance="10000"
      inkscape:object-nodes="true"
      inkscape:snap-grids="true"
-     showguides="false"
+     showguides="true"
      inkscape:guide-bbox="true"
      inkscape:window-maximized="1"
      inkscape:bbox-paths="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,485 +93,131 @@
   <defs
      id="defs3">
     <linearGradient
-       id="linearGradient4847">
+       id="c"
+       x2="1"
+       gradientTransform="matrix(0,-95.402258,95.402258,0,1631.3042,210.24074)"
+       gradientUnits="userSpaceOnUse">
       <stop
+         stop-color="#f6fbff"
          offset="0"
-         style="stop-color:#626262;stop-opacity:1"
-         id="stop4843" />
+         id="stop12" />
       <stop
+         stop-color="#eaeff2"
          offset="1"
-         style="stop-color:#4c4c4c;stop-opacity:1"
-         id="stop4845" />
+         id="stop14" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="b"
+       x2="1"
+       gradientTransform="matrix(0,-203.23056,203.23056,0,561.91613,254.13381)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#ec2e5b"
          offset="0"
-         id="stop923" />
+         id="stop7" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#f46587"
          offset="1"
-         id="stop925" />
+         id="stop9" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-5">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient3194"
-       x1="335.73108"
-       y1="62"
-       x2="352.26993"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="169.66859"
-       x2="4.4137931"
-       y1="386.30838"
-       x1="494.34482"
-       id="linearGradient4226-1"
-       xlink:href="#linearGradient4338"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.96286,268)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6646"
-       x="-0.01363613"
-       width="1.0272723"
-       y="-0.01071443"
-       height="1.0214289">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.0000135"
-         id="feGaussianBlur6648" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6668"
-       x="-0.054544518"
-       width="1.109089"
-       y="-0.042857721"
-       height="1.0857154">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.000054"
-         id="feGaussianBlur6670" />
-    </filter>
-    <linearGradient
-       id="linearGradient10292">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(-0.00528208,-207.68288,207.68288,-0.00528208,235.6135,259.06168)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         id="stop10294"
-         style="stop-color:#666666;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop10296"
-         style="stop-color:#333333;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4338">
-      <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
+         stop-color="#b7b4b4"
          offset="0"
-         id="stop4340" />
+         id="stop2" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:1"
+         stop-color="#f1f1f1"
          offset="1"
-         id="stop4342" />
+         id="stop4" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4847"
-       id="linearGradient18935"
-       x1="352.77151"
-       y1="106.5"
-       x2="335.23242"
-       y2="61.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983-6">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985-0"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971-6">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1311"
-       x1="327.99951"
-       y1="188"
-       x2="335.99951"
-       y2="212"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1309"
-       x1="332"
-       y1="236"
-       x2="324"
-       y2="252"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4847"
-       id="linearGradient916"
+       xlink:href="#c"
+       id="linearGradient530"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05664062,-0.05663901,0,349.74506,214)"
-       x1="44.137936"
-       y1="240.29004"
-       x2="450.20694"
-       y2="386.29437" />
+       gradientTransform="matrix(0,-19.591535,19.591535,0,647.78567,95.138723)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4847"
-       id="linearGradient920"
+       xlink:href="#b"
+       id="linearGradient532"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.03604403,-0.03604301,0,339.56482,252.90909)"
-       x1="39.093575"
-       y1="240.26906"
-       x2="455.25125"
-       y2="401.58029" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4847"
-       id="linearGradient18935-0"
-       x1="352.89749"
-       y1="106.50614"
-       x2="334.86411"
-       y2="61.500103"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="matrix(0,-41.734847,41.734847,0,428.1792,104.15248)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient4316"
-       x1="372"
-       y1="134"
-       x2="372"
-       y2="162"
+       xlink:href="#a"
+       id="linearGradient534"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-37.000489)" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient18935-0-8"
-       x1="336.64893"
-       y1="59.040947"
-       x2="348.54202"
-       y2="108.83411"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient15606-6">
-      <stop
-         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.588235;"
-         offset="0"
-         id="stop15608-8" />
-      <stop
-         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.862745;"
-         offset="1"
-         id="stop15610-7" />
-    </linearGradient>
+       gradientTransform="matrix(-0.00108471,-42.649162,42.649162,-0.00108471,361.17063,105.16445)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient15606-6"
-       id="linearGradient1921"
+       xlink:href="#c"
+       id="linearGradient544"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-3288,966.63783)"
-       x1="3618.4375"
-       y1="-758.63782"
-       x2="3618.4375"
-       y2="-772.63782" />
+       gradientTransform="matrix(0,-12.777088,12.777088,0,534.12111,155.26439)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient1974"
+       xlink:href="#b"
+       id="linearGradient546"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(138.00131,-823.86221)"
-       x1="195.75"
-       y1="1016.2372"
-       x2="195.75"
-       y2="1032.2383" />
+       gradientTransform="matrix(0,-27.218379,27.218379,0,390.8995,161.14292)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient1976"
+       xlink:href="#a"
+       id="linearGradient548"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(136.5012,-824.3621)"
-       x1="195.75"
-       y1="1016.2372"
-       x2="195.75"
-       y2="1032.2383" />
+       gradientTransform="matrix(-7.0741957e-4,-27.814671,27.814671,-7.0741957e-4,347.19826,161.8029)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient1978"
+       xlink:href="#c"
+       id="linearGradient558"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,532.50131,-823.86221)"
-       x1="195.75"
-       y1="1016.2372"
-       x2="195.75"
-       y2="1032.2383" />
+       gradientTransform="matrix(0,-9.3698653,9.3698653,0,477.28881,205.32722)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient1882"
+       xlink:href="#b"
+       id="linearGradient560"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(132.5012,-780.3621)"
-       x1="195.75"
-       y1="1016.2372"
-       x2="195.75"
-       y2="1032.2383" />
+       gradientTransform="matrix(0,-19.960146,19.960146,0,372.25962,209.63814)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient54827"
+       xlink:href="#a"
+       id="linearGradient562"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,527.0012,-780.3621)"
-       x1="195.75"
-       y1="1016.2372"
-       x2="195.75"
-       y2="1032.2383" />
+       gradientTransform="matrix(-5.1877439e-4,-20.397427,20.397427,-5.1877439e-4,340.21204,210.12213)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient54830"
+       xlink:href="#c"
+       id="linearGradient572"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(132.5012,-780.36181)"
-       x1="195.75"
-       y1="1016.2372"
-       x2="195.75"
-       y2="1032.2383" />
+       gradientTransform="matrix(0,-5.9626426,5.9626426,0,420.45652,247.39005)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient15606-6"
-       id="linearGradient54821"
+       xlink:href="#b"
+       id="linearGradient574"
        gradientUnits="userSpaceOnUse"
-       x1="3618.4375"
-       y1="-758.63782"
-       x2="3618.4375"
-       y2="-772.63782"
-       gradientTransform="translate(-0.00120978,9.9e-6)" />
+       gradientTransform="matrix(0,-12.701913,12.701913,0,353.61975,250.13337)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient8365"
+       xlink:href="#a"
+       id="linearGradient576"
        gradientUnits="userSpaceOnUse"
-       x1="3716.1616"
-       y1="683.97705"
-       x2="3716.1616"
-       y2="705.13123" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient8363"
-       gradientUnits="userSpaceOnUse"
-       x1="3716.1616"
-       y1="685.14032"
-       x2="3716.1616"
-       y2="706.41693" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient54812"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(3427.4996,-1790.9996)"
-       x1="195.75"
-       y1="1006.3704"
-       x2="195.75"
-       y2="1038.3638" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient54809"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,3822.4996,-1791.4996)"
-       x1="195.75"
-       y1="1006.8059"
-       x2="195.75"
-       y2="1038.8622" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient15606-6"
-       id="linearGradient54806"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5,0,0,1.57143,-1803,336.508)"
-       x1="3618.4375"
-       y1="-758.63782"
-       x2="3618.4375"
-       y2="-772.63782" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient54797"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(3435.5,-1891.5)"
-       x1="195.75"
-       y1="1016.2372"
-       x2="195.75"
-       y2="1032.2383" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient54794"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,3830.5,-1892)"
-       x1="195.75"
-       y1="1016.2372"
-       x2="195.75"
-       y2="1032.2383" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient3006"
-       gradientUnits="userSpaceOnUse"
-       x1="3716.1616"
-       y1="683.97705"
-       x2="3716.1616"
-       y2="705.13123" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient3008"
-       gradientUnits="userSpaceOnUse"
-       x1="3716.1616"
-       y1="683.97705"
-       x2="3716.1616"
-       y2="705.13123" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient3008-6"
-       gradientUnits="userSpaceOnUse"
-       x1="3716.1616"
-       y1="683.97705"
-       x2="3716.1616"
-       y2="705.13123" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient15606-6"
-       id="linearGradient3132"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5,0,0,1.57143,-1803,336.508)"
-       x1="3618.4375"
-       y1="-758.63782"
-       x2="3618.4375"
-       y2="-772.63782" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient3134"
-       gradientUnits="userSpaceOnUse"
-       x1="3716.1616"
-       y1="683.97705"
-       x2="3716.1616"
-       y2="705.13123" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient3136"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(3435.5,-1891.5)"
-       x1="195.75"
-       y1="1016.2372"
-       x2="195.75"
-       y2="1032.2383" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient10292"
-       id="linearGradient3138"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,3830.5,-1892)"
-       x1="195.75"
-       y1="1016.2372"
-       x2="195.75"
-       y2="1032.2383" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3976"
-       id="linearGradient18820-3"
-       x1="201.07812"
-       y1="269.99988"
-       x2="102.92188"
-       y2="45.999878"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3976">
-      <stop
-         offset="0"
-         style="stop-color:#626262;stop-opacity:1"
-         id="stop3972" />
-      <stop
-         offset="1"
-         style="stop-color:#4e4e4e;stop-opacity:1"
-         id="stop3974" />
-    </linearGradient>
+       gradientTransform="matrix(-3.3012922e-4,-12.980183,12.980183,-3.3012922e-4,333.22583,250.44136)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -670,7 +317,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">libreoffice-math</tspan></text>
+           id="tspan924">libreoffice-math</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -705,512 +352,129 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99158418;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 342.28786,133.99591 c -0.0832,0 -0.1556,0.007 -0.2168,0.0156 l -0.0371,0.006 -0.0371,0.0117 c -1.02052,0.30458 -1.3544,1.66824 -0.54687,2.36914 0,0 0,0.002 0,0.002 l 5.08984,4.76563 0.006,0.004 c 0.44144,0.39204 1.03582,0.39851 1.50781,0.21874 0.47199,-0.17975 0.9171,-0.5946 0.94141,-1.18945 v -0.01 -1.35352 -0.002 c 0.006,-1.0363 0.0251,-1.82214 -0.0176,-2.45508 -0.0427,-0.63344 -0.14348,-1.14825 -0.47266,-1.55274 -0.32917,-0.40448 -0.82834,-0.59266 -1.42968,-0.68554 -0.60135,-0.0929 -1.35232,-0.1114 -2.36133,-0.13281 h -0.006 -2.26953 c -0.0478,-0.005 -0.0951,-0.0117 -0.15039,-0.0117 z m -7.25782,0.002 -4.95507,0.002 c -2.79936,0 -4.57517,0.10197 -5.71875,1.13282 -0.24259,0.21892 -0.43083,0.4754 -0.5879,0.74414 -0.0117,0.02 -0.0564,0.0782 -0.11132,0.1875 -0.0907,0.18027 -0.17065,0.37241 -0.23828,0.57617 -0.0671,0.20198 -0.12496,0.41859 -0.17383,0.65039 -0.0486,0.23023 -0.0869,0.47111 -0.11914,0.72851 v 0.002 c -0.0646,0.51578 -0.10015,1.09026 -0.11524,1.73633 -0.007,0.32198 -0.0116,0.66266 -0.01,1.02343 v 8.21875 8.22071 c -0.002,0.3594 0.002,0.69873 0.01,1.02148 0.0151,0.64603 0.0505,1.22236 0.11524,1.73828 0.0323,0.25754 0.0707,0.4986 0.11914,0.72852 0.0971,0.4603 0.23097,0.86702 0.41211,1.22656 0.18147,0.36018 0.41279,0.67544 0.69922,0.93359 0.14342,0.12929 0.30075,0.24284 0.46679,0.34375 0.33271,0.20222 0.70911,0.35057 1.12891,0.46094 v 0.002 c 1.04936,0.27537 2.37421,0.32422 4.12305,0.32422 h 11.85546 c 0.69562,0 1.32241,-0.0101 1.89063,-0.0371 h 0.002 c 0.23885,-0.0115 0.45772,-0.0289 0.66992,-0.0469 h 0.002 0.002 c 0.006,-5.4e-4 0.052,-0.004 0.0898,-0.006 h 0.0137 c 0.0155,-0.001 0.0141,-1.1e-4 0.0332,-0.002 h 0.002 c 0.51385,-0.0486 0.97388,-0.12251 1.38867,-0.23047 0.20576,-0.0536 0.4054,-0.11525 0.59571,-0.19141 0.18901,-0.0755 0.36479,-0.163 0.52929,-0.26172 0.1657,-0.0995 0.3216,-0.21271 0.46485,-0.33984 0.12928,-0.11465 0.24087,-0.23957 0.34179,-0.36524 0,2e-5 0.005,-0.005 0.006,-0.006 l 0.0215,-0.0215 0.0156,-0.0195 0.006,-0.008 0.002,-0.004 0.008,-0.008 0.008,-0.0137 c 4e-5,-7e-5 0.008,-0.016 0.0117,-0.0234 0.003,-0.004 0.009,-0.008 0.0117,-0.0117 -5.4e-4,7e-4 -0.007,0.003 -0.008,0.004 0.01,-0.0181 0.0172,-0.0306 0.0254,-0.0469 -0.006,0.0128 -0.01,0.0233 -0.0117,0.0273 0.095,-0.13149 0.18742,-0.26844 0.26562,-0.41992 0.0922,-0.17881 0.17175,-0.3686 0.24024,-0.56836 0.069,-0.20111 0.12594,-0.41283 0.17578,-0.63867 0.0501,-0.22709 0.0911,-0.46643 0.125,-0.71875 0.0307,-0.22912 0.0546,-0.4717 0.0742,-0.71875 l 0.002,-0.002 v -0.004 c -10e-4,0.0185 0.005,-0.009 0.01,-0.082 v -0.002 c 0.002,-0.0307 0.004,-0.0623 0,-0.006 v -0.002 -0.002 c 0.0411,-0.56466 0.0568,-1.18956 0.0586,-1.89062 v -0.004 -11.1875 c -0.007,-1.5618 -1.32097,-2.69049 -2.26758,-3.50391 l -0.01,-0.008 -0.002,-0.002 -6.71093,-6.47461 -0.008,-0.006 c -1.54333,-1.391 -2.79437,-2.15039 -4.97461,-2.15039 z"
-         id="path964-1-7-1"
-         inkscape:connector-curvature="0" />
+         d="m 247.78973,259.06168 -58.16888,-0.0674 V 51.545338 l 59.83429,-0.2166 c 10.39675,0.12515 15.59513,8.22114 15.59513,17.94885 V 240.27532 c 0.45245,10.68074 -6.60387,18.55532 -17.26054,18.78636 z"
+         fill="url(#a)"
+         id="path17"
+         style="fill:url(#a);stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.13511628;marker:none;enable-background:accumulate"
-         d="m 335.08789,134.63086 c -0.17031,0.006 -0.34104,0.0223 -0.51367,0.0488 -1.34136,4.6e-4 -2.68403,-5e-5 -4.02539,0.002 -1.72214,0.12816 -3.48931,-0.23506 -5.09961,0.50391 -1.08921,1.01332 -0.6417,2.68549 -0.81445,3.97461 -0.0758,6.75555 0.0246,13.51181 0.0332,20.26757 0.3529,1.23223 1.50347,2.06307 2.78906,1.86719 5.96413,0.10826 11.92988,0.0258 17.89453,0.0234 1.28166,-0.35155 2.12004,-1.63874 1.89844,-2.95117 -0.0487,-4.57837 0.24454,-9.17777 -0.0684,-13.74414 -2.74191,-3.11361 -5.86019,-5.9686 -8.91406,-8.73243 -0.86559,-0.85919 -1.98753,-1.30437 -3.17969,-1.25976 z"
-         id="rect4158-92-6-7-3"
-         inkscape:connector-curvature="0" />
+         d="m 155.74957,51.579038 79.47742,-7.45101 c 10.6326,-1.07337 15.27745,4.6304 15.35927,16.06202 L 249.9124,248.15471 c -0.19253,12.71678 -5.88187,19.3784 -17.09688,19.84529 l -76.54611,-8.93832 H 74.520105 c -10.44007,0 -21.048609,-8.50031 -21.106369,-21.74655 V 72.589138 c 0.399499,-15.23894 6.753079,-20.98122 21.992019,-21.2604 z"
+         fill="url(#b)"
+         id="path19"
+         style="fill:url(#b);stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.13511628;marker:none;enable-background:accumulate"
-         d="m 342.43453,133.5 c -0.0499,0 -0.0992,0.005 -0.14846,0.0114 -0.63275,0.19268 -0.84778,1.10823 -0.35998,1.53887 l 5.15449,4.82872 c 0.52901,0.47937 1.38249,0.0699 1.41036,-0.62634 v -1.36063 c 0.0226,-4.21424 0.33006,-4.29412 -3.66401,-4.38062 h -2.24263 c -0.0493,-0.007 -0.0999,-0.0114 -0.14977,-0.0114 z m -12.63559,0.0804 c -5.53701,-3.3e-4 -6.32794,0.58227 -6.29884,6.26467 v 8.19515 8.19514 c -0.0291,5.68242 1.00827,6.26467 6.54528,6.26467 h 11.7978 c 5.49726,0 6.52858,-0.57993 6.54266,-6.15295 v -11.14923 c -0.006,-1.25658 -1.15546,-2.31787 -2.08629,-3.11916 l -0.008,-0.006 -6.70166,-6.47491 c -1.50985,-1.36345 -2.55339,-2.01695 -4.61908,-2.01707 z m 7.22852,2.4196 8.97205,8.99977 V 158 c 0,0 -0.11213,1.17819 -0.44846,1.49951 -0.33633,0.32134 -1.56951,0.42847 -1.56951,0.42847 h -15.96407 c 0,0 -1.23318,-0.10713 -1.56951,-0.42847 C 326.11164,159.17819 325.99951,158 325.99951,158 l -0.018,-20.07203 c 0,0 0.11213,-1.17819 0.44845,-1.49951 C 326.76633,136.10713 327.99951,136 327.99951,136 Z"
-         id="rect4158-92-6-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 249.9124,248.15471 c -0.19253,12.71678 -5.88187,19.3784 -17.09688,19.84529 l -77.41251,-9.0394 V 51.612728 l 79.82398,-7.4847 c 10.6326,-1.07337 15.27745,4.6304 15.35927,16.06202 z"
+         fill-opacity="0.15"
+         id="path21"
+         style="stroke-width:4.81331" />
       <path
-         style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 323.49951,148 v 0.041 8.19531 c -0.0291,5.68242 1.00791,6.26367 6.54492,6.26367 h 11.79883 c 5.49726,0 6.52889,-0.57932 6.54297,-6.15234 V 148 Z"
-         id="rect4398"
-         inkscape:connector-curvature="0" />
+         d="m 363.6711,105.16445 -11.9454,-0.0138 V 62.54949 l 12.2874,-0.04448 c 2.13505,0.0257 3.20257,1.688269 3.20257,3.685924 v 35.115606 c 0.0929,2.19337 -1.35615,3.81047 -3.54457,3.85791 z"
+         fill="url(#a)"
+         id="path522"
+         style="fill:url(#linearGradient534);stroke-width:0.988448" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 353.50267,61.372909 c -0.13268,1.31e-4 -0.25604,0.01264 -0.36719,0.0293 l -0.0781,0.01172 -0.0762,0.02344 c -0.87574,0.279121 -1.39412,1.031903 -1.56445,1.792968 -0.1518,0.678132 0.0116,1.444638 0.51367,2.050782 l -0.36328,-0.363282 -0.01,-0.0078 -0.002,-0.0039 c 0,0 -0.002,0.0038 -0.002,0.0039 -0.28283,-0.2673 -0.55686,-0.524524 -0.83398,-0.767578 h -0.002 l -0.002,-0.0039 -0.002,-0.002 c 0,0 -0.006,-0.0019 -0.006,-0.002 -0.2711,-0.237536 -0.5406,-0.460957 -0.81055,-0.669922 0,0 -0.006,-0.0038 -0.006,-0.0039 -1.8e-4,-8.7e-5 -0.006,-0.0038 -0.006,-0.0039 -0.26922,-0.208011 -0.54257,-0.405967 -0.82617,-0.587891 h -0.002 l -0.002,-0.002 c 0,1e-6 -0.004,-0.0019 -0.004,-0.002 -0.27684,-0.177258 -0.55998,-0.341168 -0.85742,-0.488281 1e-5,0 -0.006,-0.0019 -0.006,-0.002 -0.29595,-0.146081 -0.60404,-0.275888 -0.92383,-0.386719 l -0.004,-0.002 h -0.002 -0.002 c -0.31787,-0.109783 -0.64897,-0.202793 -0.99414,-0.275391 0,-10e-7 -0.009,7.3e-5 -0.01,0 -0.34183,-0.07151 -0.69666,-0.126987 -1.07031,-0.162109 h -0.002 c -0.37669,-0.03533 -0.76878,-0.05072 -1.17774,-0.05078 h -0.002 -8.26738 c -4.1516,0 -6.86541,0.144562 -8.65234,1.832031 -0.89392,0.844181 -1.42053,2.015243 -1.71289,3.464843 -0.29235,1.449602 -0.3762,2.716457 -0.36524,4.956881 V 84.497515 97.24947 c -0.0108,2.23702 0.0732,4.00312 0.36524,5.45117 0.29236,1.44961 0.81896,2.62067 1.71289,3.46485 0.22046,0.20818 0.46372,0.3989 0.72656,0.5664 l 0.004,0.002 0.006,0.004 c 0,0 0.011,0.004 0.0117,0.004 0.24938,0.15738 0.51414,0.29744 0.79688,0.41797 l 0.006,0.002 c 10e-4,5.8e-4 0.003,0.003 0.004,0.004 h 0.002 c 0.001,2.9e-4 0.01,0.003 0.0117,0.004 0.28562,0.12045 0.58739,0.22665 0.90625,0.31446 h 0.002 0.002 c 0.31721,0.0872 0.65158,0.16192 1.00586,0.22265 h 0.004 0.002 0.002 c 0.35215,0.0602 0.71743,0.1063 1.10157,0.14453 2e-5,0 0.005,-1e-5 0.006,0 0.38435,0.0381 0.78775,0.0683 1.21289,0.0899 h 0.004 0.002 c 4.7e-4,1e-5 0.005,-1e-5 0.006,0 l 0.004,0.002 c 3.5e-4,1e-5 0.0746,-7e-5 0.0723,0 0.83602,0.0405 1.74479,0.0566 2.7539,0.0566 h 0.002 17.03691 c 4.12301,0 6.31689,-0.14165 8.10202,-1.80263 0.89298,-0.83017 1.42413,-1.9843 1.72461,-3.41016 0.30048,-1.42587 0.39703,-3.161323 0.40234,-5.359373 v -18.908211 -0.002 c -0.009,-1.901937 -1.18883,-3.38937 -2.32226,-4.541016 -0.37676,-0.382884 -0.75737,-0.733609 -1.10938,-1.050781 l -0.28515,-0.257813 h 0.0273 l -0.0117,-0.01172 h -0.002 l -0.0508,-0.05078 c 0.7203,0.562642 1.63962,0.613597 2.36523,0.31836 0.78035,-0.317514 1.50219,-1.045367 1.54102,-2.060547 v -0.01953 -1.630708 -0.0059 c 0.008,-1.627914 0.0362,-2.86715 -0.0274,-3.875 -0.0638,-1.009375 -0.2058,-1.850441 -0.73633,-2.546875 -0.53053,-0.696434 -1.36221,-1.029214 -2.28515,-1.181641 -0.92293,-0.152428 -2.03533,-0.179157 -3.52344,-0.212891 h -0.0117 l -2.84421,-9.7e-5 h -0.002 c -0.073,-0.0069 -0.14393,-0.0174 -0.2207,-0.01758 z m -24.57206,43.876801 c 7.7e-4,4.2e-4 10e-4,0.002 0.002,0.002 -0.0334,0.003 -0.0689,0.006 -0.0684,0.006 5.2e-4,-8e-5 0.0335,-0.004 0.0664,-0.008 z m -0.0312,1.98438 c 0.005,2.6e-4 0.0335,0.004 0.0645,0.006 -0.0263,-10e-4 -0.0586,-0.004 -0.0586,-0.004 z"
-         id="path964-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccscccccccccccccccccccccccccccccccscsccccccccccccccccccsccccccccccccccc" />
+         d="m 344.76999,62.55641 16.32126,-1.530118 c 2.18348,-0.220424 3.13733,0.950886 3.15414,3.298451 L 364.107,102.92463 c -0.0395,2.61148 -1.20788,3.97949 -3.51096,4.07537 l -15.71929,-1.83555 h -16.78781 c -2.14394,0 -4.32248,-1.7456 -4.33434,-4.46581 V 66.870985 c 0.082,-3.129426 1.38679,-4.308644 4.51622,-4.365975 z"
+         fill="url(#b)"
+         id="path524"
+         style="fill:url(#linearGradient532);stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6668);enable-background:accumulate"
-         d="M 102.92188 46 C 67.62515 46 64 49.625611 64 84.994141 L 64 156 L 64 158 L 64 229.00586 C 64 244.47959 64.693319 253.87799 68.429688 259.55469 C 68.963453 260.36564 69.559812 261.0997 70.224609 261.76562 C 75.542989 267.0931 85.27351 268 102.92188 268 L 201.07812 268 C 203.13276 268 205.06552 267.98518 206.91211 267.95508 C 207.57101 267.94428 208.1733 267.9199 208.80664 267.9043 C 209.95599 267.876 211.09853 267.8452 212.16602 267.79883 C 213.43596 267.74363 214.67536 267.67931 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.44517 267.45882 217.67424 267.44102 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67577 267.09975 221.31832 267.00362 221.94336 266.90039 C 222.16533 266.86369 222.37512 266.82019 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.01019 266.50659 224.24912 266.45017 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.69251 266.09626 225.94528 266.02572 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.98625 265.36467 228.26277 265.25859 228.53516 265.14844 C 228.73131 265.06914 228.92945 264.98988 229.11914 264.90625 C 229.3939 264.78514 229.6565 264.65577 229.91797 264.52539 C 230.0924 264.43839 230.27277 264.35491 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.02943 263.29518 232.41788 263.01413 232.78711 262.71484 C 233.12677 262.43952 233.44633 262.14559 233.75586 261.8418 C 233.83036 261.7687 233.90178 261.69201 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01257 256.99161 237.07571 256.85555 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.81286 254.90311 237.95901 254.4144 238.09961 253.91406 C 238.14041 253.7689 238.17961 253.62078 238.21875 253.47266 C 238.28325 253.22887 238.34214 252.97259 238.40234 252.7207 C 238.54618 252.11901 238.67815 251.49292 238.79883 250.84375 C 238.83073 250.67198 238.86618 250.50525 238.89648 250.33008 C 239.03717 249.51898 239.16395 248.67505 239.27344 247.78906 C 239.29544 247.61129 239.31328 247.41914 239.33398 247.23828 C 239.41648 246.52006 239.48974 245.77779 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78859 241.4566 239.80646 241.21235 239.81836 240.95312 C 239.82536 240.80563 239.82738 240.64128 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96989 235.43296 239.97567 235.00563 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 128.24023 C 239.956 118.50733 231.82093 110.28461 225.23828 104.07812 L 225.18945 104.02734 L 184.66602 61.619141 C 173.98913 51.057981 166.6082 46 152 46 L 102.92188 46 z M 199.9043 46.089844 C 197.73512 48.865721 197.51891 53.493389 200.11328 56.001953 L 228.60938 86.388672 C 232.33314 90.084594 239.72783 86.956935 239.99023 81.609375 C 239.9886 81.189355 239.99156 80.748144 239.98828 80.337891 C 239.98738 79.846541 239.97958 79.384529 239.97656 78.90625 C 239.61491 51.652251 235.0161 46.715732 208.63086 46.089844 L 199.9043 46.089844 z "
-         id="path5316-1" />
+         d="m 364.10701,102.92463 c -0.0395,2.61148 -1.20788,3.97949 -3.51097,4.07537 l -15.8972,-1.8563 V 62.563329 l 16.39242,-1.537037 c 2.18348,-0.220424 3.13733,0.950886 3.15414,3.298452 z"
+         fill-opacity="0.15"
+         id="path526"
+         style="stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6646);enable-background:accumulate"
-         d="M 102.92188 45 C 67.62515 45 64 48.625611 64 83.994141 L 64 156 L 64 157 L 64 229.00586 C 64 244.47959 64.693319 253.87799 68.429688 259.55469 C 68.963453 260.36564 69.559812 261.0997 70.224609 261.76562 C 75.542989 267.0931 85.27351 268 102.92188 268 L 201.07812 268 C 203.13276 268 205.06552 267.98518 206.91211 267.95508 C 207.57101 267.94428 208.1733 267.9199 208.80664 267.9043 C 209.95599 267.876 211.09853 267.8452 212.16602 267.79883 C 213.43596 267.74363 214.67536 267.67931 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.44517 267.45882 217.67424 267.44102 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67577 267.09975 221.31832 267.00362 221.94336 266.90039 C 222.16533 266.86369 222.37512 266.82019 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.01019 266.50659 224.24912 266.45017 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.69251 266.09626 225.94528 266.02572 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.98625 265.36467 228.26277 265.25859 228.53516 265.14844 C 228.73131 265.06914 228.92945 264.98988 229.11914 264.90625 C 229.3939 264.78514 229.6565 264.65577 229.91797 264.52539 C 230.0924 264.43839 230.27277 264.35491 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.02943 263.29518 232.41788 263.01413 232.78711 262.71484 C 233.12677 262.43952 233.44633 262.14559 233.75586 261.8418 C 233.83036 261.7687 233.90178 261.69201 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01257 256.99161 237.07571 256.85555 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.81286 254.90311 237.95901 254.4144 238.09961 253.91406 C 238.14041 253.7689 238.17961 253.62078 238.21875 253.47266 C 238.28325 253.22887 238.34214 252.97259 238.40234 252.7207 C 238.54618 252.11901 238.67815 251.49292 238.79883 250.84375 C 238.83073 250.67198 238.86618 250.50525 238.89648 250.33008 C 239.03717 249.51898 239.16395 248.67505 239.27344 247.78906 C 239.29544 247.61129 239.31328 247.41914 239.33398 247.23828 C 239.41648 246.52006 239.48974 245.77779 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78859 241.4566 239.80646 241.21235 239.81836 240.95312 C 239.82536 240.80563 239.82738 240.64128 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96989 235.43296 239.97567 235.00563 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 127.24023 C 239.956 117.50733 231.82093 109.28462 225.23828 103.07812 L 225.18945 103.02734 L 184.66602 60.619141 C 173.98913 50.057981 166.6082 45 152 45 L 102.92188 45 z M 200.89062 45.089844 C 197.85089 47.592149 197.17007 53.156086 200.11328 56.001953 L 228.60938 86.388672 C 232.33829 90.089704 239.75115 86.948987 239.99414 81.587891 C 239.99392 81.377038 239.99278 81.169387 239.99219 80.960938 C 239.99209 79.762634 239.97942 78.632386 239.9668 77.509766 C 239.56354 50.620533 234.88168 45.712543 208.63086 45.089844 L 200.89062 45.089844 z "
-         id="path5316-84" />
+         d="m 348.829,161.8029 -7.79048,-0.009 v -27.78336 l 8.01352,-0.029 c 1.39243,0.0168 2.08864,1.10104 2.08864,2.40386 v 22.90148 c 0.0606,1.43046 -0.88445,2.48509 -2.31168,2.51603 z"
+         fill="url(#a)"
+         id="path536"
+         style="fill:url(#linearGradient548);stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="M 102.92188 44 C 100.74614 44 98.695529 44.014677 96.753906 44.048828 C 67.272036 44.576673 64.085938 49.836144 64.085938 82.994141 L 64.085938 156 L 64.085938 229.00586 C 64.085938 262.16386 67.272036 267.42333 96.753906 267.95117 C 98.695529 267.98532 100.74614 268 102.92188 268 C 102.95214 268.00001 102.9775 268 103.00781 268 L 201.07812 268 C 203.13276 268 205.06552 267.98518 206.91211 267.95508 C 207.57101 267.94428 208.1733 267.9199 208.80664 267.9043 C 209.95599 267.876 211.09853 267.8452 212.16602 267.79883 C 213.43596 267.74363 214.67536 267.67931 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.44517 267.45882 217.67424 267.44102 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67577 267.09975 221.31832 267.00362 221.94336 266.90039 C 222.16533 266.86369 222.37512 266.82019 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.01019 266.50659 224.24912 266.45017 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.69251 266.09626 225.94528 266.02572 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.98625 265.36467 228.26277 265.25859 228.53516 265.14844 C 228.73131 265.06914 228.92945 264.98988 229.11914 264.90625 C 229.3939 264.78514 229.6565 264.65577 229.91797 264.52539 C 230.0924 264.43839 230.27277 264.35491 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.02943 263.29518 232.41788 263.01413 232.78711 262.71484 C 233.12677 262.43952 233.44633 262.14559 233.75586 261.8418 C 233.83036 261.7687 233.90178 261.69201 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01257 256.99161 237.07571 256.85555 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.81286 254.90311 237.95901 254.4144 238.09961 253.91406 C 238.14041 253.7689 238.17961 253.62078 238.21875 253.47266 C 238.28325 253.22887 238.34214 252.97259 238.40234 252.7207 C 238.54618 252.11901 238.67815 251.49292 238.79883 250.84375 C 238.83073 250.67198 238.86618 250.50525 238.89648 250.33008 C 239.03717 249.51898 239.16395 248.67505 239.27344 247.78906 C 239.29544 247.61129 239.31328 247.41914 239.33398 247.23828 C 239.41648 246.52006 239.48974 245.77779 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78859 241.4566 239.80646 241.21235 239.81836 240.95312 C 239.82536 240.80563 239.82738 240.64128 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96989 235.43296 239.97567 235.00563 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 126.24023 C 239.956 116.50733 231.82093 108.28461 225.23828 102.07812 L 225.18945 102.02734 L 184.66602 59.619141 C 173.98918 49.057981 166.6082 44 152 44 L 102.92188 44 z M 202.6543 44.089844 C 198.17969 45.582244 196.66368 52.666443 200.11328 56.001953 L 228.60938 86.388672 C 232.34293 90.094303 239.77066 86.941636 239.99609 81.568359 C 240.04429 50.239345 236.44281 44.749576 208.63086 44.089844 L 202.6543 44.089844 z "
-         id="path5316-3" />
+         d="m 336.50219,134.01505 10.6443,-0.9979 c 1.42401,-0.14376 2.04608,0.62014 2.05705,2.15116 l -0.0903,25.17384 c -0.0258,1.70314 -0.78774,2.59532 -2.28975,2.65785 l -10.25171,-1.1971 H 325.6232 c -1.39822,0 -2.81901,-1.13843 -2.82674,-2.91248 V 136.8289 c 0.0535,-2.04093 0.90443,-2.80998 2.94536,-2.84737 z"
+         fill="url(#b)"
+         id="path538"
+         style="fill:url(#linearGradient546);stroke-width:0.64464" />
       <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
+         d="m 349.11329,160.34215 c -0.0258,1.70314 -0.78775,2.59532 -2.28976,2.65785 l -10.36774,-1.21063 v -27.76981 l 10.69071,-1.00241 c 1.424,-0.14376 2.04608,0.62014 2.05704,2.15116 z"
+         fill-opacity="0.15"
+         id="path540"
+         style="stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188,44.000001 C 67.62516,44.000001 64,47.625611 64,82.994141 V 156 229.00586 C 64,264.37439 67.62516,268 102.92188,268 h 98.15625 C 236.37486,268 240.17299,264.37398 240,229.00586 V 126.24023 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 C 173.98919,49.057941 166.6082,44.000001 152,44.000001 Z"
-         id="path5316"
-         inkscape:connector-curvature="0" />
+         d="m 341.40792,210.12213 -5.71302,-0.007 v -20.37447 l 5.87658,-0.0213 c 1.02112,0.0123 1.53167,0.80743 1.53167,1.76283 v 16.79442 c 0.0444,1.049 -0.64859,1.8224 -1.69523,1.84509 z"
+         fill="url(#a)"
+         id="path550"
+         style="fill:url(#linearGradient562);stroke-width:0.472736" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
+         d="m 332.36826,189.74437 7.80582,-0.73179 c 1.04427,-0.10543 1.50046,0.45477 1.5085,1.57751 l -0.0662,18.46082 c -0.0189,1.24897 -0.57767,1.90324 -1.67915,1.94909 l -7.51792,-0.87787 h -8.02896 c -1.02535,0 -2.06727,-0.83485 -2.07294,-2.13582 v -16.17845 c 0.0392,-1.49668 0.66325,-2.06065 2.15993,-2.08807 z"
+         fill="url(#b)"
+         id="path552"
+         style="fill:url(#linearGradient560);stroke-width:0.472736" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 336.47266,62.53125 c -2.54605,0.125056 -5.20872,-0.172424 -7.6543,0.734375 -2.06925,0.92116 -2.01809,3.398277 -2.0625,5.275391 -0.12434,10.502012 -0.11238,21.057362 -0.006,31.578124 -0.12334,1.98292 0.63227,4.46788 2.8418,4.9082 2.62679,0.58433 5.46112,0.20883 8.17187,0.34375 6.49357,-0.0369 12.99711,0.17568 19.48438,-0.14257 1.74238,-0.10485 3.51946,-1.14906 3.78515,-3.00391 0.68454,-4.301369 0.39547,-8.69136 0.47657,-13.031251 -0.0649,-3.98446 0.0576,-8.013155 -0.13672,-11.96875 -0.97445,-1.812644 -2.68743,-3.115699 -4.02539,-4.65625 -3.03938,-3.047213 -6.0344,-6.216406 -9.33008,-8.9375 -2.17644,-1.504884 -4.96484,-0.887223 -7.44141,-1.078125 -1.36757,-0.01595 -2.73389,-0.02666 -4.10156,-0.02148 z"
-         id="path964"
-         inkscape:connector-curvature="0" />
+         d="m 341.6164,209.05091 c -0.0189,1.24897 -0.57768,1.90324 -1.67916,1.94909 l -7.60301,-0.88779 v -20.36453 l 7.83986,-0.7351 c 1.04426,-0.10543 1.50046,0.45477 1.50849,1.57751 z"
+         fill-opacity="0.15"
+         id="path554"
+         style="stroke-width:0.472736" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.20550393;marker:none;enable-background:accumulate"
-         d="m 353.5,61.375 c -0.0742,0 -0.1474,0.0066 -0.2207,0.01758 -0.94065,0.29981 -1.26034,1.724451 -0.53516,2.394531 l 7.51367,7.513672 c 0.78643,0.74591 2.35309,0.108771 2.39453,-0.974609 v -2.117188 c 0.0336,-6.55752 0.34204,-6.681806 -5.5957,-6.816406 h -3.33398 C 353.64936,61.381278 353.57418,61.375 353.5,61.375 Z M 335.23047,61.5 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 V 84 96.751953 c -0.0433,8.842037 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70563,-0.9024 9.72656,-9.574219 V 78.021484 c -0.009,-1.95527 -1.71775,-3.606675 -3.10156,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 C 348.62066,62.51706 347.069,61.5 343.99805,61.5 Z M 346.5,65 359,77.5 V 100 c 0,0 -0.1667,1.8333 -0.6667,2.3333 C 357.8333,102.8333 356,103 356,103 h -24 c 0,0 -1.8333,-0.1667 -2.3333,-0.6667 C 329.1667,101.8333 329,100 329,100 V 68 c 0,0 0.1667,-1.8333 0.6667,-2.3333 C 330.1667,65.1667 332,65 332,65 Z"
-         id="rect4158-92-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 333.98685,250.44136 -3.63556,-0.004 v -12.96557 l 3.73964,-0.0135 c 0.64981,0.008 0.9747,0.51382 0.9747,1.1218 v 10.68736 c 0.0283,0.66754 -0.41274,1.15971 -1.07878,1.17415 z"
+         fill="url(#a)"
+         id="path564"
+         style="fill:url(#linearGradient576);stroke-width:0.300832" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.90435,236.5 c 0.71048,0 1.27344,0.0154 1.75195,0.0957 0.47851,0.0803 0.89671,0.23728 1.20703,0.54688 0.31032,0.30959 0.46726,0.7261 0.54688,1.20508 0.0796,0.47897 0.0933,1.04352 0.0898,1.75586 V 244 v 3.89844 c 0.003,0.71121 -0.0103,1.27546 -0.0898,1.7539 -0.0796,0.47898 -0.23655,0.89549 -0.54688,1.20508 -0.31033,0.3096 -0.72851,0.46655 -1.20703,0.54688 -0.47852,0.0803 -1.04147,0.0957 -1.75195,0.0957 h -5.8086 c -0.71048,0 -1.27236,-0.0153 -1.75,-0.0957 -0.47763,-0.0804 -0.89584,-0.23713 -1.20508,-0.54688 -0.30921,-0.30975 -0.46469,-0.72681 -0.54492,-1.20508 -0.0802,-0.47826 -0.0957,-1.04201 -0.0957,-1.7539 V 244 240.10156 c 0,-0.71189 0.0155,-1.27564 0.0957,-1.7539 0.0802,-0.47827 0.2357,-0.89533 0.54492,-1.20508 0.30924,-0.30975 0.72745,-0.4665 1.20508,-0.54688 0.47764,-0.0804 1.03952,-0.0957 1.75,-0.0957 z"
-         id="path918"
-         inkscape:connector-curvature="0" />
+         d="m 328.23434,237.47369 4.96734,-0.46568 c 0.66453,-0.0671 0.95484,0.2894 0.95995,1.00387 l -0.0421,11.74779 c -0.012,0.7948 -0.3676,1.21116 -1.06855,1.24033 l -4.78413,-0.55864 h -5.10934 c -0.65249,0 -1.31553,-0.53127 -1.31914,-1.35916 v -10.29538 c 0.0249,-0.95243 0.42207,-1.31132 1.3745,-1.32877 z"
+         fill="url(#b)"
+         id="path566"
+         style="fill:url(#linearGradient574);stroke-width:0.300832" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 336.13453,188.5 c 1.11158,0 1.98683,0.0256 2.70703,0.14648 0.72019,0.1209 1.3105,0.34863 1.74218,0.7793 0.43169,0.43067 0.65954,1.01974 0.7793,1.74024 0.11977,0.72049 0.14217,1.59669 0.13672,2.71093 V 200 v 6.125 c 0.005,1.1131 -0.017,1.989 -0.13672,2.70898 -0.11976,0.72051 -0.3476,1.30957 -0.7793,1.74024 -0.43169,0.43067 -1.02199,0.6584 -1.74218,0.7793 -0.7202,0.12089 -1.59545,0.14648 -2.70703,0.14648 h -8.26954 c -1.11158,0 -1.98637,-0.0255 -2.70507,-0.14648 -0.7187,-0.12095 -1.30623,-0.34848 -1.73633,-0.7793 -0.4301,-0.43083 -0.6566,-1.01849 -0.77735,-1.73828 -0.12074,-0.71979 -0.14648,-1.59713 -0.14648,-2.71094 V 200 193.875 c 0,-1.11381 0.0257,-1.99115 0.14648,-2.71094 0.12075,-0.71979 0.34725,-1.30745 0.77735,-1.73828 0.4301,-0.43082 1.01763,-0.65835 1.73633,-0.7793 0.7187,-0.12094 1.59349,-0.14648 2.70507,-0.14648 z"
-         id="path914"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1309);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0962,238 c -0.6888,0 -1.1839,0.0205 -1.5039,0.0742 -0.30449,0.0511 -0.38369,0.11806 -0.39649,0.13086 -0.0131,0.0131 -0.0746,0.0855 -0.125,0.38867 -0.0529,0.31839 -0.0733,0.81274 -0.0703,1.50195 v 0.004 3.90039 3.90234 0.002 c -0.003,0.68916 0.0176,1.18495 0.0703,1.50195 0.0504,0.30317 0.1119,0.37557 0.125,0.38867 0.0128,0.0128 0.0918,0.0798 0.39649,0.13086 0.32002,0.0537 0.8151,0.0742 1.5039,0.0742 h 5.8086 c 0.68894,0 1.18348,-0.0206 1.50195,-0.0742 0.30433,-0.0512 0.38043,-0.1186 0.39063,-0.1289 0.0112,-0.0112 0.0774,-0.0858 0.1289,-0.39258 0.0536,-0.31974 0.0742,-0.81575 0.0742,-1.50586 V 244 241 l -3,-3 z"
-         id="path1291" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1311);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86573,190 c -1.08855,0 -1.90034,0.0312 -2.45898,0.125 -0.54887,0.0921 -0.79683,0.22878 -0.93164,0.36328 -0.13436,0.13404 -0.26642,0.37645 -0.35742,0.92383 -0.0925,0.55627 -0.12219,1.36674 -0.11719,2.45703 v 0.004 6.12695 6.12891 0.002 c -0.005,1.0898 0.0249,1.9019 0.11719,2.45703 0.091,0.5474 0.22306,0.78979 0.35742,0.92383 0.13484,0.13452 0.38277,0.27118 0.93164,0.36328 0.55862,0.0938 1.37043,0.125 2.45898,0.125 h 8.26954 c 1.08864,0 1.90078,-0.0314 2.45703,-0.125 0.54703,-0.0921 0.78777,-0.227 0.92187,-0.36133 0.13429,-0.13451 0.26913,-0.37646 0.36133,-0.92578 0.0936,-0.55811 0.125,-1.37233 0.125,-2.46303 V 200 197 L 333,190 Z"
-         id="path1293"
-         sodipodi:nodetypes="scccccccccccsscccscccs" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 323.0005,200 v 6.125 c -0.0217,4.42101 0.45314,4.875 4.86523,4.875 h 8.26954 c 4.41209,0 4.86523,-0.45393 4.86523,-4.875 V 200 Z"
-         id="path1007"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 322.0005,244 v 3.89844 C 321.9867,250.71181 322.28851,251 325.0962,251 h 5.8086 c 2.8077,0 3.0957,-0.28815 3.0957,-3.10156 V 244 Z"
-         id="path1016"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 325.50195,84 v 12.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 V 84 Z"
-         id="path964-0"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18820-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188 44 C 90.788624 44 82.396956 44.428807 76.609375 46.427734 C 74.505793 47.154326 72.745865 48.088818 71.275391 49.285156 C 71.274692 49.285724 71.274136 49.286541 71.273438 49.287109 C 70.171193 50.184574 69.229818 51.229668 68.429688 52.445312 C 68.174328 52.833282 67.936671 53.242531 67.708984 53.666016 C 67.651564 53.772798 67.598688 53.886993 67.542969 53.996094 C 67.382444 54.310441 67.226879 54.630866 67.080078 54.964844 C 67.006949 55.131203 66.93897 55.305225 66.869141 55.476562 C 66.748138 55.773462 66.628968 56.074579 66.517578 56.386719 C 66.446853 56.584913 66.379471 56.787726 66.3125 56.992188 C 66.212808 57.29649 66.117028 57.607335 66.025391 57.925781 C 65.965274 58.134707 65.90637 58.345421 65.849609 58.560547 C 65.756412 58.913766 65.668449 59.278191 65.583984 59.648438 C 65.536317 59.857386 65.488342 60.062875 65.443359 60.277344 C 65.362062 60.664875 65.287698 61.068729 65.214844 61.474609 C 65.176853 61.686319 65.133436 61.890634 65.097656 62.107422 C 64.994386 62.732944 64.90026 63.376169 64.814453 64.044922 C 64.814368 64.045582 64.814538 64.046215 64.814453 64.046875 C 64.730212 64.703594 64.654689 65.386182 64.585938 66.085938 C 64.558109 66.36935 64.535208 66.668359 64.509766 66.958984 C 64.471641 67.394278 64.435363 67.831478 64.402344 68.283203 C 64.320685 69.400176 64.258682 70.586022 64.205078 71.806641 C 64.154684 72.953182 64.119332 74.174143 64.089844 75.416016 C 64.07606 75.996757 64.054735 76.540389 64.044922 77.142578 C 64.014642 78.996321 64 80.929692 64 82.994141 L 64 156 L 64 229.00586 C 64 231.07031 64.014642 233.00368 64.044922 234.85742 C 64.054735 235.45961 64.07606 236.00324 64.089844 236.58398 C 64.119332 237.82586 64.154684 239.04682 64.205078 240.19336 C 64.258682 241.41398 64.320685 242.59982 64.402344 243.7168 C 64.435363 244.16852 64.471641 244.60572 64.509766 245.04102 C 64.535208 245.33164 64.558109 245.63065 64.585938 245.91406 C 64.654689 246.61382 64.730212 247.29641 64.814453 247.95312 C 64.814533 247.95375 64.814373 247.95445 64.814453 247.95508 C 64.90026 248.62383 64.994386 249.26706 65.097656 249.89258 C 65.133436 250.10937 65.176853 250.31368 65.214844 250.52539 C 65.287698 250.93127 65.362062 251.33512 65.443359 251.72266 C 65.488342 251.93713 65.536317 252.14261 65.583984 252.35156 C 65.668449 252.72181 65.756412 253.08623 65.849609 253.43945 C 65.90637 253.65458 65.965274 253.86529 66.025391 254.07422 C 66.117028 254.39267 66.212808 254.70351 66.3125 255.00781 C 66.379471 255.21227 66.446853 255.41509 66.517578 255.61328 C 66.628968 255.92542 66.748138 256.22654 66.869141 256.52344 C 66.93897 256.69478 67.006949 256.8688 67.080078 257.03516 C 67.226879 257.36913 67.382444 257.68956 67.542969 258.00391 C 67.598688 258.11301 67.651564 258.2272 67.708984 258.33398 C 67.936671 258.75747 68.174328 259.16672 68.429688 259.55469 C 68.963454 260.36564 69.559812 261.09969 70.224609 261.76562 C 70.557008 262.09859 70.905713 262.4136 71.273438 262.71289 C 71.274154 262.71347 71.274674 262.71426 71.275391 262.71484 C 72.745865 263.91118 74.505793 264.84567 76.609375 265.57227 C 82.396956 267.57119 90.788624 268 102.92188 268 L 201.07812 268 C 203.1354 268 205.06339 267.98528 206.91211 267.95508 C 206.92365 267.95489 206.93381 267.95528 206.94531 267.95508 C 207.59075 267.94401 208.18439 267.91962 208.80664 267.9043 C 209.2637 267.89304 209.69197 267.87615 210.14258 267.86328 C 210.81633 267.8421 211.52187 267.82684 212.16602 267.79883 C 212.17279 267.79853 212.17877 267.79717 212.18555 267.79688 C 213.43824 267.74231 214.66024 267.67979 215.80469 267.5957 C 215.81466 267.59497 215.82402 267.59449 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.23558 267.47754 217.24681 267.47753 217.25781 267.47656 C 217.46816 267.45801 217.685 267.43997 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67616 267.09973 221.31798 267.00366 221.94336 266.90039 C 221.94542 266.90005 221.94716 266.89878 221.94922 266.89844 C 222.16891 266.86195 222.37713 266.81983 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.00025 266.50867 224.22962 266.45386 224.46094 266.40039 C 224.47079 266.39813 224.4804 266.3968 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.68584 266.09801 225.93206 266.0296 226.17578 265.95898 C 226.18242 265.95706 226.18868 265.95505 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.85083 265.41318 227.99309 265.35464 228.13867 265.29883 C 228.27101 265.24829 228.40567 265.20081 228.53516 265.14844 C 228.5463 265.14393 228.55721 265.13927 228.56836 265.13477 C 228.75355 265.05996 228.94022 264.98513 229.11914 264.90625 C 229.28649 264.83249 229.44465 264.75208 229.60547 264.67383 C 229.70972 264.62427 229.81573 264.57638 229.91797 264.52539 C 229.92526 264.52175 229.93214 264.5173 229.93945 264.51367 C 230.10652 264.43083 230.2783 264.35078 230.43945 264.26367 C 230.43995 264.2634 230.44091 264.26394 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.40332 263.04924 233.10973 262.47581 233.75586 261.8418 C 233.75717 261.84051 233.75845 261.83918 233.75977 261.83789 C 233.83088 261.76789 233.8992 261.69466 233.96875 261.62305 C 233.97067 261.62108 233.97269 261.61916 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01198 256.99293 237.07424 256.85802 237.13281 256.71875 C 237.13336 256.71744 237.13422 256.71615 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.8128 254.90328 237.95906 254.41419 238.09961 253.91406 C 238.10016 253.9121 238.10101 253.91016 238.10156 253.9082 C 238.14177 253.76492 238.18014 253.61878 238.21875 253.47266 C 238.25475 253.33659 238.2866 253.19365 238.32031 253.05273 C 238.34775 252.94302 238.37574 252.832 238.40234 252.7207 C 238.40295 252.71818 238.40369 252.71542 238.4043 252.71289 C 238.54743 252.11352 238.67865 251.4902 238.79883 250.84375 C 238.82465 250.7047 238.8511 250.56733 238.87695 250.42773 C 238.88281 250.39444 238.89069 250.3635 238.89648 250.33008 C 238.89659 250.32947 238.89638 250.32874 238.89648 250.32812 C 239.03705 249.51759 239.16403 248.67439 239.27344 247.78906 C 239.27936 247.74118 239.28361 247.6901 239.28906 247.64062 C 239.30493 247.50972 239.31875 247.37085 239.33398 247.23828 C 239.3363 247.21815 239.33755 247.19595 239.33984 247.17578 C 239.41881 246.48269 239.49003 245.76862 239.55273 245.0293 C 239.55328 245.02286 239.55414 245.0162 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78349 241.55491 239.79357 241.40032 239.80273 241.24609 C 239.80753 241.14632 239.81376 241.05363 239.81836 240.95312 C 239.81877 240.94439 239.81798 240.93463 239.81836 240.92578 C 239.8239 240.79729 239.82694 240.65948 239.83203 240.5293 C 239.83253 240.51759 239.83349 240.5039 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96307 235.84067 239.96271 235.82927 239.96289 235.81836 C 239.96965 235.41022 239.97579 234.99445 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 126.24023 C 239.99175 124.41532 239.69913 122.64313 239.18555 120.92773 C 238.84316 119.78414 238.40271 118.66667 237.88281 117.57422 C 235.02338 111.56573 229.76385 106.34509 225.23828 102.07812 L 225.18945 102.02734 L 184.66602 59.619141 C 173.98907 49.058011 166.6082 44 152 44 L 102.92188 44 z M 202.6543 44.089844 C 198.17969 45.582244 196.66368 52.666443 200.11328 56.001953 L 228.60938 86.388672 C 232.34293 90.094303 239.77066 86.941636 239.99609 81.568359 C 239.99904 79.653502 239.98605 77.841831 239.95703 76.115234 C 239.95423 75.948427 239.94846 75.795955 239.94531 75.630859 C 239.91561 74.073736 239.87303 72.583034 239.80859 71.173828 C 239.76149 70.141731 239.70379 69.149343 239.63477 68.193359 C 238.48179 52.247696 234.0865 46.656477 219.97266 44.832031 C 218.6759 44.664404 217.29786 44.529298 215.83203 44.419922 C 215.12248 44.366977 214.38958 44.320376 213.63867 44.279297 C 213.63006 44.278828 213.61995 44.277811 213.61133 44.277344 C 212.04337 44.192346 210.38654 44.131491 208.63086 44.089844 L 202.6543 44.089844 z M 119.56641 55.945312 C 130.94041 55.949312 142.19691 55.986006 153.46484 56.191406 C 160.70267 55.806356 167.33104 59.645279 172.32031 64.599609 C 188.42569 80.562439 203.72801 97.31363 219.59766 113.50977 C 223.01384 117.3863 227.86068 121.27297 227.77148 126.91016 C 228.13347 156.76715 227.92575 186.62924 227.87695 216.48828 C 227.61216 226.73843 228.27253 237.18437 226.96875 247.45312 C 226.42181 249.81071 226.43599 253.48893 223.40625 254.10352 C 215.81737 255.95335 207.89537 255.57352 200.13867 255.80078 C 164.59267 255.97868 128.71027 256.09951 93.162109 255.66406 C 88.457189 255.24944 83.282319 255.67006 79.042969 253.2793 C 76.215659 249.46054 76.934056 244.27573 76.597656 239.79492 C 76.014926 191.14952 75.895482 142.48894 76.013672 93.822266 C 76.296742 83.105596 75.520041 72.053786 77.582031 61.384766 C 77.890341 58.111406 81.437525 57.376809 84.078125 56.974609 C 95.865615 55.846619 107.85901 56.107003 119.56641 55.945312 z "
-         id="rect4158-92-3" />
+         d="m 334.11952,249.75967 c -0.012,0.7948 -0.36762,1.21116 -1.06856,1.24033 l -4.83828,-0.56495 V 237.4758 l 4.989,-0.46779 c 0.66453,-0.0671 0.95484,0.2894 0.95995,1.00387 z"
+         fill-opacity="0.15"
+         id="path568"
+         style="stroke-width:0.300832" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,156 v 73.00683 C 63.827405,264.37495 67.625545,268 102.92228,268 h 98.15624 c 35.29672,0 38.00361,-3.63655 38.92188,-38.99317 V 156 Z"
-         id="path4255"
-         sodipodi:nodetypes="ccssscc" />
+         d="m 153.90126,114.88372 -32.60057,56.4409 -11.41236,-19.78271 h -0.0241 -14.680604 v 7.3403 h 10.478584 l 15.64808,27.10376 4.22608,-7.32105 32.61982,-56.46978 h 47.1079 v 7.33068 h 7.3403 v -14.6421 z m 15.41222,24.21096 -13.48208,2.37778 v 1.81462 c 1.00598,-0.0674 1.90607,-0.10108 2.68101,-0.10108 2.4211,0 4.25016,0.45726 5.4968,1.36216 1.24184,0.90972 2.25745,2.45961 3.03239,4.64966 0.16847,0.47171 1.29478,4.78925 3.37895,12.96707 -0.84233,1.882 -2.62326,4.94808 -5.34759,9.18861 -2.72434,4.24053 -4.8807,6.99374 -6.46428,8.27409 -0.64017,0.53909 -1.16001,0.81345 -1.56433,0.81345 -0.4717,0 -1.14557,-0.38988 -2.01678,-1.16483 -1.21295,-1.07336 -2.35852,-1.61246 -3.4367,-1.61246 -1.07337,0 -1.98309,0.36582 -2.72434,1.10707 -0.74125,0.74125 -1.11187,1.67022 -1.11187,2.77728 0,1.24665 0.40913,2.243 1.21777,2.97944 1.10706,0.9771 2.32964,1.46324 3.67737,1.46324 1.9157,0 3.90841,-0.83751 5.95888,-2.51736 3.16234,-2.62325 7.36918,-8.50512 12.61569,-17.62153 2.22375,9.99243 3.687,15.65289 4.39455,16.96692 1.11188,2.11786 2.60882,3.17197 4.49082,3.17197 1.28035,0 2.83986,-0.74125 4.69298,-2.21893 3.26343,-2.62807 5.9637,-5.92038 8.08156,-9.89136 l -1.7713,-0.90972 c -1.31404,2.48849 -2.89762,4.51489 -4.74593,6.06478 -0.94341,0.77013 -1.76648,1.16001 -2.47404,1.16001 -0.43801,0 -0.87121,-0.2503 -1.30922,-0.76051 -0.43801,-0.53909 -0.97711,-2.13711 -1.61728,-4.79406 l -4.13463,-17.36161 c 2.89761,-5.01548 5.3861,-8.39442 7.47507,-10.14647 1.10706,-0.93859 2.06491,-1.41511 2.87355,-1.41511 0.53909,0 1.59802,0.27436 3.17679,0.81345 0.80863,0.30324 1.56914,0.44282 2.27188,0.44282 1.21295,0 2.29114,-0.41394 3.23455,-1.25627 0.50539,-0.4717 0.75087,-1.35254 0.75087,-2.62807 0,-1.11187 -0.4332,-2.05047 -1.30922,-2.82541 -0.84233,-0.77495 -1.9879,-1.16001 -3.4367,-1.16001 -0.97229,0 -1.86276,0.16846 -2.67139,0.5054 -1.28034,0.53909 -2.75803,1.54026 -4.43788,3.02276 -1.68465,1.44399 -3.11421,2.97944 -4.28866,4.59671 l -4.4475,6.66644 c -1.38142,-5.15025 -2.37296,-8.33185 -2.97944,-9.5448 -0.84233,-1.74723 -2.08416,-3.49928 -3.73032,-5.25132 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path23"
+         style="display:inline;enable-background:new;fill:url(#c);stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,227.00586 v 2 C 63.827405,264.37398 67.625545,268 102.92228,268 h 98.15624 c 35.29672,0 38.00361,-3.63752 38.92188,-38.99414 v -2 C 239.08213,262.36248 236.37524,266 201.07852,266 h -98.15624 c -35.296735,0 -39.094875,-3.62602 -38.921885,-38.99414 z"
-         id="path945"
-         inkscape:connector-curvature="0" />
+         d="m 344.39044,75.556479 -6.69476,11.590542 -2.34361,-4.062521 h -0.005 -3.01477 v 1.507383 h 2.15186 l 3.21344,5.565951 0.86786,-1.50343 6.69871,-11.596473 h 9.67394 v 1.505408 h 1.50739 v -3.00686 z m 3.16501,4.971894 -2.76864,0.488294 v 0.372645 c 0.20657,-0.01384 0.39141,-0.02076 0.55056,-0.02076 0.49719,0 0.8728,0.0939 1.12881,0.27973 0.25502,0.186818 0.46357,0.505099 0.62272,0.954842 0.0346,0.09687 0.2659,0.983506 0.69389,2.66288 -0.17297,0.386482 -0.5387,1.016124 -1.09816,1.886947 -0.55946,0.870823 -1.00229,1.436214 -1.32749,1.699143 -0.13146,0.110706 -0.23821,0.167048 -0.32124,0.167048 -0.0969,0 -0.23525,-0.08007 -0.41416,-0.239206 -0.24909,-0.220422 -0.48434,-0.33113 -0.70575,-0.33113 -0.22043,0 -0.40725,0.07512 -0.55947,0.227344 -0.15222,0.152221 -0.22833,0.342992 -0.22833,0.570335 0,0.256008 0.084,0.460616 0.25008,0.611849 0.22734,0.200655 0.47841,0.300487 0.75517,0.300487 0.39341,0 0.80262,-0.171989 1.2237,-0.516958 0.64941,-0.538703 1.51332,-1.746587 2.59072,-3.618707 0.45667,2.052017 0.75716,3.214433 0.90246,3.484278 0.22833,0.434918 0.53574,0.651387 0.92222,0.651387 0.26293,0 0.58318,-0.152221 0.96374,-0.455673 0.67016,-0.539693 1.22468,-1.215793 1.6596,-2.031262 l -0.36375,-0.186817 c -0.26984,0.511029 -0.59504,0.927165 -0.97461,1.245446 -0.19373,0.158151 -0.36276,0.238216 -0.50806,0.238216 -0.0899,0 -0.17891,-0.0514 -0.26886,-0.156176 -0.0899,-0.110706 -0.20065,-0.438871 -0.33212,-0.984495 l -0.84907,-3.56533 c 0.59504,-1.029965 1.10607,-1.723854 1.53506,-2.08365 0.22734,-0.192747 0.42404,-0.290603 0.5901,-0.290603 0.11071,0 0.32816,0.05634 0.65238,0.167046 0.16605,0.06227 0.32223,0.09094 0.46654,0.09094 0.24909,0 0.47051,-0.08501 0.66424,-0.257984 0.10379,-0.09687 0.1542,-0.277754 0.1542,-0.539693 0,-0.228331 -0.089,-0.421079 -0.26886,-0.580218 -0.17298,-0.159142 -0.40823,-0.238217 -0.70575,-0.238217 -0.19967,0 -0.38253,0.0346 -0.54859,0.103788 -0.26293,0.110706 -0.56638,0.316303 -0.91135,0.620745 -0.34596,0.296534 -0.63953,0.611849 -0.88071,0.943967 l -0.91332,1.369001 c -0.28369,-1.05764 -0.48731,-1.711004 -0.61185,-1.960092 -0.17298,-0.358807 -0.428,-0.718603 -0.76605,-1.078396 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path528"
+         style="display:inline;enable-background:new;fill:url(#linearGradient530);stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07999998;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:7.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 180.0004,268 60,-60 v 22.48388 C 239.9481,264.47969 236.19772,268 201.8263,268 Z"
-         id="path4254"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccsc" />
-      <g
-         transform="translate(-3285.9988,955.6378)"
-         style="display:inline;enable-background:new"
-         id="g8298">
-        <rect
-           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient54806);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           id="rect8463"
-           width="24"
-           height="22.000021"
-           x="3617.9988"
-           y="-877.63782" />
-        <rect
-           y="-858.63782"
-           x="3617.9988"
-           height="1"
-           width="24"
-           id="rect8465"
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-        <rect
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           id="rect8467"
-           width="24"
-           height="1"
-           x="3617.9988"
-           y="-875.63782" />
-        <rect
-           y="-3619.9988"
-           x="-877.63782"
-           height="1"
-           width="22"
-           id="rect8469"
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           transform="rotate(90)" />
-        <rect
-           transform="rotate(90)"
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           id="rect8471"
-           width="22"
-           height="1"
-           x="-877.63782"
-           y="-3640.9988" />
-        <g
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8px;font-family:Vegur;display:inline;fill:url(#linearGradient3008);fill-opacity:1;stroke:none"
-           id="g8473"
-           transform="matrix(1.50411,0,0,1.50411,-1963.9,-1914.17)">
-          <path
-             inkscape:connector-curvature="0"
-             d="m 3725.0541,691.79021 v 1.99453 h -0.9972 v -0.93078 h -6.1831 l -1.3962,8.24407 h -1.5956 l -1.3297,-4.18852 h -0.7979 v -1.13024 l 1.6622,2e-5 1.1634,3.32421 1.1635,-7.3133"
-             style="font-family:Symbol;fill:url(#linearGradient3006);fill-opacity:1"
-             id="path8475"
-             sodipodi:nodetypes="ccccccccccccc" />
-        </g>
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc"
-           id="path8477"
-           d="m 3636.9988,-867.63779 -7,7"
-           style="fill:none;stroke:url(#linearGradient54797);stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:none;stroke:url(#linearGradient54794);stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 3629.9988,-867.63779 7,7"
-           id="path8479"
-           sodipodi:nodetypes="cc" />
-      </g>
-      <g
-         transform="translate(-3285.9988,917.63811)"
-         style="display:inline;enable-background:new"
-         id="g8353">
-        <rect
-           y="-772.63782"
-           x="3613.9988"
-           height="14.000002"
-           width="16"
-           id="rect8291"
-           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient54821);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-        <rect
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           id="rect8297"
-           width="16.000021"
-           height="1.0000125"
-           x="3613.9988"
-           y="-760.63812" />
-        <rect
-           y="-772.63782"
-           x="3613.9988"
-           height="1"
-           width="16"
-           id="rect8377"
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-        <rect
-           transform="rotate(90)"
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           id="rect8379"
-           width="12.999707"
-           height="0.99997932"
-           x="-772.63782"
-           y="-3614.9988" />
-        <rect
-           y="-3629.9988"
-           x="-772.63782"
-           height="0.99997932"
-           width="12.999707"
-           id="rect8381"
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           transform="rotate(90)" />
-        <g
-           transform="matrix(1.50411,0,0,1.50411,-1968.9,-1815.17)"
-           id="g8331"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8px;font-family:Vegur;display:inline;fill:url(#linearGradient8365);fill-opacity:1;stroke:none">
-          <path
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="ccccccccccccc"
-             id="path8333"
-             style="font-family:Symbol;fill:url(#linearGradient8363);fill-opacity:1"
-             d="m 3721.0651,694.44959 v 1.32969 h -0.6648 v -0.59836 h -3.6568 l -1.3964,5.25249 h -0.9308 l -1.3296,-3.32422 -0.6649,-10e-6 v -0.66485 l 1.3297,2e-5 1.0637,2.65937 1.2635,-4.65414" />
-        </g>
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:none;stroke:url(#linearGradient54812);stroke-width:1.29999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 3626.9984,-766.13735 -4,3.99968"
-           id="path8383"
-           sodipodi:nodetypes="cc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc"
-           id="path8387"
-           d="m 3622.9984,-766.13735 4,3.99968"
-           style="fill:none;stroke:url(#linearGradient54809);stroke-width:1.29999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
+         d="m 336.25466,142.49336 -4.36615,7.55905 -1.52844,-2.64947 h -0.003 -1.96616 v 0.98307 h 1.40339 l 2.09572,3.62997 0.566,-0.9805 4.36872,-7.56292 h 6.30909 v 0.98179 h 0.98308 v -1.96099 z m 2.06413,3.24254 -1.80563,0.31845 v 0.24303 c 0.13472,-0.009 0.25527,-0.0135 0.35906,-0.0135 0.32425,0 0.56922,0.0612 0.73618,0.18243 0.16632,0.12184 0.30233,0.32941 0.40612,0.62272 0.0226,0.0632 0.17342,0.64142 0.45254,1.73666 -0.11281,0.25206 -0.35133,0.66269 -0.71619,1.23062 -0.36487,0.56793 -0.65367,0.93666 -0.86576,1.10814 -0.0857,0.0722 -0.15535,0.10894 -0.2095,0.10894 -0.0632,0 -0.15342,-0.0522 -0.27011,-0.156 -0.16245,-0.14375 -0.31587,-0.21595 -0.46027,-0.21595 -0.14376,0 -0.26559,0.049 -0.36487,0.14826 -0.0993,0.0993 -0.14891,0.22369 -0.14891,0.37196 0,0.16696 0.0548,0.3004 0.1631,0.39903 0.14826,0.13086 0.312,0.19597 0.4925,0.19597 0.25657,0 0.52345,-0.11216 0.79806,-0.33714 0.42353,-0.35133 0.98695,-1.13908 1.6896,-2.36003 0.29783,1.33827 0.4938,2.09637 0.58856,2.27235 0.14892,0.28365 0.3494,0.42482 0.60145,0.42482 0.17148,0 0.38034,-0.0993 0.62853,-0.29718 0.43706,-0.35197 0.7987,-0.7929 1.08235,-1.32473 l -0.23723,-0.12184 c -0.17598,0.33328 -0.38807,0.60467 -0.63562,0.81225 -0.12634,0.10314 -0.23658,0.15536 -0.33134,0.15536 -0.0586,0 -0.11668,-0.0335 -0.17534,-0.10186 -0.0586,-0.0722 -0.13086,-0.28622 -0.2166,-0.64206 l -0.55375,-2.32521 c 0.38807,-0.67172 0.72135,-1.12426 1.00113,-1.35891 0.14827,-0.1257 0.27655,-0.18952 0.38485,-0.18952 0.0722,0 0.21402,0.0367 0.42546,0.10894 0.1083,0.0406 0.21015,0.0593 0.30427,0.0593 0.16245,0 0.30685,-0.0554 0.4332,-0.16825 0.0677,-0.0632 0.10056,-0.18114 0.10056,-0.35197 0,-0.14891 -0.058,-0.27462 -0.17534,-0.3784 -0.11281,-0.10379 -0.26624,-0.15536 -0.46027,-0.15536 -0.13022,0 -0.24948,0.0226 -0.35778,0.0677 -0.17147,0.0722 -0.36938,0.20628 -0.59436,0.40483 -0.22562,0.19339 -0.41708,0.39903 -0.57437,0.61563 l -0.59565,0.89283 c -0.18501,-0.68977 -0.31781,-1.11587 -0.39903,-1.27832 -0.11281,-0.23401 -0.27913,-0.46866 -0.4996,-0.70331 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path542"
+         style="display:inline;enable-background:new;fill:url(#linearGradient544);stroke-width:0.64464" />
       <path
-         sodipodi:nodetypes="cc"
-         id="path6070"
-         d="m 331,245.00039 -3,2.9999"
-         style="display:inline;fill:none;stroke:url(#linearGradient54830);stroke-width:1px;stroke-linecap:square;stroke-linejoin:round;stroke-opacity:1;enable-background:new"
-         inkscape:connector-curvature="0" />
-      <g
-         transform="translate(0,2.8216664e-4)"
-         style="display:inline;enable-background:new"
-         id="g1942">
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccccc"
-           id="path6045"
-           d="m 331.5,243 v -0.5 h -5 l -1,6.00007 -0.25,-2.99997 h -0.75"
-           style="display:inline;fill:none;stroke:url(#linearGradient1882);stroke-width:1px;stroke-linecap:square;stroke-linejoin:round;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc"
-           id="path6072"
-           d="M 328,245.0001 331,248"
-           style="display:inline;fill:none;stroke:url(#linearGradient54827);stroke-width:1px;stroke-linecap:square;stroke-linejoin:round;stroke-opacity:1" />
-      </g>
-      <g
-         style="display:inline;enable-background:new"
-         id="g1990"
-         transform="translate(-1,1.0000026)">
-        <rect
-           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1921);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           id="rect1901"
-           width="14.000021"
-           height="11.999997"
-           x="325.99997"
-           y="196" />
-        <rect
-           y="207"
-           x="325.99997"
-           height="0.99999738"
-           width="14.000021"
-           id="rect1903"
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-        <rect
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           id="rect1905"
-           width="13.000031"
-           height="1"
-           x="325.99997"
-           y="196" />
-        <rect
-           y="-326.99997"
-           x="195.99998"
-           height="1.0000207"
-           width="12.000003"
-           id="rect1907"
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           transform="rotate(90)" />
-        <rect
-           transform="rotate(90)"
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           id="rect1909"
-           width="12.000003"
-           height="1.0000207"
-           x="195.99998"
-           y="-339.99997" />
-        <path
-           sodipodi:nodetypes="cc"
-           id="path1966"
-           d="m 336.50011,201.49999 -3,2.9999"
-           style="display:inline;fill:none;stroke:url(#linearGradient1974);stroke-width:1px;stroke-linecap:square;stroke-linejoin:round;stroke-opacity:1"
-           inkscape:connector-curvature="0" />
-        <path
-           style="display:inline;fill:none;stroke:url(#linearGradient1976);stroke-width:1px;stroke-linecap:square;stroke-linejoin:round;stroke-opacity:1"
-           d="m 337.5,199 v -0.5 h -6 l -1,7.00007 -1.25,-3.99997 h -0.75"
-           id="path1968"
-           sodipodi:nodetypes="cccccc"
-           inkscape:connector-curvature="0" />
-        <path
-           style="display:inline;fill:none;stroke:url(#linearGradient1978);stroke-width:1px;stroke-linecap:square;stroke-linejoin:round;stroke-opacity:1"
-           d="m 333.50011,201.49999 3,2.9999"
-           id="path1970"
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0" />
-      </g>
-      <g
-         transform="matrix(5,0,0,5,-17997.991,4519.1889)"
-         style="display:inline;enable-background:new"
-         id="g8298-2">
-        <rect
-           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3132);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           id="rect8463-7"
-           width="24"
-           height="22.000021"
-           x="3617.9988"
-           y="-877.63782" />
-        <rect
-           y="-858.63782"
-           x="3617.9988"
-           height="1"
-           width="24"
-           id="rect8465-0"
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-        <rect
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           id="rect8467-9"
-           width="24"
-           height="1"
-           x="3617.9988"
-           y="-875.63782" />
-        <rect
-           y="-3619.9988"
-           x="-877.63782"
-           height="1"
-           width="22"
-           id="rect8469-3"
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           transform="rotate(90)" />
-        <rect
-           transform="rotate(90)"
-           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-           id="rect8471-6"
-           width="22"
-           height="1"
-           x="-877.63782"
-           y="-3640.9988" />
-        <g
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8px;font-family:Vegur;display:inline;fill:url(#linearGradient3008-6);fill-opacity:1;stroke:none"
-           id="g8473-0"
-           transform="matrix(1.50411,0,0,1.50411,-1963.9,-1914.17)">
-          <path
-             inkscape:connector-curvature="0"
-             d="m 3725.0541,691.79021 v 1.99453 h -0.9972 v -0.93078 h -6.1831 l -1.3962,8.24407 h -1.5956 l -1.3297,-4.18852 h -0.7979 v -1.13024 l 1.6622,2e-5 1.1634,3.32421 1.1635,-7.3133"
-             style="font-family:Symbol;fill:url(#linearGradient3134);fill-opacity:1"
-             id="path8475-6"
-             sodipodi:nodetypes="ccccccccccccc" />
-        </g>
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc"
-           id="path8477-2"
-           d="m 3636.9988,-867.63779 -7,7"
-           style="fill:none;stroke:url(#linearGradient3136);stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:none;stroke:url(#linearGradient3138);stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 3629.9988,-867.63779 7,7"
-           id="path8479-6"
-           sodipodi:nodetypes="cc" />
-      </g>
+         d="m 332.18674,195.9618 -3.20185,5.5433 -1.12085,-1.94294 h -0.002 -1.44185 v 0.72092 h 1.02915 l 1.53686,2.66197 0.41507,-0.71903 3.20373,-5.54614 h 4.62666 v 0.71998 h 0.72093 v -1.43806 z m 1.51369,2.37786 -1.32413,0.23353 v 0.17822 c 0.0988,-0.007 0.1872,-0.01 0.26331,-0.01 0.23779,0 0.41743,0.0449 0.53987,0.13379 0.12197,0.0893 0.22171,0.24156 0.29782,0.45666 0.0166,0.0463 0.12718,0.47037 0.33186,1.27355 -0.0827,0.18484 -0.25764,0.48597 -0.5252,0.90245 -0.26757,0.41648 -0.47936,0.68689 -0.63489,0.81264 -0.0629,0.053 -0.11393,0.0799 -0.15364,0.0799 -0.0463,0 -0.1125,-0.0383 -0.19808,-0.1144 -0.11913,-0.10542 -0.23163,-0.15837 -0.33753,-0.15837 -0.10542,0 -0.19476,0.0359 -0.26757,0.10873 -0.0728,0.0728 -0.1092,0.16404 -0.1092,0.27277 0,0.12244 0.0402,0.22029 0.11961,0.29262 0.10872,0.096 0.2288,0.14371 0.36116,0.14371 0.18815,0 0.38387,-0.0822 0.58525,-0.24723 0.31059,-0.25765 0.72376,-0.83533 1.23904,-1.73069 0.21841,0.9814 0.36212,1.53734 0.43161,1.66639 0.10921,0.20801 0.25623,0.31153 0.44106,0.31153 0.12575,0 0.27892,-0.0728 0.46092,-0.21793 0.32051,-0.25811 0.58572,-0.58146 0.79373,-0.97147 l -0.17397,-0.0893 c -0.12905,0.24441 -0.28459,0.44343 -0.46612,0.59565 -0.0927,0.0756 -0.17349,0.11393 -0.24299,0.11393 -0.043,0 -0.0856,-0.0246 -0.12858,-0.0747 -0.043,-0.053 -0.096,-0.2099 -0.15884,-0.47085 l -0.40608,-1.70515 c 0.28458,-0.4926 0.52899,-0.82446 0.73416,-0.99654 0.10873,-0.0922 0.2028,-0.13898 0.28222,-0.13898 0.053,0 0.15695,0.0269 0.31201,0.0799 0.0794,0.0298 0.15411,0.0435 0.22313,0.0435 0.11913,0 0.22502,-0.0406 0.31768,-0.12339 0.0496,-0.0463 0.0737,-0.13283 0.0737,-0.25811 0,-0.1092 -0.0425,-0.20138 -0.12858,-0.27749 -0.0827,-0.0761 -0.19524,-0.11393 -0.33753,-0.11393 -0.0955,0 -0.18295,0.0166 -0.26237,0.0496 -0.12575,0.0529 -0.27088,0.15127 -0.43587,0.29687 -0.16545,0.14182 -0.30586,0.29262 -0.4212,0.45146 l -0.43681,0.65475 c -0.13568,-0.50584 -0.23306,-0.81831 -0.29262,-0.93744 -0.0827,-0.17161 -0.2047,-0.34368 -0.36638,-0.51576 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path556"
+         style="display:inline;enable-background:new;fill:url(#linearGradient558);stroke-width:0.472736" />
       <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;opacity:0.3"
-         d="m 102.92188,44 c -2.50815,0 -4.811706,0.02551 -7.011724,0.07227 -1.569123,0.03333 -3.085758,0.07665 -4.505859,0.142578 -0.892728,0.04133 -1.761123,0.08803 -2.597656,0.144531 -0.07361,0.005 -0.155337,0.0086 -0.228516,0.01367 -0.03977,0.0028 -0.07364,0.0069 -0.113281,0.0098 -1.116046,0.0793 -2.169724,0.179402 -3.1875,0.291016 -0.281404,0.03076 -0.565732,0.06033 -0.839844,0.09375 -0.275699,0.03373 -0.547991,0.06893 -0.816406,0.105469 -0.386448,0.05241 -0.763169,0.107586 -1.134766,0.166015 -0.245075,0.0387 -0.493706,0.07575 -0.732422,0.117188 -0.386715,0.06683 -0.756638,0.14255 -1.126953,0.216797 -0.50787,0.102283 -1.000729,0.211021 -1.478515,0.328125 -0.190937,0.04659 -0.386033,0.09158 -0.572266,0.140625 -0.3252,0.08602 -0.638123,0.17771 -0.949219,0.271484 -0.174107,0.05225 -0.347813,0.105409 -0.517578,0.160157 -0.32699,0.105899 -0.647816,0.216555 -0.958984,0.332031 -0.09794,0.0362 -0.19267,0.07416 -0.289063,0.111328 -1.533658,0.593687 -2.876219,1.308506 -4.044922,2.173828 -0.01464,0.01084 -0.03034,0.02036 -0.04492,0.03125 -4.841904,3.613548 -6.740009,9.796263 -7.419922,20.238281 -0.01716,0.264046 -0.02929,0.544903 -0.04492,0.814453 -0.06629,1.140594 -0.126494,2.305415 -0.167969,3.546875 -9.88e-4,0.02958 -9.78e-4,0.06216 -0.002,0.0918 -0.04738,1.439614 -0.07924,2.944486 -0.09961,4.525391 C 64.509576,49.175312 70.065023,46 102.92188,46 h 62.52929 c -0.85989,-0.295464 -1.74582,-0.553137 -2.65429,-0.783203 -0.15701,-0.03958 -0.31205,-0.08153 -0.47071,-0.119141 -0.38771,-0.0924 -0.78156,-0.17709 -1.17969,-0.257812 -0.28362,-0.0571 -0.57205,-0.108999 -0.86132,-0.160156 -0.33217,-0.05924 -0.66192,-0.122415 -1.00196,-0.173829 -0.61547,-0.09216 -1.24344,-0.171652 -1.88672,-0.238281 -0.25531,-0.02678 -0.51929,-0.04563 -0.77929,-0.06836 -0.49344,-0.04258 -0.99476,-0.07925 -1.50586,-0.107422 -0.26087,-0.01459 -0.52138,-0.03022 -0.78711,-0.04102 C 153.56684,44.020455 152.79888,44 152,44 Z"
-         id="path7802" />
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;opacity:0.4"
-         d="M 202.6543,44.089844 C 201.58308,44.447123 200.68698,45.129921 199.98242,46 h 1.0957 c 34.15108,4e-6 38.64021,3.484765 38.89649,35.740234 0.003,-0.03712 0.0117,-0.07204 0.0137,-0.109375 -0.0536,-17.671398 -1.15787,-27.178174 -7.08008,-32.177734 -0.31691,-0.265045 -0.64554,-0.519153 -0.99023,-0.759766 -1.34338,-0.937742 -2.91268,-1.68853 -4.71875,-2.296875 -0.14212,-0.04772 -0.27668,-0.09862 -0.42188,-0.144531 -0.31902,-0.101184 -0.65609,-0.192499 -0.99023,-0.285156 -0.25795,-0.07131 -0.51412,-0.144507 -0.78125,-0.210938 -0.32384,-0.08078 -0.65655,-0.156631 -0.99414,-0.230468 -0.32254,-0.07033 -0.65294,-0.136909 -0.98828,-0.201172 -0.32063,-0.06164 -0.64012,-0.123397 -0.97266,-0.179688 -0.46228,-0.07802 -0.94194,-0.148582 -1.42773,-0.216797 -0.21622,-0.03046 -0.42163,-0.06516 -0.64258,-0.09375 -0.003,-3.28e-4 -0.005,-0.0016 -0.008,-0.002 -0.70741,-0.09114 -1.44413,-0.170948 -2.20118,-0.24414 -0.30752,-0.02983 -0.6294,-0.05499 -0.94531,-0.08203 -0.52075,-0.04445 -1.04787,-0.08768 -1.59179,-0.125 -0.34138,-0.02349 -0.68841,-0.04362 -1.03907,-0.06445 -0.36733,-0.02177 -0.74929,-0.04154 -1.12695,-0.06055 -1.40861,-0.07105 -2.86508,-0.128967 -4.42188,-0.166015 -0.006,-1.28e-4 -0.0105,5e-6 -0.0156,0 h -0.004 z"
-         id="path7800" />
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;opacity:0.3"
-         d="M 64.011719,81.421875 C 64.009827,81.961067 64,82.439442 64,82.994141 v 2 c -0.0062,-1.260292 0.0066,-2.391311 0.01172,-3.572266 z"
-         id="path5316-35" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23242,61.5 c -4.11577,0 -6.55968,0.226752 -7.96875,1.558594 -0.28725,0.271486 -0.52183,0.601863 -0.72851,0.972656 -0.0468,0.08393 -0.10154,0.156606 -0.14454,0.246094 -2.5e-4,5.28e-4 2.6e-4,0.0014 0,0.002 -0.11616,0.241982 -0.2184,0.50414 -0.30859,0.789062 -0.0904,0.285534 -0.16955,0.593694 -0.23633,0.925782 -0.0668,0.332095 -0.1223,0.688232 -0.16797,1.070312 -0.0913,0.764147 -0.1422,1.632501 -0.16406,2.617188 -0.0109,0.492345 -0.0144,1.013779 -0.0117,1.566406 V 84 96.751953 c -0.003,0.552627 8e-4,1.074061 0.0117,1.566406 0.0219,0.984686 0.0727,1.853041 0.16406,2.617191 0.0457,0.38208 0.1012,0.73821 0.16797,1.07031 0.13356,0.66417 0.31198,1.23197 0.54492,1.7168 0.23295,0.48482 0.52078,0.88581 0.87305,1.21875 0.17614,0.16648 0.36842,0.31556 0.57813,0.44921 0.41895,0.26701 0.90872,0.47238 1.47656,0.62891 6.2e-4,1.7e-4 0.001,-1.7e-4 0.002,0 1.42142,0.39113 3.3408,0.48047 5.91211,0.48047 h 17.53906 c 1.02156,0 1.93959,-0.015 2.76368,-0.0566 0.34097,-0.0172 0.65525,-0.0427 0.96484,-0.0703 0.0645,-0.006 0.13795,-0.007 0.20117,-0.0137 0.001,-1.4e-4 0.003,1.3e-4 0.004,0 0.73118,-0.0725 1.37505,-0.17995 1.93945,-0.33399 0.28273,-0.0772 0.54639,-0.16492 0.79102,-0.26758 0.24462,-0.10265 0.47066,-0.22006 0.67968,-0.35156 0.20903,-0.1315 0.40024,-0.27771 0.57618,-0.44141 0.15581,-0.14498 0.29602,-0.30775 0.42773,-0.48046 0.017,-0.0223 0.0381,-0.0397 0.0547,-0.0625 0.001,-0.002 0.003,-0.004 0.004,-0.006 0.14374,-0.19776 0.2725,-0.41443 0.38868,-0.6504 0.11725,-0.23815 0.22082,-0.49693 0.3125,-0.77734 0.0917,-0.28041 0.17164,-0.58218 0.24023,-0.9082 0.0686,-0.32602 0.12581,-0.6758 0.17383,-1.05078 0.0428,-0.33417 0.0752,-0.6967 0.10351,-1.072269 0.003,-0.04534 0.0104,-0.0849 0.0137,-0.130859 4.2e-4,-0.0061 -4.3e-4,-0.01341 0,-0.01953 0.059,-0.850021 0.0853,-1.80463 0.0879,-2.88086 V 78.021484 c -0.009,-1.95527 -1.71776,-3.606675 -3.10157,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 C 348.62263,62.517026 347.07095,61.5 344,61.5 Z"
-         id="path964-1"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.005859,227.00586 v 2 c -0.0022,0.44238 0.0048,0.82141 0.0039,1.25391 0.0013,0.45945 0.007,0.88359 0.0098,1.33203 -0.01134,-1.48776 -0.02159,-2.96803 -0.01367,-4.58594 z M 240,227.75781 C 239.94446,262.39 236.11596,266 201.08398,266 h -98.15625 c -32.934263,0 -38.440959,-3.18029 -38.890621,-32.33398 0.304544,24.87428 3.489356,31.9654 22.175782,33.76562 0.0033,3.2e-4 0.0064,-3.2e-4 0.0098,0 0.761225,0.073 1.548247,0.13868 2.361328,0.19531 0.002,1.4e-4 0.0039,-1.4e-4 0.0059,0 0.814659,0.0567 1.655065,0.10648 2.523437,0.14844 6.7e-4,3e-5 0.0013,-3e-5 0.002,0 0.579873,0.028 1.24712,0.0365 1.851563,0.0586 1.208255,0.0442 2.391096,0.0937 3.701172,0.11719 0.0014,3e-5 0.0025,-2e-5 0.0039,0 1.964377,0.0351 4.045339,0.0488 6.250009,0.0488 0.002,0 0.004,0 0.006,0 h 98.15039 c 3.67649,0 6.93682,-0.0556 9.96094,-0.16602 2.42031,-0.0885 4.71577,-0.20623 6.75196,-0.40234 19.49586,-1.8777 22.12352,-9.49921 22.20507,-37.08398 -8.2e-4,-0.46208 0.006,-0.86842 0.004,-1.3418 z"
-         id="path5316-8"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 353.49905,61.375285 c -0.0742,0 -0.14719,0.007 -0.22049,0.018 -0.94065,0.29981 -1.25935,1.72298 -0.53417,2.39306 l 7.51333,7.51498 c 0.78643,0.74591 2.35311,0.10873 2.39455,-0.97465 v -2.118 c 0.0336,-6.55752 0.34308,-6.68079 -5.59466,-6.81539 H 353.722 c -0.0733,-0.0113 -0.14877,-0.018 -0.22295,-0.018 z"
-         id="rect4158-92-6-6"
-         sodipodi:nodetypes="scccccccs" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1004);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         clip-path="url(#clipPath994-5)"
-         d="m 335.23242,61.5 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 V 84 96.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 V 79.021813 C 362.49246,77.807802 361.8315,76.711812 361,75.756188 V 84 96.251953 c 0,2.193451 -0.0614,3.870697 -0.26562,5.087887 -0.20419,1.2172 -0.52867,1.92435 -0.99805,2.39454 -0.46938,0.47016 -1.17436,0.79564 -2.38867,1 -1.21432,0.20434 -2.8892,0.26562 -5.07813,0.26562 h -16.53906 c -2.18893,0 -3.86589,-0.0612 -5.08399,-0.26562 -1.21809,-0.20448 -1.92877,-0.5295 -2.40039,-1 -0.47161,-0.47052 -0.79596,-1.17682 -0.99804,-2.39258 -0.20209,-1.21576 -0.25879,-2.893414 -0.24805,-5.085941 v -0.002 V 84 71.746094 v -0.002 c -0.0107,-2.192528 0.046,-3.870175 0.24805,-5.085938 0.20209,-1.215763 0.52643,-1.922078 0.99804,-2.392578 0.47161,-0.4705 1.18426,-0.79553 2.40235,-1 C 331.86653,63.061202 333.54154,63 335.73047,63 H 348 c -1.40176,-1.001118 -3.79892,-1.5 -5.922,-1.5 z"
-         id="path990"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssccccscccsscccccccccscscss" />
-      <path
-         inkscape:connector-curvature="0"
-         style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04419417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 353.35547,61.876953 -0.14453,0.121094 c -0.28875,0.242959 -0.43321,0.748579 -0.31836,1.111328 0.007,0.0217 0.07,0.0936 0.11523,0.150391 0.056,-0.101219 0.12158,-0.193105 0.20313,-0.261719 l 0.14453,-0.121094 2.71875,0.02539 c 2.70745,0.02522 3.50936,0.05935 4.26562,0.185547 1.36683,0.228076 1.67801,0.658049 1.79102,2.474609 0.0245,0.393967 0.0317,1.552688 0.0352,2.636719 0.007,-1.466927 -5.4e-4,-3.080545 -0.0352,-3.636719 -0.11301,-1.81656 -0.42419,-2.246533 -1.79102,-2.474609 -0.75626,-0.126199 -1.55817,-0.160327 -4.26562,-0.185547 z"
-         id="path7025" />
-      <path
-         transform="translate(4.9980746e-4)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971-6)" />
-      <path
-         id="path1085"
-         d="m 327.86573,188.5 c -1.11158,0 -1.98683,0.0256 -2.70703,0.14648 -0.72019,0.1209 -1.3105,0.34863 -1.74218,0.7793 -0.43169,0.43067 -0.65954,1.01974 -0.7793,1.74024 -0.11977,0.72049 -0.14217,1.59669 -0.13672,2.71093 V 200 v 6.125 c -0.005,1.1131 0.017,1.989 0.13672,2.70898 0.11976,0.72051 0.3476,1.30957 0.7793,1.74024 0.43169,0.43067 1.02199,0.6584 1.74218,0.7793 0.7202,0.12089 1.59545,0.14648 2.70703,0.14648 h 8.26954 c 1.11158,0 1.98637,-0.0255 2.70507,-0.14648 0.7187,-0.12095 1.30623,-0.34848 1.73633,-0.7793 0.4301,-0.43083 0.6566,-1.01849 0.77735,-1.73828 0.12074,-0.71979 0.14648,-1.59713 0.14648,-2.71094 V 200 193.875 c 0,-1.11381 -0.0257,-1.99115 -0.14648,-2.71094 -0.12075,-0.71979 -0.34725,-1.30745 -0.77735,-1.73828 -0.4301,-0.43082 -1.01763,-0.65835 -1.73633,-0.7793 -0.7187,-0.12094 -1.59349,-0.14648 -2.70507,-0.14648 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path1087"
-         d="m 325.0962,236.5 c -0.71048,0 -1.27344,0.0154 -1.75195,0.0957 -0.47851,0.0803 -0.89671,0.23728 -1.20703,0.54688 -0.31032,0.30959 -0.46726,0.7261 -0.54688,1.20508 -0.0796,0.47897 -0.0933,1.04352 -0.0898,1.75586 V 244 v 3.89844 c -0.003,0.71121 0.0103,1.27546 0.0898,1.7539 0.0796,0.47898 0.23655,0.89549 0.54688,1.20508 0.31033,0.3096 0.72851,0.46655 1.20703,0.54688 0.47852,0.0803 1.04147,0.0957 1.75195,0.0957 h 5.8086 c 0.71048,0 1.27236,-0.0153 1.75,-0.0957 0.47763,-0.0804 0.89584,-0.23713 1.20508,-0.54688 0.30921,-0.30975 0.46469,-0.72681 0.54492,-1.20508 0.0802,-0.47826 0.0957,-1.04201 0.0957,-1.7539 V 244 240.10156 c 0,-0.71189 -0.0155,-1.27564 -0.0957,-1.7539 -0.0802,-0.47827 -0.2357,-0.89533 -0.54492,-1.20508 -0.30924,-0.30975 -0.72745,-0.4665 -1.20508,-0.54688 -0.47764,-0.0804 -1.03952,-0.0957 -1.75,-0.0957 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         transform="translate(4.9980746e-4)"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983-6)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99158418;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 342.28662,133.49219 c -0.0504,0 -0.10067,0.005 -0.15039,0.0117 -0.63831,0.19051 -0.85538,1.0957 -0.36328,1.52148 l 5.09961,4.77344 c 0.53367,0.47395 1.59687,0.0693 1.625,-0.61914 v -1.34571 c 0.0228,-4.16669 0.23241,-4.24454 -3.79688,-4.33007 h -2.26367 c -0.0498,-0.007 -0.10004,-0.0117 -0.15039,-0.0117 z m -12.21289,0.004 c -2.78209,0 -4.43425,0.14534 -5.38672,1.00391 -0.19416,0.175 -0.35249,0.38793 -0.49219,0.62695 -0.0316,0.054 -0.0686,0.10247 -0.0976,0.16016 -0.0785,0.156 -0.14802,0.3261 -0.20899,0.50977 -0.0611,0.18405 -0.11501,0.38162 -0.16015,0.5957 -0.0452,0.21409 -0.0824,0.44315 -0.11329,0.68945 -0.0617,0.49261 -0.0965,1.05274 -0.11132,1.6875 -0.007,0.31739 -0.01,0.65353 -0.008,1.00977 V 148 v 8.2207 c -0.002,0.35623 3.5e-4,0.69239 0.008,1.00977 0.0148,0.63477 0.0495,1.19491 0.11132,1.6875 0.0309,0.24631 0.0682,0.47537 0.11329,0.68945 0.0903,0.42816 0.21168,0.79292 0.36914,1.10547 0.15746,0.31252 0.35171,0.57249 0.58984,0.78711 0.11906,0.10732 0.24887,0.20291 0.39062,0.28906 0.28319,0.17212 0.61423,0.30534 0.99805,0.40625 0.96081,0.25213 2.25995,0.3086 3.99805,0.3086 h 11.85547 c 0.69054,0 1.31013,-0.0106 1.86719,-0.0371 0.23047,-0.0111 0.44308,-0.0272 0.65234,-0.0449 0.0436,-0.004 0.094,-0.004 0.13672,-0.008 h 0.002 c 0.49424,-0.0467 0.92903,-0.11749 1.31055,-0.21679 0.19111,-0.0498 0.36981,-0.10571 0.53515,-0.17188 0.16536,-0.0661 0.31771,-0.14178 0.45899,-0.22656 0.14129,-0.0848 0.2717,-0.17962 0.39062,-0.28516 0.10532,-0.0934 0.20005,-0.19727 0.28907,-0.30859 0.0115,-0.0144 0.0259,-0.0264 0.0371,-0.041 6.7e-4,-0.001 9.5e-4,-0.003 0.002,-0.004 0.0971,-0.12749 0.18514,-0.26586 0.26367,-0.41797 0.0792,-0.15352 0.14897,-0.32121 0.21094,-0.50196 0.062,-0.18077 0.11573,-0.37576 0.16211,-0.58593 0.0464,-0.21016 0.0847,-0.43601 0.11718,-0.67774 0.0289,-0.21541 0.0511,-0.44929 0.0703,-0.6914 0.002,-0.0292 0.008,-0.0543 0.01,-0.084 2.9e-4,-0.004 -2.9e-4,-0.008 0,-0.0117 0.0399,-0.54795 0.0568,-1.16365 0.0586,-1.85742 v -11.18578 c -0.006,-1.26044 -1.16032,-2.32513 -2.09571,-3.1289 l -0.008,-0.006 -6.72986,-6.49196 c -1.51744,-1.36767 -2.56676,-2.02344 -4.64258,-2.02344 z"
-         id="path964-1-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccccccccccccccccsscccccccccccccccccccccccss" />
-      <path
-         style="opacity:0.3;fill:url(#linearGradient4316);fill-opacity:1;stroke:none;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 343.16802,134.07487 c -0.99147,0.035 -1.02734,0.0465 -1.02734,0.33594 0,0.10178 0.15173,0.31016 0.45898,0.64648 h 2.87891 c 0.15931,0 0.30929,0.0306 0.45312,0.0762 0.32342,0.02 0.64497,0.0487 0.96485,0.10352 0.0264,0.32124 0.0306,0.64828 0.0371,0.97461 0.0263,0.11154 0.0449,0.2259 0.0449,0.3457 v 2.61719 c 0.25501,0.21272 0.45277,0.36813 0.49023,0.36914 0.45172,0.0121 0.5059,-0.28833 0.46289,-2.54883 -0.0534,-2.80528 0.043,-2.67754 -2.15624,-2.83984 -0.86922,-0.0642 -2.04216,-0.1 -2.60743,-0.0801 z m -10.83984,0.0371 c -5.16676,0.002 -5.89229,0.0632 -6.90234,0.57617 -0.60351,0.30649 -1.03843,1.06517 -1.2461,2.17187 -0.24355,1.30043 -0.239,21.42491 0.006,22.5 0.4115,1.80781 1.06039,2.3312 3.18555,2.56446 0.49142,0.054 4.63516,0.0862 9.20703,0.0723 7.44102,-0.0226 8.39113,-0.0477 9.0625,-0.24023 1.20765,-0.3464 1.67604,-0.80148 2.02539,-1.96289 0.17841,-0.59326 0.21211,-1.68489 0.25391,-8.28321 0.0479,-7.5564 0.0468,-6.60393 -0.21875,-7.15257 -0.0736,-0.15205 -0.33859,-0.46265 -0.72266,-0.875 v 4.07422 c 0,0.12416 -0.0206,0.24218 -0.0488,0.35742 0.0246,3.83198 -0.0428,6.67596 -0.12305,10.47289 0.094,0.98908 -0.26416,2.20979 -1.37304,2.42969 -4.17852,0.21246 -8.39772,0.16055 -12.60547,0.18945 -2.09316,-0.0712 -4.2187,0.13385 -6.29102,-0.20117 -1.20786,-0.09 -1.37139,-1.432 -1.46679,-2.37696 -0.1751,-6.57883 -0.13104,-13.28191 -0.041,-19.88867 0.0853,-1.09208 -0.0376,-2.65795 1.18164,-3.16406 2.366,-0.42229 4.785,-0.2218 7.17578,-0.3125 0.61114,0.0344 0.29054,0.0147 0.94202,0.0117 0.059,-0.007 0.11677,-0.0176 0.17773,-0.0176 h 3.5918 c -0.42688,-0.30915 -0.78914,-0.52782 -1.16797,-0.68359 -0.60974,-0.25114 0.12581,-0.26372 -4.60217,-0.26172 z"
-         id="path4296"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cscscccscccccccccccccccccsccccccccccscccc" />
+         d="m 328.11882,241.43024 -2.03754,3.52755 -0.71327,-1.23641 h -0.001 -0.91754 v 0.45876 h 0.65491 l 0.97801,1.69399 0.26413,-0.45757 2.03874,-3.52936 h 2.94424 v 0.45817 h 0.45877 v -0.91513 z m 0.96326,1.51318 -0.84263,0.14861 v 0.11342 c 0.0629,-0.004 0.11913,-0.006 0.16756,-0.006 0.15132,0 0.26564,0.0286 0.34356,0.0851 0.0776,0.0568 0.14109,0.15372 0.18952,0.2906 0.0106,0.0295 0.0809,0.29933 0.21118,0.81044 -0.0526,0.11763 -0.16395,0.30926 -0.33422,0.57429 -0.17027,0.26503 -0.30504,0.43711 -0.40402,0.51713 -0.04,0.0337 -0.0725,0.0509 -0.0978,0.0509 -0.0295,0 -0.0716,-0.0244 -0.12605,-0.0728 -0.0758,-0.0671 -0.1474,-0.10078 -0.21479,-0.10078 -0.0671,0 -0.12394,0.0228 -0.17027,0.0692 -0.0463,0.0463 -0.0695,0.10439 -0.0695,0.17358 0,0.0779 0.0256,0.14019 0.0761,0.18621 0.0692,0.0611 0.1456,0.0915 0.22983,0.0915 0.11973,0 0.24428,-0.0523 0.37243,-0.15733 0.19765,-0.16396 0.46058,-0.53158 0.78848,-1.10135 0.13899,0.62453 0.23044,0.97831 0.27466,1.06043 0.0695,0.13237 0.16306,0.19825 0.28068,0.19825 0.08,0 0.17749,-0.0463 0.29331,-0.13869 0.20396,-0.16425 0.37273,-0.37002 0.5051,-0.6182 l -0.1107,-0.0568 c -0.0821,0.15553 -0.18111,0.28218 -0.29663,0.37905 -0.059,0.0481 -0.1104,0.0725 -0.15463,0.0725 -0.0274,0 -0.0545,-0.0157 -0.0818,-0.0475 -0.0274,-0.0337 -0.0611,-0.13357 -0.10108,-0.29963 l -0.25841,-1.08509 c 0.18109,-0.31348 0.33663,-0.52466 0.46719,-0.63417 0.0692,-0.0587 0.12905,-0.0884 0.17959,-0.0884 0.0337,0 0.0999,0.0171 0.19855,0.0508 0.0505,0.019 0.0981,0.0277 0.142,0.0277 0.0758,0 0.14319,-0.0258 0.20216,-0.0785 0.0316,-0.0295 0.0469,-0.0845 0.0469,-0.16425 0,-0.0695 -0.027,-0.12815 -0.0818,-0.17659 -0.0526,-0.0484 -0.12424,-0.0725 -0.21479,-0.0725 -0.0608,0 -0.11642,0.0106 -0.16696,0.0316 -0.08,0.0337 -0.17238,0.0963 -0.27737,0.18892 -0.10529,0.0902 -0.19464,0.18621 -0.26804,0.28729 l -0.27797,0.41666 c -0.0863,-0.32189 -0.14831,-0.52074 -0.18621,-0.59655 -0.0526,-0.10921 -0.13027,-0.2187 -0.23315,-0.32821 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path570"
+         style="display:inline;enable-background:new;fill:url(#linearGradient572);stroke-width:0.300832" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/libreoffice-startcenter.svg
+++ b/icons/src/fullcolor/default/apps/libreoffice-startcenter.svg
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="libreoffice-startcenter.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
      id="base"
-     pagecolor="#8e8e8e"
+     pagecolor="#ffffff"
      bordercolor="#000000"
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="1.38881"
-     inkscape:cy="212.02597"
-     inkscape:current-layer="layer5"
+     inkscape:zoom="2"
+     inkscape:cx="281"
+     inkscape:cy="190"
+     inkscape:current-layer="layer2"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -50,7 +50,7 @@
      gridtolerance="10000"
      inkscape:object-nodes="true"
      inkscape:snap-grids="true"
-     showguides="false"
+     showguides="true"
      inkscape:guide-bbox="true"
      inkscape:window-maximized="1"
      inkscape:bbox-paths="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,239 +93,214 @@
   <defs
      id="defs3">
     <linearGradient
-       id="linearGradient3976">
+       id="linearGradient3018"
+       x1="23.719999"
+       x2="22.785999"
+       y1="11.696"
+       y2="8.4789"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(65.128569,0,0,65.128569,-1309.891,-506.54657)">
       <stop
+         stop-color="#c72b0c"
          offset="0"
-         style="stop-color:#626262;stop-opacity:1"
-         id="stop3972" />
+         id="stop1443" />
       <stop
+         stop-color="#cc3206"
+         offset=".51348"
+         id="stop1445" />
+      <stop
+         stop-color="#e58102"
          offset="1"
-         style="stop-color:#4e4e4e;stop-opacity:1"
-         id="stop3974" />
+         id="stop1447" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3028"
+       x1="21.608999"
+       x2="22.791"
+       y1="11.283"
+       y2="11.837"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(65.128569,0,0,65.128569,-1309.891,-506.54657)">
+      <stop
+         stop-color="#eb233c"
+         offset="0"
+         id="stop1450" />
+      <stop
+         stop-color="#910505"
+         offset="1"
+         id="stop1452" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3008"
+       x1="21.190001"
+       x2="22.268999"
+       y1="11.457"
+       y2="8.7909002"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(65.128569,0,0,65.128569,-1309.891,-506.54657)">
+      <stop
+         stop-color="#b4327d"
+         offset="0"
+         id="stop1436" />
+      <stop
+         stop-color="#b4191e"
+         offset=".55628"
+         id="stop1438" />
+      <stop
+         stop-color="#820a05"
+         offset="1"
+         id="stop1440" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-5">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient3194"
-       x1="335.73108"
-       y1="62"
-       x2="352.26993"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
+       xlink:href="#linearGradient3008"
+       id="linearGradient24039"
        gradientUnits="userSpaceOnUse"
-       y2="169.66859"
-       x2="4.4137931"
-       y1="386.30838"
-       x1="494.34482"
-       id="linearGradient4226-1"
-       xlink:href="#linearGradient4338"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.96286,268)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6646"
-       x="-0.01363613"
-       width="1.0272723"
-       y="-0.01071443"
-       height="1.0214289">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.0000135"
-         id="feGaussianBlur6648" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6668"
-       x="-0.054544518"
-       width="1.109089"
-       y="-0.042857721"
-       height="1.0857154">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.000054"
-         id="feGaussianBlur6670" />
-    </filter>
+       gradientTransform="matrix(13.374617,0,0,13.374617,43.217801,-52.23639)"
+       x1="21.190001"
+       y1="11.457"
+       x2="22.268999"
+       y2="8.7909002" />
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient4338">
-      <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
-         offset="0"
-         id="stop4340" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="1"
-         id="stop4342" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3976"
-       id="linearGradient18935"
-       x1="352.77151"
-       y1="106.5"
-       x2="335.23242"
-       y2="61.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983-6">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985-0"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971-6">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1311"
-       x1="327.99951"
-       y1="188"
-       x2="335.99951"
-       y2="212"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1309"
-       x1="332"
-       y1="236"
-       x2="324"
-       y2="252"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3976"
-       id="linearGradient916"
+       xlink:href="#linearGradient3028"
+       id="linearGradient24041"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05664062,-0.05663901,0,349.74506,214)"
-       x1="44.137936"
-       y1="240.29004"
-       x2="450.20694"
-       y2="386.29437" />
+       gradientTransform="matrix(13.374617,0,0,13.374617,43.217801,-52.23639)"
+       x1="21.608999"
+       y1="11.283"
+       x2="22.791"
+       y2="11.837" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3976"
-       id="linearGradient920"
+       xlink:href="#linearGradient3018"
+       id="linearGradient24043"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.03604403,-0.03604301,0,339.56482,252.90909)"
-       x1="39.093575"
-       y1="240.26906"
-       x2="455.25125"
-       y2="401.58029" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient3976"
-       id="linearGradient18935-0"
-       x1="352.89749"
-       y1="106.50614"
-       x2="334.86411"
-       y2="61.500103"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="matrix(13.374617,0,0,13.374617,43.217801,-52.23639)"
+       x1="23.719999"
+       y1="11.696"
+       x2="22.785999"
+       y2="8.4789" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient4316"
-       x1="372"
-       y1="134"
-       x2="372"
-       y2="162"
+       xlink:href="#linearGradient3008"
+       id="linearGradient24053"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-37.000489)" />
+       gradientTransform="matrix(8.7225761,0,0,8.7225761,139.8377,59.150182)"
+       x1="21.190001"
+       y1="11.457"
+       x2="22.268999"
+       y2="8.7909002" />
     <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
        inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient18935-0-8"
-       x1="336.64893"
-       y1="59.040947"
-       x2="348.54202"
-       y2="108.83411"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3028"
+       id="linearGradient24055"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(8.7225761,0,0,8.7225761,139.8377,59.150182)"
+       x1="21.608999"
+       y1="11.283"
+       x2="22.791"
+       y2="11.837" />
     <linearGradient
-       gradientTransform="translate(0,-4e-6)"
        inkscape:collect="always"
-       xlink:href="#linearGradient3976"
-       id="linearGradient18820-3"
-       x1="201.07812"
-       y1="269.99988"
-       x2="102.92188"
-       y2="45.999878"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3018"
+       id="linearGradient24057"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(8.7225761,0,0,8.7225761,139.8377,59.150182)"
+       x1="23.719999"
+       y1="11.696"
+       x2="22.785999"
+       y2="8.4789" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3008"
+       id="linearGradient24067"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(6.6873083,0,0,6.6873083,181.60891,131.8818)"
+       x1="21.190001"
+       y1="11.457"
+       x2="22.268999"
+       y2="8.7909002" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3028"
+       id="linearGradient24069"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(6.6873083,0,0,6.6873083,181.60891,131.8818)"
+       x1="21.608999"
+       y1="11.283"
+       x2="22.791"
+       y2="11.837" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3018"
+       id="linearGradient24071"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(6.6873083,0,0,6.6873083,181.60891,131.8818)"
+       x1="23.719999"
+       y1="11.696"
+       x2="22.785999"
+       y2="8.4789" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3008"
+       id="linearGradient24081"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.3612877,0,0,4.3612877,229.91885,199.57509)"
+       x1="21.190001"
+       y1="11.457"
+       x2="22.268999"
+       y2="8.7909002" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3028"
+       id="linearGradient24083"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.3612877,0,0,4.3612877,229.91885,199.57509)"
+       x1="21.608999"
+       y1="11.283"
+       x2="22.791"
+       y2="11.837" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3018"
+       id="linearGradient24085"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.3612877,0,0,4.3612877,229.91885,199.57509)"
+       x1="23.719999"
+       y1="11.696"
+       x2="22.785999"
+       y2="8.4789" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3008"
+       id="linearGradient24087"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(65.128569,0,0,65.128569,-1312.6785,-507.412)"
+       x1="21.190001"
+       y1="11.457"
+       x2="22.268999"
+       y2="8.7909002" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3028"
+       id="linearGradient24089"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(65.128569,0,0,65.128569,-1312.6785,-507.412)"
+       x1="21.608999"
+       y1="11.283"
+       x2="22.791"
+       y2="11.837" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3018"
+       id="linearGradient24091"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(65.128569,0,0,65.128569,-1312.6785,-507.412)"
+       x1="23.719999"
+       y1="11.696"
+       x2="22.785999"
+       y2="8.4789" />
   </defs>
   <metadata
      id="metadata4">
@@ -424,7 +400,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">libreoffice-startcenter</tspan></text>
+           id="tspan924">libreoffice-startcenter</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -459,234 +435,98 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99158418;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 342.28786,133.99591 c -0.0832,0 -0.1556,0.007 -0.2168,0.0156 l -0.0371,0.006 -0.0371,0.0117 c -1.02052,0.30458 -1.3544,1.66824 -0.54687,2.36914 0,0 0,0.002 0,0.002 l 5.08984,4.76563 0.006,0.004 c 0.44144,0.39204 1.03582,0.39851 1.50781,0.21874 0.47199,-0.17975 0.9171,-0.5946 0.94141,-1.18945 v -0.01 -1.35352 -0.002 c 0.006,-1.0363 0.0251,-1.82214 -0.0176,-2.45508 -0.0427,-0.63344 -0.14348,-1.14825 -0.47266,-1.55274 -0.32917,-0.40448 -0.82834,-0.59266 -1.42968,-0.68554 -0.60135,-0.0929 -1.35232,-0.1114 -2.36133,-0.13281 h -0.006 -2.26953 c -0.0478,-0.005 -0.0951,-0.0117 -0.15039,-0.0117 z m -7.25782,0.002 -4.95507,0.002 c -2.79936,0 -4.57517,0.10197 -5.71875,1.13282 -0.24259,0.21892 -0.43083,0.4754 -0.5879,0.74414 -0.0117,0.02 -0.0564,0.0782 -0.11132,0.1875 -0.0907,0.18027 -0.17065,0.37241 -0.23828,0.57617 -0.0671,0.20198 -0.12496,0.41859 -0.17383,0.65039 -0.0486,0.23023 -0.0869,0.47111 -0.11914,0.72851 v 0.002 c -0.0646,0.51578 -0.10015,1.09026 -0.11524,1.73633 -0.007,0.32198 -0.0116,0.66266 -0.01,1.02343 v 8.21875 8.22071 c -0.002,0.3594 0.002,0.69873 0.01,1.02148 0.0151,0.64603 0.0505,1.22236 0.11524,1.73828 0.0323,0.25754 0.0707,0.4986 0.11914,0.72852 0.0971,0.4603 0.23097,0.86702 0.41211,1.22656 0.18147,0.36018 0.41279,0.67544 0.69922,0.93359 0.14342,0.12929 0.30075,0.24284 0.46679,0.34375 0.33271,0.20222 0.70911,0.35057 1.12891,0.46094 v 0.002 c 1.04936,0.27537 2.37421,0.32422 4.12305,0.32422 h 11.85546 c 0.69562,0 1.32241,-0.0101 1.89063,-0.0371 h 0.002 c 0.23885,-0.0115 0.45772,-0.0289 0.66992,-0.0469 h 0.002 0.002 c 0.006,-5.4e-4 0.052,-0.004 0.0898,-0.006 h 0.0137 c 0.0155,-0.001 0.0141,-1.1e-4 0.0332,-0.002 h 0.002 c 0.51385,-0.0486 0.97388,-0.12251 1.38867,-0.23047 0.20576,-0.0536 0.4054,-0.11525 0.59571,-0.19141 0.18901,-0.0755 0.36479,-0.163 0.52929,-0.26172 0.1657,-0.0995 0.3216,-0.21271 0.46485,-0.33984 0.12928,-0.11465 0.24087,-0.23957 0.34179,-0.36524 0,2e-5 0.005,-0.005 0.006,-0.006 l 0.0215,-0.0215 0.0156,-0.0195 0.006,-0.008 0.002,-0.004 0.008,-0.008 0.008,-0.0137 c 4e-5,-7e-5 0.008,-0.016 0.0117,-0.0234 0.003,-0.004 0.009,-0.008 0.0117,-0.0117 -5.4e-4,7e-4 -0.007,0.003 -0.008,0.004 0.01,-0.0181 0.0172,-0.0306 0.0254,-0.0469 -0.006,0.0128 -0.01,0.0233 -0.0117,0.0273 0.095,-0.13149 0.18742,-0.26844 0.26562,-0.41992 0.0922,-0.17881 0.17175,-0.3686 0.24024,-0.56836 0.069,-0.20111 0.12594,-0.41283 0.17578,-0.63867 0.0501,-0.22709 0.0911,-0.46643 0.125,-0.71875 0.0307,-0.22912 0.0546,-0.4717 0.0742,-0.71875 l 0.002,-0.002 v -0.004 c -10e-4,0.0185 0.005,-0.009 0.01,-0.082 v -0.002 c 0.002,-0.0307 0.004,-0.0623 0,-0.006 v -0.002 -0.002 c 0.0411,-0.56466 0.0568,-1.18956 0.0586,-1.89062 v -0.004 -11.1875 c -0.007,-1.5618 -1.32097,-2.69049 -2.26758,-3.50391 l -0.01,-0.008 -0.002,-0.002 -6.71093,-6.47461 -0.008,-0.006 c -1.54333,-1.391 -2.79437,-2.15039 -4.97461,-2.15039 z"
-         id="path964-1-7-1"
-         inkscape:connector-curvature="0" />
+         d="m 178.24465,81.42192 -55.75981,21.89099 c 0,0 -14.04304,5.57632 -14.04304,12.18425 v 81.99038 c 0,0 0.4038,4.36165 -0.91373,5.53004 -1.31432,1.16842 -25.993486,16.93932 -25.993486,16.93932 0,0 -5.76452,1.60149 -9.00143,0 -3.23624,-1.60153 -6.66329,-4.5525 -6.66329,-7.69432 V 104.23384 c 0,0 -0.37774,-10.48569 2.7608,-13.1514 3.14115,-2.66508 78.147786,-45.11978 78.147786,-45.11978 0,0 6.16832,-3.57362 15.33514,-1.07658 8.62956,2.3505 19.65062,7.8786 16.12848,36.53714 z"
+         fill="url(#linearGradient3008)"
+         id="path4545"
+         style="display:inline;fill:url(#linearGradient24087);stroke-width:65.1287;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.13511628;marker:none;enable-background:accumulate"
-         d="m 334.25586,134.71289 c -0.45236,0.0121 -0.90224,0.0272 -1.33594,0.006 -2.52549,0.19734 -5.18742,-0.29143 -7.57031,0.5625 -1.22203,1.79732 -0.53543,4.18481 -0.77344,6.22656 0.0816,5.97656 -0.25479,11.9827 0.23438,17.94141 0.31504,2.23143 2.92802,1.8499 4.54297,1.88476 5.47813,-0.0313 10.98834,0.22939 16.44726,-0.22656 1.82302,-0.71065 1.25717,-3.16493 1.46875,-4.67383 0.0755,-3.85966 0.0248,-7.72188 0.0391,-11.58203 -2.69482,-3.40969 -6.0967,-6.20501 -9.31836,-9.10351 -1.00037,-1.08075 -2.37728,-1.07153 -3.73437,-1.03516 z"
-         id="rect4158-92-6-7-3"
-         inkscape:connector-curvature="0" />
+         d="m 176.48617,221.8326 h -71.15946 c 0,0 -6.327252,-0.4038 -8.884856,4.17342 -2.55759,4.57725 -2.15379,9.96206 0.13664,11.57724 2.288654,1.61519 49.540726,28.27036 51.425536,29.2128 1.88481,0.94241 9.69243,2.82722 17.2988,-1.68295 12.2507,-5.11582 11.95954,-9.69243 11.15195,-25.71276 0,-12.02401 0.11088,-13.23477 0.0336,-17.56842 z"
+         fill="url(#linearGradient3028)"
+         id="path4547"
+         style="display:inline;fill:url(#linearGradient24089);stroke-width:65.1287;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.13511628;marker:none;enable-background:accumulate"
-         d="m 342.43453,133.5 c -0.0499,0 -0.0992,0.005 -0.14846,0.0114 -0.63275,0.19268 -0.84778,1.10823 -0.35998,1.53887 l 5.15449,4.82872 c 0.52901,0.47937 1.38249,0.0699 1.41036,-0.62634 v -1.36063 c 0.0226,-4.21424 0.33006,-4.29412 -3.66401,-4.38062 h -2.24263 c -0.0493,-0.007 -0.0999,-0.0114 -0.14977,-0.0114 z m -12.63559,0.0804 c -5.53701,-3.3e-4 -6.32794,0.58227 -6.29884,6.26467 v 8.19515 8.19514 c -0.0291,5.68242 1.00827,6.26467 6.54528,6.26467 h 11.7978 c 5.49726,0 6.52858,-0.57993 6.54266,-6.15295 v -11.14923 c -0.006,-1.25658 -1.15546,-2.31787 -2.08629,-3.11916 l -0.008,-0.006 -6.70166,-6.47491 c -1.50985,-1.36345 -2.55339,-2.01695 -4.61908,-2.01707 z m 7.22852,2.4196 8.97205,8.99977 V 158 c 0,0 -0.11213,1.17819 -0.44846,1.49951 -0.33633,0.32134 -1.56951,0.42847 -1.56951,0.42847 h -15.96407 c 0,0 -1.23318,-0.10713 -1.56951,-0.42847 C 326.11164,159.17819 325.99951,158 325.99951,158 l -0.018,-20.07203 c 0,0 0.11213,-1.17819 0.44845,-1.49951 C 326.76633,136.10713 327.99951,136 327.99951,136 Z"
-         id="rect4158-92-6-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 161.70199,44.80663 c 0,0 14.40906,5.01659 14.40906,16.02033 0,0 -0.007,117.13373 -0.007,189.95397 0,8.06291 -7.26249,13.21327 -17.35678,16.84811 l 65.89711,-19.92412 c 0,0 13.46206,-3.50003 13.46206,-16.96209 V 85.69498 c 0,0 1.11761,-15.13523 -8.78259,-19.60955 C 219.42369,61.61174 161.7009,44.80857 161.7009,44.80857 Z"
+         fill="url(#linearGradient3018)"
+         id="path4549"
+         style="display:inline;fill:url(#linearGradient24091);stroke-width:65.1287;enable-background:new" />
       <path
-         style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 323.49951,148 v 0.041 8.19531 c -0.0291,5.68242 1.00791,6.26367 6.54492,6.26367 h 11.79883 c 5.49726,0 6.52889,-0.57932 6.54297,-6.15234 V 148 Z"
-         id="rect4398"
-         inkscape:connector-curvature="0" />
+         d="m 349.38952,68.684859 -11.45067,4.495472 c 0,0 -2.88384,1.145137 -2.88384,2.502123 v 16.83731 c 0,0 0.0829,0.895696 -0.18764,1.135633 -0.26991,0.239943 -5.33795,3.47861 -5.33795,3.47861 0,0 -1.18378,0.328878 -1.84851,0 -0.66458,-0.328885 -1.36835,-0.934888 -1.36835,-1.580083 V 73.369451 c 0,0 -0.0776,-2.153313 0.56695,-2.700735 0.64506,-0.547294 16.0482,-9.265669 16.0482,-9.265669 0,0 1.26671,-0.733869 3.14918,-0.221084 1.77215,0.482692 4.0354,1.617927 3.3121,7.503163 z"
+         fill="url(#linearGradient3008)"
+         id="path24031"
+         style="display:inline;fill:url(#linearGradient24039);stroke-width:13.3746;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 353.50267,61.372958 c -0.13268,1.31e-4 -0.25604,0.01264 -0.36719,0.0293 l -0.0781,0.01172 -0.0762,0.02344 c -0.87574,0.279121 -1.39412,1.031903 -1.56445,1.792968 -0.1518,0.678132 0.0116,1.444638 0.51367,2.050782 l -0.36328,-0.363282 -0.01,-0.0078 -0.002,-0.0039 c 0,0 -0.002,0.0038 -0.002,0.0039 -0.28283,-0.2673 -0.55686,-0.524524 -0.83398,-0.767578 h -0.002 l -0.002,-0.0039 -0.002,-0.002 c 0,0 -0.006,-0.0019 -0.006,-0.002 -0.2711,-0.237536 -0.5406,-0.460957 -0.81055,-0.669922 0,0 -0.006,-0.0038 -0.006,-0.0039 -1.8e-4,-8.7e-5 -0.006,-0.0038 -0.006,-0.0039 -0.26922,-0.208011 -0.54257,-0.405967 -0.82617,-0.587891 h -0.002 l -0.002,-0.002 c 0,10e-7 -0.004,-0.0019 -0.004,-0.002 -0.27684,-0.177258 -0.55998,-0.341168 -0.85742,-0.488281 1e-5,0 -0.006,-0.0019 -0.006,-0.002 -0.29595,-0.146081 -0.60404,-0.275888 -0.92383,-0.386719 l -0.004,-0.002 h -0.002 -0.002 c -0.31787,-0.109783 -0.64897,-0.202793 -0.99414,-0.275391 0,-10e-7 -0.009,7.3e-5 -0.01,0 -0.34183,-0.07151 -0.69666,-0.126987 -1.07031,-0.162109 h -0.002 c -0.37669,-0.03533 -0.76878,-0.05072 -1.17774,-0.05078 h -0.002 -8.26738 c -4.1516,0 -6.86541,0.144562 -8.65234,1.832031 -0.89392,0.844181 -1.42053,2.015243 -1.71289,3.464843 -0.29235,1.449602 -0.3762,2.716408 -0.36524,4.956832 V 84.497515 97.24947 c -0.0108,2.23702 0.0732,4.00312 0.36524,5.45117 0.29236,1.44961 0.81896,2.62067 1.71289,3.46485 0.22046,0.20818 0.46372,0.3989 0.72656,0.5664 l 0.004,0.002 0.006,0.004 c 0,0 0.011,0.004 0.0117,0.004 0.24938,0.15738 0.51414,0.29744 0.79688,0.41797 l 0.006,0.002 c 10e-4,5.8e-4 0.003,0.003 0.004,0.004 h 0.002 c 0.001,2.9e-4 0.01,0.003 0.0117,0.004 0.28562,0.12045 0.58739,0.22665 0.90625,0.31446 h 0.002 0.002 c 0.31721,0.0872 0.65158,0.16192 1.00586,0.22265 h 0.004 0.002 0.002 c 0.35215,0.0602 0.71743,0.1063 1.10157,0.14453 2e-5,0 0.005,-1e-5 0.006,0 0.38435,0.0381 0.78775,0.0683 1.21289,0.0899 h 0.004 0.002 c 4.7e-4,1e-5 0.005,-1e-5 0.006,0 l 0.004,0.002 c 3.5e-4,1e-5 0.0746,-7e-5 0.0723,0 0.83602,0.0405 3.76301,0.0566 2.7539,0.0566 h 0.002 17.03691 c 4.12301,0 6.31689,-0.14175 8.10202,-1.80273 0.89298,-0.83017 1.42413,-1.9843 1.72461,-3.41016 0.30048,-1.42587 0.39703,-3.16132 0.40234,-5.35937 v -18.908211 -0.002 c -0.009,-1.901937 -1.18883,-3.38937 -2.32226,-4.541016 -0.37676,-0.382884 -0.75737,-0.733609 -1.10938,-1.050781 l -0.28515,-0.257813 h 0.0273 l -0.0117,-0.01172 h -0.002 l -0.0508,-0.05078 c 0.7203,0.562642 1.63962,0.613597 2.36523,0.31836 0.78035,-0.317514 1.50219,-1.045367 1.54102,-2.060547 v -0.01953 -1.63066 -0.0059 c 0.008,-1.627913 0.0362,-2.86715 -0.0274,-3.875 -0.0638,-1.009375 -0.2058,-1.850441 -0.73633,-2.546875 -0.53053,-0.696434 -1.36221,-1.029213 -2.28515,-1.181641 -0.92293,-0.152428 -2.03533,-0.179157 -3.52344,-0.21289 h -0.0117 -2.84421 -0.002 c -0.073,-0.0069 -0.14393,-0.0174 -0.2207,-0.01758 z m -24.57206,43.876752 c 7.7e-4,4.2e-4 10e-4,0.002 0.002,0.002 -0.0334,0.003 -0.0689,0.006 -0.0684,0.006 5.2e-4,-8e-5 0.0335,-0.004 0.0664,-0.008 z m -0.0312,1.98438 c 0.005,2.6e-4 0.0335,0.004 0.0645,0.006 -0.0263,-10e-4 -0.0586,-0.004 -0.0586,-0.004 z"
-         id="path964-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccscccccccccccccccccccccccccccccccscsccccccccccccccccccsccccccccccccccc" />
+         d="M 349.02841,97.519196 H 334.4153 c 0,0 -1.29934,-0.08292 -1.82457,0.857041 -0.52521,0.939971 -0.44229,2.045783 0.0281,2.377473 0.47,0.33169 10.17355,5.80552 10.56061,5.99905 0.38705,0.19353 1.99041,0.58059 3.55243,-0.3456 2.51577,-1.05057 2.45597,-1.99041 2.29013,-5.2803 0,-2.469218 0.0228,-2.717856 0.007,-3.607802 z"
+         fill="url(#linearGradient3028)"
+         id="path24033"
+         style="display:inline;fill:url(#linearGradient24041);stroke-width:13.3746;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6668);enable-background:accumulate"
-         d="M 102.92188 46 C 67.62515 46 64 49.625611 64 84.994141 L 64 156 L 64 158 L 64 229.00586 C 64 244.47959 64.69332 253.87799 68.429688 259.55469 C 68.963453 260.36564 69.559812 261.0997 70.224609 261.76562 C 75.542988 267.0931 85.273502 268 102.92188 268 L 201.07812 268 C 203.13276 268 205.06552 267.98518 206.91211 267.95508 C 207.57101 267.94428 208.1733 267.9199 208.80664 267.9043 C 209.95599 267.876 211.09853 267.8452 212.16602 267.79883 C 213.43596 267.74363 214.67536 267.67931 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.44517 267.45882 217.67424 267.44102 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67577 267.09975 221.31832 267.00362 221.94336 266.90039 C 222.16533 266.86369 222.37512 266.82019 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.01019 266.50659 224.24912 266.45017 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.69251 266.09626 225.94528 266.02572 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.98625 265.36467 228.26277 265.25859 228.53516 265.14844 C 228.73131 265.06914 228.92945 264.98988 229.11914 264.90625 C 229.3939 264.78514 229.6565 264.65577 229.91797 264.52539 C 230.0924 264.43839 230.27277 264.35491 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.02943 263.29518 232.41788 263.01413 232.78711 262.71484 C 233.12677 262.43952 233.44633 262.14559 233.75586 261.8418 C 233.83036 261.7687 233.90178 261.69201 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01257 256.99161 237.07571 256.85555 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.81286 254.90311 237.95901 254.4144 238.09961 253.91406 C 238.14041 253.7689 238.17961 253.62078 238.21875 253.47266 C 238.28325 253.22887 238.34214 252.97259 238.40234 252.7207 C 238.54618 252.11901 238.67815 251.49292 238.79883 250.84375 C 238.83073 250.67198 238.86618 250.50525 238.89648 250.33008 C 239.03717 249.51898 239.16395 248.67505 239.27344 247.78906 C 239.29544 247.61129 239.31328 247.41914 239.33398 247.23828 C 239.41648 246.52006 239.48974 245.77779 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78859 241.4566 239.80646 241.21235 239.81836 240.95312 C 239.82536 240.80563 239.82738 240.64128 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96989 235.43296 239.97567 235.00563 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 128.24023 C 239.956 118.50733 231.82093 110.28461 225.23828 104.07812 L 225.18945 104.02734 L 184.66602 61.619141 C 173.98913 51.057981 166.6082 46 152 46 L 102.92188 46 z M 199.9043 46.089844 C 197.73512 48.865721 197.51891 53.493389 200.11328 56.001953 L 228.60938 86.388672 C 232.33314 90.084594 239.72783 86.956935 239.99023 81.609375 C 239.9886 81.189355 239.99156 80.748144 239.98828 80.337891 C 239.98738 79.846541 239.97958 79.384529 239.97656 78.90625 C 239.61491 51.652251 235.0161 46.715732 208.63086 46.089844 L 199.9043 46.089844 z "
-         id="path5316-1" />
+         d="m 345.99237,61.165648 c 0,0 2.959,1.030192 2.959,3.289889 0,0 -10e-4,24.054249 -10e-4,39.008403 0,1.65578 -1.49141,2.71344 -3.56434,3.45988 l 13.53244,-4.09156 c 0,0 2.76453,-0.71875 2.76453,-3.483285 V 69.562362 c 0,0 0.22951,-3.108127 -1.80357,-4.026961 -2.03307,-0.918704 -13.88685,-4.369355 -13.88685,-4.369355 z"
+         fill="url(#linearGradient3018)"
+         id="path24035"
+         style="display:inline;fill:url(#linearGradient24043);stroke-width:13.3746;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6646);enable-background:accumulate"
-         d="M 102.92188 45 C 67.62515 45 64 48.625611 64 83.994141 L 64 156 L 64 157 L 64 229.00586 C 64 244.47959 64.69332 253.87799 68.429688 259.55469 C 68.963453 260.36564 69.559812 261.0997 70.224609 261.76562 C 75.542988 267.0931 85.273502 268 102.92188 268 L 201.07812 268 C 203.13276 268 205.06552 267.98518 206.91211 267.95508 C 207.57101 267.94428 208.1733 267.9199 208.80664 267.9043 C 209.95599 267.876 211.09853 267.8452 212.16602 267.79883 C 213.43596 267.74363 214.67536 267.67931 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.44517 267.45882 217.67424 267.44102 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67577 267.09975 221.31832 267.00362 221.94336 266.90039 C 222.16533 266.86369 222.37512 266.82019 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.01019 266.50659 224.24912 266.45017 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.69251 266.09626 225.94528 266.02572 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.98625 265.36467 228.26277 265.25859 228.53516 265.14844 C 228.73131 265.06914 228.92945 264.98988 229.11914 264.90625 C 229.3939 264.78514 229.6565 264.65577 229.91797 264.52539 C 230.0924 264.43839 230.27277 264.35491 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.02943 263.29518 232.41788 263.01413 232.78711 262.71484 C 233.12677 262.43952 233.44633 262.14559 233.75586 261.8418 C 233.83036 261.7687 233.90178 261.69201 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01257 256.99161 237.07571 256.85555 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.81286 254.90311 237.95901 254.4144 238.09961 253.91406 C 238.14041 253.7689 238.17961 253.62078 238.21875 253.47266 C 238.28325 253.22887 238.34214 252.97259 238.40234 252.7207 C 238.54618 252.11901 238.67815 251.49292 238.79883 250.84375 C 238.83073 250.67198 238.86618 250.50525 238.89648 250.33008 C 239.03717 249.51898 239.16395 248.67505 239.27344 247.78906 C 239.29544 247.61129 239.31328 247.41914 239.33398 247.23828 C 239.41648 246.52006 239.48974 245.77779 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78859 241.4566 239.80646 241.21235 239.81836 240.95312 C 239.82536 240.80563 239.82738 240.64128 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96989 235.43296 239.97567 235.00563 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 127.24023 C 239.956 117.50733 231.82093 109.28462 225.23828 103.07812 L 225.18945 103.02734 L 184.66602 60.619141 C 173.98913 50.057981 166.6082 45 152 45 L 102.92188 45 z M 200.89062 45.089844 C 197.85089 47.592149 197.17007 53.156086 200.11328 56.001953 L 228.60938 86.388672 C 232.33829 90.089704 239.75115 86.948987 239.99414 81.587891 C 239.99392 81.377038 239.99278 81.169387 239.99219 80.960938 C 239.99209 79.762634 239.97942 78.632386 239.9668 77.509766 C 239.56354 50.620533 234.88168 45.712543 208.63086 45.089844 L 200.89062 45.089844 z "
-         id="path5316-84" />
+         d="m 339.51491,138.01187 -7.46783,2.93183 c 0,0 -1.88076,0.74682 -1.88076,1.63182 v 10.98085 c 0,0 0.0541,0.58415 -0.12238,0.74063 -0.17602,0.15648 -3.48127,2.26866 -3.48127,2.26866 0,0 -0.77203,0.21448 -1.20555,0 -0.43342,-0.21449 -0.8924,-0.60971 -0.8924,-1.03049 v -14.46814 c 0,0 -0.0506,-1.40433 0.36975,-1.76134 0.42069,-0.35693 10.46622,-6.04283 10.46622,-6.04283 0,0 0.82611,-0.47861 2.05381,-0.14419 1.15575,0.3148 2.63178,1.05517 2.16007,4.89337 z"
+         fill="url(#linearGradient3008)"
+         id="path24045"
+         style="display:inline;fill:url(#linearGradient24053);stroke-width:8.72259;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="M 102.92188 44 C 100.74614 44 98.695529 44.014677 96.753906 44.048828 C 67.272036 44.576673 64.085938 49.836144 64.085938 82.994141 L 64.085938 156 L 64.085938 229.00586 C 64.085938 262.16386 67.272036 267.42333 96.753906 267.95117 C 98.695529 267.98532 100.74614 268 102.92188 268 C 102.95214 268.00001 102.9775 268 103.00781 268 L 201.07812 268 C 203.13276 268 205.06552 267.98518 206.91211 267.95508 C 207.57101 267.94428 208.1733 267.9199 208.80664 267.9043 C 209.95599 267.876 211.09853 267.8452 212.16602 267.79883 C 213.43596 267.74363 214.67536 267.67931 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.44517 267.45882 217.67424 267.44102 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67577 267.09975 221.31832 267.00362 221.94336 266.90039 C 222.16533 266.86369 222.37512 266.82019 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.01019 266.50659 224.24912 266.45017 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.69251 266.09626 225.94528 266.02572 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.98625 265.36467 228.26277 265.25859 228.53516 265.14844 C 228.73131 265.06914 228.92945 264.98988 229.11914 264.90625 C 229.3939 264.78514 229.6565 264.65577 229.91797 264.52539 C 230.0924 264.43839 230.27277 264.35491 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.02943 263.29518 232.41788 263.01413 232.78711 262.71484 C 233.12677 262.43952 233.44633 262.14559 233.75586 261.8418 C 233.83036 261.7687 233.90178 261.69201 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01257 256.99161 237.07571 256.85555 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.81286 254.90311 237.95901 254.4144 238.09961 253.91406 C 238.14041 253.7689 238.17961 253.62078 238.21875 253.47266 C 238.28325 253.22887 238.34214 252.97259 238.40234 252.7207 C 238.54618 252.11901 238.67815 251.49292 238.79883 250.84375 C 238.83073 250.67198 238.86618 250.50525 238.89648 250.33008 C 239.03717 249.51898 239.16395 248.67505 239.27344 247.78906 C 239.29544 247.61129 239.31328 247.41914 239.33398 247.23828 C 239.41648 246.52006 239.48974 245.77779 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78859 241.4566 239.80646 241.21235 239.81836 240.95312 C 239.82536 240.80563 239.82738 240.64128 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96989 235.43296 239.97567 235.00563 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 126.24023 C 239.956 116.50733 231.82093 108.28461 225.23828 102.07812 L 225.18945 102.02734 L 184.66602 59.619141 C 173.98909 49.05803 166.6082 44 152 44 L 102.92188 44 z M 202.6543 44.089844 C 198.17969 45.582244 196.66368 52.666443 200.11328 56.001953 L 228.60938 86.388672 C 232.34293 90.094303 239.77066 86.941636 239.99609 81.568359 C 240.04429 50.239345 236.44281 44.749576 208.63086 44.089844 L 202.6543 44.089844 z "
-         id="path5316-3" />
+         d="m 339.2794,156.81687 h -9.53028 c 0,0 -0.8474,-0.0541 -1.18994,0.55894 -0.34253,0.61302 -0.28845,1.3342 0.0183,1.55052 0.30652,0.21632 6.63492,3.78621 6.88735,3.91243 0.25243,0.12622 1.29809,0.37865 2.3168,-0.22539 1.64072,-0.68516 1.60173,-1.2981 1.49357,-3.44368 0,-1.61036 0.0149,-1.77251 0.005,-2.35291 z"
+         fill="url(#linearGradient3028)"
+         id="path24047"
+         style="display:inline;fill:url(#linearGradient24055);stroke-width:8.72259;enable-background:new" />
       <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
+         d="m 337.29938,133.10803 c 0,0 1.92978,0.67187 1.92978,2.14558 0,0 -9.4e-4,15.68756 -9.4e-4,25.44027 0,1.07985 -0.97265,1.76963 -2.32456,2.25644 l 8.8255,-2.66841 c 0,0 1.80296,-0.46875 1.80296,-2.27171 v -19.42605 c 0,0 0.14968,-2.02704 -1.17624,-2.62628 -1.32592,-0.59915 -9.05665,-2.84958 -9.05665,-2.84958 z"
+         fill="url(#linearGradient3018)"
+         id="path24049"
+         style="display:inline;fill:url(#linearGradient24057);stroke-width:8.72259;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188,44.000001 C 67.62516,44.000001 64,47.625611 64,82.994141 V 156 229.00586 C 64,264.37439 67.62516,268 102.92188,268 h 98.15625 C 236.37486,268 240.17299,264.37398 240,229.00586 V 126.24023 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 C 173.98919,49.057941 166.6082,44.000001 152,44.000001 Z"
-         id="path5316"
-         inkscape:connector-curvature="0" />
+         d="m 334.69477,192.34243 -5.72534,2.24773 c 0,0 -1.44192,0.57257 -1.44192,1.25106 v 8.41866 c 0,0 0.0415,0.44785 -0.0938,0.56782 -0.13495,0.11997 -2.66897,1.7393 -2.66897,1.7393 0,0 -0.5919,0.16444 -0.92426,0 -0.33229,-0.16444 -0.68418,-0.46744 -0.68418,-0.79004 v -11.09224 c 0,0 -0.0388,-1.07665 0.28348,-1.35036 0.32253,-0.27365 8.0241,-4.63284 8.0241,-4.63284 0,0 0.63336,-0.36693 1.57459,-0.11054 0.88607,0.24135 2.0177,0.80896 1.65605,3.75158 z"
+         fill="url(#linearGradient3008)"
+         id="path24059"
+         style="display:inline;fill:url(#linearGradient24067);stroke-width:6.68732;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
+         d="m 334.51421,206.7596 h -7.30655 c 0,0 -0.64968,-0.0415 -0.91229,0.42852 -0.26261,0.46998 -0.22115,1.02289 0.014,1.18873 0.235,0.16585 5.08677,2.90276 5.2803,2.99953 0.19353,0.0968 0.99521,0.29029 1.77622,-0.1728 1.25788,-0.52529 1.22799,-0.99521 1.14507,-2.64015 0,-1.23461 0.0114,-1.35893 0.003,-1.8039 z"
+         fill="url(#linearGradient3028)"
+         id="path24061"
+         style="display:inline;fill:url(#linearGradient24069);stroke-width:6.68732;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.5,62.558594 c -2.56739,0.197545 -5.5956,-0.248988 -7.71484,1.501953 -1.61265,2.60175 -1.03276,5.900036 -1.25782,8.810547 -0.0569,9.221434 -0.24244,18.470385 0.19922,27.664066 0.0895,2.14893 1.2461,4.53645 3.67383,4.66015 6.74091,0.43986 13.59594,0.16181 20.38281,0.19141 2.87871,-0.17687 5.86199,0.25414 8.63282,-0.70508 2.29464,-1.50171 1.65229,-4.5939 1.875,-6.929687 0.0177,-6.805603 0.31687,-13.702294 -0.0352,-20.529297 -0.80743,-1.843671 -2.64468,-3.112144 -3.91406,-4.638672 -3.22271,-3.095747 -6.137,-6.592984 -9.78125,-9.205078 -2.23017,-1.377899 -4.99737,-0.515898 -7.48828,-0.802734 -1.52414,-0.01856 -3.04804,-0.03334 -4.57227,-0.01758 z"
-         id="path964"
-         inkscape:connector-curvature="0" />
+         d="m 332.99619,188.58282 c 0,0 1.4795,0.5151 1.4795,1.64495 0,0 -7.2e-4,12.02712 -7.2e-4,19.5042 0,0.82789 -0.7457,1.35672 -1.78217,1.72994 l 6.76622,-2.04578 c 0,0 1.38227,-0.35938 1.38227,-1.74165 v -14.8933 c 0,0 0.11475,-1.55407 -0.90178,-2.01348 -1.01654,-0.45935 -6.94343,-2.18468 -6.94343,-2.18468 z"
+         fill="url(#linearGradient3018)"
+         id="path24063"
+         style="display:inline;fill:url(#linearGradient24071);stroke-width:6.68732;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.20550393;marker:none;enable-background:accumulate"
-         d="m 353.5,61.375 c -0.0742,0 -0.1474,0.0066 -0.2207,0.01758 -0.94065,0.29981 -1.26034,1.724451 -0.53516,2.394531 l 7.51367,7.513672 c 0.78643,0.74591 2.35309,0.108771 2.39453,-0.974609 v -2.117188 c 0.0336,-6.55752 0.34204,-6.681806 -5.5957,-6.816406 h -3.33398 C 353.64936,61.381278 353.57418,61.375 353.5,61.375 Z M 335.23047,61.5 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 V 84 96.751953 c -0.0433,8.842037 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70563,-0.9024 9.72656,-9.574219 V 78.021484 c -0.009,-1.95527 -1.71775,-3.606675 -3.10156,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 C 348.62066,62.51706 347.069,61.5 343.99805,61.5 Z M 346.5,65 359,77.5 V 100 c 0,0 -0.1667,1.8333 -0.6667,2.3333 C 357.8333,102.8333 356,103 356,103 h -24 c 0,0 -1.8333,-0.1667 -2.3333,-0.6667 C 329.1667,101.8333 329,100 329,100 V 68 c 0,0 0.1667,-1.8333 0.6667,-2.3333 C 330.1667,65.1667 332,65 332,65 Z"
-         id="rect4158-92-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 329.75745,239.00593 -3.73392,1.46592 c 0,0 -0.94038,0.37341 -0.94038,0.81591 v 5.49042 c 0,0 0.027,0.29208 -0.0612,0.37032 -0.088,0.0782 -1.74064,1.13433 -1.74064,1.13433 0,0 -0.38602,0.10724 -0.60277,0 -0.21672,-0.10725 -0.44621,-0.30486 -0.44621,-0.51525 v -7.23406 c 0,0 -0.0253,-0.70217 0.18488,-0.88068 0.21034,-0.17846 5.23311,-3.02141 5.23311,-3.02141 0,0 0.41306,-0.23931 1.02691,-0.0721 0.57787,0.1574 1.31589,0.52758 1.08003,2.44668 z"
+         fill="url(#linearGradient3008)"
+         id="path24073"
+         style="display:inline;fill:url(#linearGradient24081);stroke-width:4.3613;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.90435,236.5 c 0.71048,0 1.27344,0.0154 1.75195,0.0957 0.47851,0.0803 0.89671,0.23728 1.20703,0.54688 0.31032,0.30959 0.46726,0.7261 0.54688,1.20508 0.0796,0.47897 0.0933,1.04352 0.0898,1.75586 V 244 v 3.89844 c 0.003,0.71121 -0.0103,1.27546 -0.0898,1.7539 -0.0796,0.47898 -0.23655,0.89549 -0.54688,1.20508 -0.31033,0.3096 -0.72851,0.46655 -1.20703,0.54688 -0.47852,0.0803 -1.04147,0.0957 -1.75195,0.0957 h -5.8086 c -0.71048,0 -1.27236,-0.0153 -1.75,-0.0957 -0.47763,-0.0804 -0.89584,-0.23713 -1.20508,-0.54688 -0.30921,-0.30975 -0.46469,-0.72681 -0.54492,-1.20508 -0.0802,-0.47826 -0.0957,-1.04201 -0.0957,-1.7539 V 244 240.10156 c 0,-0.71189 0.0155,-1.27564 0.0957,-1.7539 0.0802,-0.47827 0.2357,-0.89533 0.54492,-1.20508 0.30924,-0.30975 0.72745,-0.4665 1.20508,-0.54688 0.47764,-0.0804 1.03952,-0.0957 1.75,-0.0957 z"
-         id="path918"
-         inkscape:connector-curvature="0" />
+         d="m 329.63969,248.40843 h -4.76514 c 0,0 -0.4237,-0.027 -0.59496,0.27947 -0.17127,0.30652 -0.14423,0.66711 0.009,0.77526 0.15325,0.10816 3.31745,1.89311 3.44367,1.95622 0.12621,0.0631 0.64905,0.18932 1.1584,-0.1127 0.82036,-0.34258 0.80086,-0.64905 0.74678,-1.72184 0,-0.80517 0.007,-0.88625 0.002,-1.17645 z"
+         fill="url(#linearGradient3028)"
+         id="path24075"
+         style="display:inline;fill:url(#linearGradient24083);stroke-width:4.3613;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 336.13453,188.5 c 1.11158,0 1.98683,0.0256 2.70703,0.14648 0.72019,0.1209 1.3105,0.34863 1.74218,0.7793 0.43169,0.43067 0.65954,1.01974 0.7793,1.74024 0.11977,0.72049 0.14217,1.59669 0.13672,2.71093 V 200 v 6.125 c 0.005,1.1131 -0.017,1.989 -0.13672,2.70898 -0.11976,0.72051 -0.3476,1.30957 -0.7793,1.74024 -0.43169,0.43067 -1.02199,0.6584 -1.74218,0.7793 -0.7202,0.12089 -1.59545,0.14648 -2.70703,0.14648 h -8.26954 c -1.11158,0 -1.98637,-0.0255 -2.70507,-0.14648 -0.7187,-0.12095 -1.30623,-0.34848 -1.73633,-0.7793 -0.4301,-0.43083 -0.6566,-1.01849 -0.77735,-1.73828 -0.12074,-0.71979 -0.14648,-1.59713 -0.14648,-2.71094 V 200 193.875 c 0,-1.11381 0.0257,-1.99115 0.14648,-2.71094 0.12075,-0.71979 0.34725,-1.30745 0.77735,-1.73828 0.4301,-0.43082 1.01763,-0.65835 1.73633,-0.7793 0.7187,-0.12094 1.59349,-0.14648 2.70507,-0.14648 z"
-         id="path914"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1309);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0962,238 c -0.6888,0 -1.1839,0.0205 -1.5039,0.0742 -0.30449,0.0511 -0.38369,0.11806 -0.39649,0.13086 -0.0131,0.0131 -0.0746,0.0855 -0.125,0.38867 -0.0529,0.31839 -0.0733,0.81274 -0.0703,1.50195 v 0.004 3.90039 3.90234 0.002 c -0.003,0.68916 0.0176,1.18495 0.0703,1.50195 0.0504,0.30317 0.1119,0.37557 0.125,0.38867 0.0128,0.0128 0.0918,0.0798 0.39649,0.13086 0.32002,0.0537 0.8151,0.0742 1.5039,0.0742 h 5.8086 c 0.68894,0 1.18348,-0.0206 1.50195,-0.0742 0.30433,-0.0512 0.38043,-0.1186 0.39063,-0.1289 0.0112,-0.0112 0.0774,-0.0858 0.1289,-0.39258 0.0536,-0.31974 0.0742,-0.81575 0.0742,-1.50586 V 244 241 l -3,-3 z"
-         id="path1291" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1311);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86573,190 c -1.08855,0 -1.90034,0.0312 -2.45898,0.125 -0.54887,0.0921 -0.79683,0.22878 -0.93164,0.36328 -0.13436,0.13404 -0.26642,0.37645 -0.35742,0.92383 -0.0925,0.55627 -0.12219,1.36674 -0.11719,2.45703 v 0.004 6.12695 6.12891 0.002 c -0.005,1.0898 0.0249,1.9019 0.11719,2.45703 0.091,0.5474 0.22306,0.78979 0.35742,0.92383 0.13484,0.13452 0.38277,0.27118 0.93164,0.36328 0.55862,0.0938 1.37043,0.125 2.45898,0.125 h 8.26954 c 1.08864,0 1.90078,-0.0314 2.45703,-0.125 0.54703,-0.0921 0.78777,-0.227 0.92187,-0.36133 0.13429,-0.13451 0.26913,-0.37646 0.36133,-0.92578 0.0936,-0.55811 0.125,-1.37233 0.125,-2.46303 V 200 197 L 333,190 Z"
-         id="path1293"
-         sodipodi:nodetypes="scccccccccccsscccscccs" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 323.0005,200 v 6.125 c -0.0217,4.42101 0.45314,4.875 4.86523,4.875 h 8.26954 c 4.41209,0 4.86523,-0.45393 4.86523,-4.875 V 200 Z"
-         id="path1007"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 322.0005,244 v 3.89844 C 321.9867,250.71181 322.28851,251 325.0962,251 h 5.8086 c 2.8077,0 3.0957,-0.28815 3.0957,-3.10156 V 244 Z"
-         id="path1016"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 325.50195,84 v 12.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 V 84 Z"
-         id="path964-0"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18820-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188 44 C 90.788624 44 82.396956 44.428807 76.609375 46.427734 C 74.505793 47.154326 72.745865 48.088818 71.275391 49.285156 C 71.274692 49.285724 71.274136 49.286541 71.273438 49.287109 C 70.171193 50.184574 69.229818 51.229668 68.429688 52.445312 C 68.174328 52.833282 67.936671 53.242531 67.708984 53.666016 C 67.651564 53.772798 67.598688 53.886993 67.542969 53.996094 C 67.382444 54.310441 67.226879 54.630866 67.080078 54.964844 C 67.006949 55.131203 66.93897 55.305225 66.869141 55.476562 C 66.748138 55.773462 66.628968 56.074579 66.517578 56.386719 C 66.446853 56.584913 66.379471 56.787726 66.3125 56.992188 C 66.212808 57.29649 66.117028 57.607335 66.025391 57.925781 C 65.965274 58.134707 65.906369 58.345421 65.849609 58.560547 C 65.756412 58.913766 65.668449 59.278191 65.583984 59.648438 C 65.536317 59.857386 65.488342 60.062875 65.443359 60.277344 C 65.362062 60.664875 65.287698 61.068729 65.214844 61.474609 C 65.176853 61.686319 65.133436 61.890634 65.097656 62.107422 C 64.994386 62.732944 64.90026 63.376169 64.814453 64.044922 C 64.814368 64.045582 64.814538 64.046215 64.814453 64.046875 C 64.730212 64.703594 64.654689 65.386182 64.585938 66.085938 C 64.558109 66.36935 64.535208 66.668359 64.509766 66.958984 C 64.471641 67.394278 64.435363 67.831478 64.402344 68.283203 C 64.320685 69.400176 64.258682 70.586022 64.205078 71.806641 C 64.154684 72.953182 64.119332 74.174143 64.089844 75.416016 C 64.07606 75.996757 64.054735 76.540389 64.044922 77.142578 C 64.014642 78.996321 64 80.929692 64 82.994141 L 64 156 L 64 229.00586 C 64 231.07031 64.014642 233.00368 64.044922 234.85742 C 64.054735 235.45961 64.07606 236.00324 64.089844 236.58398 C 64.119332 237.82586 64.154684 239.04682 64.205078 240.19336 C 64.258682 241.41398 64.320685 242.59982 64.402344 243.7168 C 64.435363 244.16852 64.471641 244.60572 64.509766 245.04102 C 64.535208 245.33164 64.558109 245.63065 64.585938 245.91406 C 64.654689 246.61382 64.730212 247.29641 64.814453 247.95312 C 64.814533 247.95375 64.814373 247.95445 64.814453 247.95508 C 64.90026 248.62383 64.994386 249.26706 65.097656 249.89258 C 65.133436 250.10937 65.176853 250.31368 65.214844 250.52539 C 65.287698 250.93127 65.362062 251.33512 65.443359 251.72266 C 65.488342 251.93713 65.536317 252.14261 65.583984 252.35156 C 65.668449 252.72181 65.756412 253.08623 65.849609 253.43945 C 65.906369 253.65458 65.965274 253.86529 66.025391 254.07422 C 66.117028 254.39267 66.212808 254.70351 66.3125 255.00781 C 66.379471 255.21227 66.446853 255.41509 66.517578 255.61328 C 66.628968 255.92542 66.748138 256.22654 66.869141 256.52344 C 66.93897 256.69478 67.006949 256.8688 67.080078 257.03516 C 67.226879 257.36913 67.382444 257.68956 67.542969 258.00391 C 67.598688 258.11301 67.651564 258.2272 67.708984 258.33398 C 67.936671 258.75747 68.174328 259.16672 68.429688 259.55469 C 68.963454 260.36564 69.559812 261.09969 70.224609 261.76562 C 70.557008 262.09859 70.905713 262.4136 71.273438 262.71289 C 71.274154 262.71347 71.274674 262.71426 71.275391 262.71484 C 72.745865 263.91118 74.505793 264.84567 76.609375 265.57227 C 82.396956 267.57119 90.788624 268 102.92188 268 L 201.07812 268 C 203.1354 268 205.06339 267.98528 206.91211 267.95508 C 206.92365 267.95489 206.93381 267.95528 206.94531 267.95508 C 207.59075 267.94401 208.18439 267.91962 208.80664 267.9043 C 209.2637 267.89304 209.69197 267.87615 210.14258 267.86328 C 210.81633 267.8421 211.52187 267.82684 212.16602 267.79883 C 212.17279 267.79853 212.17877 267.79717 212.18555 267.79688 C 213.43824 267.74231 214.66024 267.67979 215.80469 267.5957 C 215.81466 267.59497 215.82402 267.59449 215.83398 267.59375 C 216.30787 267.55875 216.76876 267.51925 217.22461 267.47852 C 217.23558 267.47754 217.24681 267.47753 217.25781 267.47656 C 217.46816 267.45801 217.685 267.43997 217.89062 267.41992 C 218.61821 267.34902 219.32635 267.27308 220.00781 267.18555 C 220.67616 267.09973 221.31798 267.00366 221.94336 266.90039 C 221.94542 266.90005 221.94716 266.89878 221.94922 266.89844 C 222.16891 266.86195 222.37713 266.81983 222.5918 266.78125 C 222.98828 266.70995 223.38267 266.63799 223.76172 266.55859 C 224.00025 266.50867 224.22962 266.45386 224.46094 266.40039 C 224.47079 266.39813 224.4804 266.3968 224.49023 266.39453 C 224.80974 266.32083 225.12679 266.24436 225.43359 266.16406 C 225.68584 266.09801 225.93206 266.0296 226.17578 265.95898 C 226.18242 265.95706 226.18868 265.95505 226.19531 265.95312 C 226.4788 265.87083 226.75703 265.78403 227.0293 265.69531 C 227.25639 265.62131 227.48175 265.54541 227.70117 265.4668 C 227.85083 265.41318 227.99309 265.35464 228.13867 265.29883 C 228.27101 265.24829 228.40567 265.20081 228.53516 265.14844 C 228.5463 265.14393 228.55721 265.13927 228.56836 265.13477 C 228.75355 265.05996 228.94022 264.98513 229.11914 264.90625 C 229.28649 264.83249 229.44465 264.75208 229.60547 264.67383 C 229.70972 264.62427 229.81573 264.57638 229.91797 264.52539 C 229.92526 264.52175 229.93214 264.5173 229.93945 264.51367 C 230.10652 264.43083 230.2783 264.35078 230.43945 264.26367 C 230.43995 264.2634 230.44091 264.26394 230.44141 264.26367 C 230.85108 264.04206 231.24664 263.8101 231.62305 263.5625 C 232.40332 263.04924 233.10973 262.47581 233.75586 261.8418 C 233.75717 261.84051 233.75845 261.83918 233.75977 261.83789 C 233.83088 261.76789 233.8992 261.69466 233.96875 261.62305 C 233.97067 261.62108 233.97269 261.61916 233.97461 261.61719 C 234.20423 261.3812 234.42556 261.13606 234.63867 260.88281 C 234.71567 260.79131 234.79421 260.70123 234.86914 260.60742 C 235.41025 259.9297 235.89679 259.19065 236.33398 258.38672 C 236.38928 258.28517 236.44241 258.17983 236.49609 258.07617 C 236.6547 257.76975 236.80589 257.45409 236.95117 257.12891 C 237.01198 256.99293 237.07424 256.85802 237.13281 256.71875 C 237.13336 256.71744 237.13422 256.71615 237.13477 256.71484 C 237.31667 256.28124 237.49156 255.83594 237.65234 255.36914 C 237.8128 254.90328 237.95906 254.41419 238.09961 253.91406 C 238.10016 253.9121 238.10101 253.91016 238.10156 253.9082 C 238.14177 253.76492 238.18014 253.61878 238.21875 253.47266 C 238.25475 253.33659 238.2866 253.19365 238.32031 253.05273 C 238.34775 252.94302 238.37574 252.832 238.40234 252.7207 C 238.40295 252.71818 238.40369 252.71542 238.4043 252.71289 C 238.54743 252.11352 238.67865 251.4902 238.79883 250.84375 C 238.82465 250.7047 238.8511 250.56733 238.87695 250.42773 C 238.88281 250.39444 238.89069 250.3635 238.89648 250.33008 C 238.89659 250.32947 238.89638 250.32874 238.89648 250.32812 C 239.03705 249.51759 239.16403 248.67439 239.27344 247.78906 C 239.27936 247.74118 239.28361 247.6901 239.28906 247.64062 C 239.30493 247.50972 239.31875 247.37085 239.33398 247.23828 C 239.3363 247.21815 239.33755 247.19595 239.33984 247.17578 C 239.41881 246.48269 239.49003 245.76862 239.55273 245.0293 C 239.55328 245.02286 239.55414 245.0162 239.55469 245.00977 C 239.58019 244.70792 239.60395 244.40151 239.62695 244.0918 C 239.68395 243.3234 239.733 242.52883 239.77539 241.71094 C 239.78349 241.55491 239.79357 241.40032 239.80273 241.24609 C 239.80753 241.14632 239.81376 241.05363 239.81836 240.95312 C 239.81877 240.94439 239.81798 240.93463 239.81836 240.92578 C 239.8239 240.79729 239.82694 240.65948 239.83203 240.5293 C 239.83253 240.51759 239.83349 240.5039 239.83398 240.49219 C 239.89618 239.02911 239.93647 237.47236 239.96289 235.85156 C 239.96307 235.84067 239.96271 235.82927 239.96289 235.81836 C 239.96965 235.41022 239.97579 234.99445 239.98047 234.57617 C 240.00007 232.80253 240.0096 230.97058 240 229.00586 L 240 126.24023 C 239.99175 124.41532 239.69913 122.64313 239.18555 120.92773 C 238.84316 119.78414 238.40271 118.66667 237.88281 117.57422 C 235.02338 111.56573 229.76385 106.34509 225.23828 102.07812 L 225.18945 102.02734 L 184.66602 59.619141 C 173.98907 49.058011 166.6082 44 152 44 L 102.92188 44 z M 202.6543 44.089844 C 198.17969 45.582244 196.66368 52.666443 200.11328 56.001953 L 228.60938 86.388672 C 232.34293 90.094303 239.77066 86.941636 239.99609 81.568359 C 239.99904 79.653502 239.98605 77.841831 239.95703 76.115234 C 239.95423 75.948427 239.94846 75.795955 239.94531 75.630859 C 239.91561 74.073736 239.87303 72.583034 239.80859 71.173828 C 239.76149 70.141731 239.70379 69.149343 239.63477 68.193359 C 238.48179 52.247696 234.0865 46.656477 219.97266 44.832031 C 218.6759 44.664404 217.29786 44.529298 215.83203 44.419922 C 215.12248 44.366977 214.38958 44.320376 213.63867 44.279297 C 213.63006 44.278828 213.61995 44.277811 213.61133 44.277344 C 212.04337 44.192346 210.38654 44.131491 208.63086 44.089844 L 202.6543 44.089844 z M 119.56641 55.945312 C 130.94041 55.949312 142.19691 55.986006 153.46484 56.191406 C 160.70267 55.806356 167.33104 59.645279 172.32031 64.599609 C 188.42569 80.562439 203.72801 97.313632 219.59766 113.50977 C 223.01384 117.3863 227.86068 121.27297 227.77148 126.91016 C 228.13347 156.76716 227.92575 186.62924 227.87695 216.48828 C 227.61216 226.73843 228.27253 237.18437 226.96875 247.45312 C 226.42181 249.81071 226.43599 253.48893 223.40625 254.10352 C 215.81737 255.95335 207.89537 255.57352 200.13867 255.80078 C 164.59267 255.97868 128.71027 256.09951 93.162109 255.66406 C 88.457189 255.24944 83.282319 255.67006 79.042969 253.2793 C 76.215659 249.46054 76.934056 244.27573 76.597656 239.79492 C 76.014926 191.14952 75.895482 142.48894 76.013672 93.822266 C 76.296742 83.105596 75.520041 72.053786 77.582031 61.384766 C 77.890341 58.111406 81.437525 57.376809 84.078125 56.974609 C 95.865615 55.846619 107.85901 56.107003 119.56641 55.945312 z "
-         id="rect4158-92-3" />
+         d="m 328.64968,236.55402 c 0,0 0.9649,0.33593 0.9649,1.07279 0,0 -4.7e-4,7.84377 -4.7e-4,12.72013 0,0.53992 -0.48633,0.88481 -1.16229,1.12822 l 4.41275,-1.33421 c 0,0 0.90148,-0.23437 0.90148,-1.13585 v -9.71302 c 0,0 0.0748,-1.01352 -0.58812,-1.31314 -0.66295,-0.29958 -4.52832,-1.42479 -4.52832,-1.42479 z"
+         fill="url(#linearGradient3018)"
+         id="path24077"
+         style="display:inline;fill:url(#linearGradient24085);stroke-width:4.3613;enable-background:new" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
-       style="display:inline">
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,156 v 73.00683 C 63.827405,264.37495 67.625545,268 102.92228,268 h 98.15624 c 35.29672,0 38.00361,-3.63655 38.92188,-38.99317 V 156 Z"
-         id="path4255"
-         sodipodi:nodetypes="ccssscc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,227.00586 v 2 C 63.827405,264.37398 67.625545,268 102.92228,268 h 98.15624 c 35.29672,0 38.00361,-3.63752 38.92188,-38.99414 v -2 C 239.08213,262.36248 236.37524,266 201.07852,266 h -98.15624 c -35.296735,0 -39.094875,-3.62602 -38.921885,-38.99414 z"
-         id="path945"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07999998;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:7.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 180.0004,268 60,-60 v 22.48388 C 239.9481,264.47969 236.19772,268 201.8263,268 Z"
-         id="path4254"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccsc" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23242,61.5 c -4.11577,0 -6.55968,0.226752 -7.96875,1.558594 -0.28725,0.271486 -0.52183,0.601863 -0.72851,0.972656 -0.0468,0.08393 -0.10154,0.156606 -0.14454,0.246094 -2.5e-4,5.28e-4 2.6e-4,0.0014 0,0.002 -0.11616,0.241982 -0.2184,0.50414 -0.30859,0.789062 -0.0904,0.285534 -0.16955,0.593694 -0.23633,0.925782 -0.0668,0.332095 -0.1223,0.688232 -0.16797,1.070312 -0.0913,0.764147 -0.1422,1.632501 -0.16406,2.617188 -0.0109,0.492345 -0.0144,1.013779 -0.0117,1.566406 V 84 96.751953 c -0.003,0.552627 8e-4,1.074061 0.0117,1.566406 0.0219,0.984686 0.0727,1.853041 0.16406,2.617191 0.0457,0.38208 0.1012,0.73821 0.16797,1.07031 0.13356,0.66417 0.31198,1.23197 0.54492,1.7168 0.23295,0.48482 0.52078,0.88581 0.87305,1.21875 0.17614,0.16648 0.36842,0.31556 0.57813,0.44921 0.41895,0.26701 0.90872,0.47238 1.47656,0.62891 6.2e-4,1.7e-4 0.001,-1.7e-4 0.002,0 1.42142,0.39113 3.3408,0.48047 5.91211,0.48047 h 17.53906 c 1.02156,0 1.93959,-0.015 2.76368,-0.0566 0.34097,-0.0172 0.65525,-0.0427 0.96484,-0.0703 0.0645,-0.006 0.13795,-0.007 0.20117,-0.0137 0.001,-1.4e-4 0.003,1.3e-4 0.004,0 0.73118,-0.0725 1.37505,-0.17995 1.93945,-0.33399 0.28273,-0.0772 0.54639,-0.16492 0.79102,-0.26758 0.24462,-0.10265 0.47066,-0.22006 0.67968,-0.35156 0.20903,-0.1315 0.40024,-0.27771 0.57618,-0.44141 0.15581,-0.14498 0.29602,-0.30775 0.42773,-0.48046 0.017,-0.0223 0.0381,-0.0397 0.0547,-0.0625 0.001,-0.002 0.003,-0.004 0.004,-0.006 0.14374,-0.19776 0.2725,-0.41443 0.38868,-0.6504 0.11725,-0.23815 0.22082,-0.49693 0.3125,-0.77734 0.0917,-0.28041 0.17164,-0.58218 0.24023,-0.9082 0.0686,-0.32602 0.12581,-0.6758 0.17383,-1.05078 0.0428,-0.33417 0.0752,-0.6967 0.10351,-1.072269 0.003,-0.04534 0.0104,-0.0849 0.0137,-0.130859 4.2e-4,-0.0061 -4.3e-4,-0.01341 0,-0.01953 0.059,-0.850021 0.0853,-1.80463 0.0879,-2.88086 V 78.021484 c -0.009,-1.95527 -1.71776,-3.606675 -3.10157,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 C 348.62263,62.517026 347.07095,61.5 344,61.5 Z"
-         id="path964-1"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -2.50815,0 -4.811706,0.02551 -7.011724,0.07227 -1.569124,0.03333 -3.085758,0.07665 -4.505859,0.142578 -0.892728,0.04133 -1.761123,0.08803 -2.597656,0.144531 -0.07361,0.005 -0.155337,0.0086 -0.228516,0.01367 -0.03977,0.0028 -0.07364,0.0069 -0.113281,0.0098 -1.116046,0.0793 -2.169724,0.179402 -3.1875,0.291016 -0.281404,0.03076 -0.565732,0.06033 -0.839844,0.09375 -0.275699,0.03373 -0.547991,0.06893 -0.816406,0.105469 -0.386448,0.05241 -0.763169,0.107586 -1.134766,0.166015 -0.245075,0.0387 -0.493706,0.07575 -0.732422,0.117188 -0.386715,0.06683 -0.756638,0.14255 -1.126953,0.216797 -0.50787,0.102283 -1.000729,0.211021 -1.478515,0.328125 -0.190937,0.04659 -0.386033,0.09158 -0.572266,0.140625 -0.3252,0.08602 -0.638123,0.17771 -0.949219,0.271484 -0.174107,0.05225 -0.347813,0.105409 -0.517578,0.160157 -0.32699,0.105899 -0.647816,0.216555 -0.958984,0.332031 -0.09794,0.0362 -0.19267,0.07416 -0.289063,0.111328 -1.533658,0.593687 -2.876219,1.308506 -4.044922,2.173828 -0.01464,0.01084 -0.03034,0.02036 -0.04492,0.03125 -4.841904,3.613548 -6.740009,9.796263 -7.419922,20.238281 -0.01716,0.264046 -0.02929,0.544903 -0.04492,0.814453 -0.06629,1.140594 -0.126494,2.305415 -0.167969,3.546875 -9.88e-4,0.02958 -9.78e-4,0.06216 -0.002,0.0918 -0.04738,1.439614 -0.07924,2.944486 -0.09961,4.525391 C 64.509576,49.175312 70.065023,46 102.92188,46 h 62.52929 c -0.85989,-0.295464 -1.74582,-0.553137 -2.65429,-0.783203 -0.15701,-0.03958 -0.31205,-0.08153 -0.47071,-0.119141 -0.38771,-0.0924 -0.78156,-0.17709 -1.17969,-0.257812 -0.28362,-0.0571 -0.57205,-0.108998 -0.86132,-0.160156 -0.33217,-0.05924 -0.66192,-0.122415 -1.00196,-0.173829 -0.61547,-0.09216 -1.24344,-0.171651 -1.88672,-0.238281 -0.25531,-0.02678 -0.51929,-0.04563 -0.77929,-0.06836 -0.49344,-0.04258 -0.99476,-0.07925 -1.50586,-0.107422 -0.26087,-0.01459 -0.52138,-0.03022 -0.78711,-0.04102 C 153.56684,44.020455 152.79888,44 152,44 Z"
-         id="path7808" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 202.6543,44.089844 C 201.58308,44.447123 200.68698,45.129921 199.98242,46 h 1.0957 c 34.15108,4e-6 38.64021,3.484765 38.89649,35.740234 0.003,-0.03712 0.0117,-0.07204 0.0137,-0.109375 -0.0536,-17.671398 -1.15787,-27.178174 -7.08008,-32.177734 -0.31691,-0.265045 -0.64554,-0.519153 -0.99023,-0.759766 -1.34338,-0.937742 -2.91268,-1.68853 -4.71875,-2.296875 -0.14212,-0.04772 -0.27668,-0.09862 -0.42188,-0.144531 -0.31902,-0.101184 -0.65609,-0.192499 -0.99023,-0.285156 -0.25795,-0.07131 -0.51412,-0.144507 -0.78125,-0.210938 -0.32384,-0.08078 -0.65655,-0.156631 -0.99414,-0.230468 -0.32254,-0.07033 -0.65294,-0.136909 -0.98828,-0.201172 -0.32063,-0.06164 -0.64012,-0.123397 -0.97266,-0.179688 -0.46228,-0.07802 -0.94194,-0.148582 -1.42773,-0.216797 -0.21622,-0.03046 -0.42163,-0.06516 -0.64258,-0.09375 -0.003,-3.28e-4 -0.005,-0.0016 -0.008,-0.002 -0.70741,-0.09114 -1.44413,-0.170948 -2.20118,-0.24414 -0.30752,-0.02983 -0.6294,-0.05499 -0.94531,-0.08203 -0.52075,-0.04445 -1.04787,-0.08768 -1.59179,-0.125 -0.34138,-0.02349 -0.68841,-0.04362 -1.03907,-0.06445 -0.36733,-0.02177 -0.74929,-0.04154 -1.12695,-0.06055 -1.40861,-0.07105 -2.86508,-0.128967 -4.42188,-0.166015 -0.006,-1.28e-4 -0.0105,5e-6 -0.0156,0 h -0.004 z"
-         id="path7806" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 64.011719,81.421875 C 64.009827,81.961067 64,82.439442 64,82.994141 v 2 c -0.0062,-1.260292 0.0066,-2.391311 0.01172,-3.572266 z"
-         id="path5316-7" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.005859,227.00586 v 2 c -0.0022,0.44238 0.0048,0.82141 0.0039,1.25391 0.0013,0.45945 0.007,0.88359 0.0098,1.33203 -0.01134,-1.48776 -0.02159,-2.96803 -0.01367,-4.58594 z M 240,227.75781 C 239.94446,262.39 236.11596,266 201.08398,266 h -98.15625 c -32.934263,0 -38.440959,-3.18029 -38.890621,-32.33398 0.304544,24.87428 3.489356,31.9654 22.175782,33.76562 0.0033,3.2e-4 0.0064,-3.2e-4 0.0098,0 0.761225,0.073 1.548247,0.13868 2.361328,0.19531 0.002,1.4e-4 0.0039,-1.4e-4 0.0059,0 0.814659,0.0567 1.655065,0.10648 2.523437,0.14844 6.7e-4,3e-5 0.0013,-3e-5 0.002,0 0.579873,0.028 1.24712,0.0365 1.851563,0.0586 1.208255,0.0442 2.391096,0.0937 3.701172,0.11719 0.0014,3e-5 0.0025,-2e-5 0.0039,0 1.964377,0.0351 4.045339,0.0488 6.250009,0.0488 0.002,0 0.004,0 0.006,0 h 98.15039 c 3.67649,0 6.93682,-0.0556 9.96094,-0.16602 2.42031,-0.0885 4.71577,-0.20623 6.75196,-0.40234 19.49586,-1.8777 22.12352,-9.49921 22.20507,-37.08398 -8.2e-4,-0.46208 0.006,-0.86842 0.004,-1.3418 z"
-         id="path5316-8"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 353.49905,61.375285 c -0.0742,0 -0.14719,0.007 -0.22049,0.018 -0.94065,0.29981 -1.25935,1.72298 -0.53417,2.39306 l 7.51333,7.51498 c 0.78643,0.74591 2.35311,0.10873 2.39455,-0.97465 v -2.118 c 0.0336,-6.55752 0.34308,-6.68079 -5.59466,-6.81539 H 353.722 c -0.0733,-0.0113 -0.14877,-0.018 -0.22295,-0.018 z"
-         id="rect4158-92-6-6"
-         sodipodi:nodetypes="scccccccs" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1004);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         clip-path="url(#clipPath994-5)"
-         d="m 335.23242,61.5 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 V 84 96.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 V 79.021813 C 362.49246,77.807802 361.8315,76.711812 361,75.756188 V 84 96.251953 c 0,2.193451 -0.0614,3.870697 -0.26562,5.087887 -0.20419,1.2172 -0.52867,1.92435 -0.99805,2.39454 -0.46938,0.47016 -1.17436,0.79564 -2.38867,1 -1.21432,0.20434 -2.8892,0.26562 -5.07813,0.26562 h -16.53906 c -2.18893,0 -3.86589,-0.0612 -5.08399,-0.26562 -1.21809,-0.20448 -1.92877,-0.5295 -2.40039,-1 -0.47161,-0.47052 -0.79596,-1.17682 -0.99804,-2.39258 -0.20209,-1.21576 -0.25879,-2.893414 -0.24805,-5.085941 v -0.002 V 84 71.746094 v -0.002 c -0.0107,-2.192528 0.046,-3.870175 0.24805,-5.085938 0.20209,-1.215763 0.52643,-1.922078 0.99804,-2.392578 0.47161,-0.4705 1.18426,-0.79553 2.40235,-1 C 331.86653,63.061202 333.54154,63 335.73047,63 H 348 c -1.40176,-1.001118 -3.79892,-1.5 -5.922,-1.5 z"
-         id="path990"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssccccscccsscccccccccscscss" />
-      <path
-         inkscape:connector-curvature="0"
-         style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.04419417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 353.35547,61.876953 -0.14453,0.121094 c -0.28875,0.242959 -0.43321,0.748579 -0.31836,1.111328 0.007,0.0217 0.07,0.0936 0.11523,0.150391 0.056,-0.101219 0.12158,-0.193105 0.20313,-0.261719 l 0.14453,-0.121094 2.71875,0.02539 c 2.70745,0.02522 3.50936,0.05935 4.26562,0.185547 1.36683,0.228076 1.67801,0.658049 1.79102,2.474609 0.0245,0.393967 0.0317,1.552688 0.0352,2.636719 0.007,-1.466927 -5.4e-4,-3.080545 -0.0352,-3.636719 -0.11301,-1.81656 -0.42419,-2.246533 -1.79102,-2.474609 -0.75626,-0.126199 -1.55817,-0.160327 -4.26562,-0.185547 z"
-         id="path7025" />
-      <path
-         transform="translate(4.9980746e-4)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971-6)" />
-      <path
-         id="path1085"
-         d="m 327.86573,188.5 c -1.11158,0 -1.98683,0.0256 -2.70703,0.14648 -0.72019,0.1209 -1.3105,0.34863 -1.74218,0.7793 -0.43169,0.43067 -0.65954,1.01974 -0.7793,1.74024 -0.11977,0.72049 -0.14217,1.59669 -0.13672,2.71093 V 200 v 6.125 c -0.005,1.1131 0.017,1.989 0.13672,2.70898 0.11976,0.72051 0.3476,1.30957 0.7793,1.74024 0.43169,0.43067 1.02199,0.6584 1.74218,0.7793 0.7202,0.12089 1.59545,0.14648 2.70703,0.14648 h 8.26954 c 1.11158,0 1.98637,-0.0255 2.70507,-0.14648 0.7187,-0.12095 1.30623,-0.34848 1.73633,-0.7793 0.4301,-0.43083 0.6566,-1.01849 0.77735,-1.73828 0.12074,-0.71979 0.14648,-1.59713 0.14648,-2.71094 V 200 193.875 c 0,-1.11381 -0.0257,-1.99115 -0.14648,-2.71094 -0.12075,-0.71979 -0.34725,-1.30745 -0.77735,-1.73828 -0.4301,-0.43082 -1.01763,-0.65835 -1.73633,-0.7793 -0.7187,-0.12094 -1.59349,-0.14648 -2.70507,-0.14648 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path1087"
-         d="m 325.0962,236.5 c -0.71048,0 -1.27344,0.0154 -1.75195,0.0957 -0.47851,0.0803 -0.89671,0.23728 -1.20703,0.54688 -0.31032,0.30959 -0.46726,0.7261 -0.54688,1.20508 -0.0796,0.47897 -0.0933,1.04352 -0.0898,1.75586 V 244 v 3.89844 c -0.003,0.71121 0.0103,1.27546 0.0898,1.7539 0.0796,0.47898 0.23655,0.89549 0.54688,1.20508 0.31033,0.3096 0.72851,0.46655 1.20703,0.54688 0.47852,0.0803 1.04147,0.0957 1.75195,0.0957 h 5.8086 c 0.71048,0 1.27236,-0.0153 1.75,-0.0957 0.47763,-0.0804 0.89584,-0.23713 1.20508,-0.54688 0.30921,-0.30975 0.46469,-0.72681 0.54492,-1.20508 0.0802,-0.47826 0.0957,-1.04201 0.0957,-1.7539 V 244 240.10156 c 0,-0.71189 -0.0155,-1.27564 -0.0957,-1.7539 -0.0802,-0.47827 -0.2357,-0.89533 -0.54492,-1.20508 -0.30924,-0.30975 -0.72745,-0.4665 -1.20508,-0.54688 -0.47764,-0.0804 -1.03952,-0.0957 -1.75,-0.0957 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         transform="translate(4.9980746e-4)"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983-6)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99158418;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 342.28662,133.49219 c -0.0504,0 -0.10067,0.005 -0.15039,0.0117 -0.63831,0.19051 -0.85538,1.0957 -0.36328,1.52148 l 5.09961,4.77344 c 0.53367,0.47395 1.59687,0.0693 1.625,-0.61914 v -1.34571 c 0.0228,-4.16669 0.23241,-4.24454 -3.79688,-4.33007 h -2.26367 c -0.0498,-0.007 -0.10004,-0.0117 -0.15039,-0.0117 z m -12.21289,0.004 c -2.78209,0 -4.43425,0.14534 -5.38672,1.00391 -0.19416,0.175 -0.35249,0.38793 -0.49219,0.62695 -0.0316,0.054 -0.0686,0.10247 -0.0976,0.16016 -0.0785,0.156 -0.14802,0.3261 -0.20899,0.50977 -0.0611,0.18405 -0.11501,0.38162 -0.16015,0.5957 -0.0452,0.21409 -0.0824,0.44315 -0.11329,0.68945 -0.0617,0.49261 -0.0965,1.05274 -0.11132,1.6875 -0.007,0.31739 -0.01,0.65353 -0.008,1.00977 V 148 v 8.2207 c -0.002,0.35623 3.5e-4,0.69239 0.008,1.00977 0.0148,0.63477 0.0495,1.19491 0.11132,1.6875 0.0309,0.24631 0.0682,0.47537 0.11329,0.68945 0.0903,0.42816 0.21168,0.79292 0.36914,1.10547 0.15746,0.31252 0.35171,0.57249 0.58984,0.78711 0.11906,0.10732 0.24887,0.20291 0.39062,0.28906 0.28319,0.17212 0.61423,0.30534 0.99805,0.40625 0.96081,0.25213 2.25995,0.3086 3.99805,0.3086 h 11.85547 c 0.69054,0 1.31013,-0.0106 1.86719,-0.0371 0.23047,-0.0111 0.44308,-0.0272 0.65234,-0.0449 0.0436,-0.004 0.094,-0.004 0.13672,-0.008 h 0.002 c 0.49424,-0.0467 0.92903,-0.11749 1.31055,-0.21679 0.19111,-0.0498 0.36981,-0.10571 0.53515,-0.17188 0.16536,-0.0661 0.31771,-0.14178 0.45899,-0.22656 0.14129,-0.0848 0.2717,-0.17962 0.39062,-0.28516 0.10532,-0.0934 0.20005,-0.19727 0.28907,-0.30859 0.0115,-0.0144 0.0259,-0.0264 0.0371,-0.041 6.7e-4,-0.001 9.5e-4,-0.003 0.002,-0.004 0.0971,-0.12749 0.18514,-0.26586 0.26367,-0.41797 0.0792,-0.15352 0.14897,-0.32121 0.21094,-0.50196 0.062,-0.18077 0.11573,-0.37576 0.16211,-0.58593 0.0464,-0.21016 0.0847,-0.43601 0.11718,-0.67774 0.0289,-0.21541 0.0511,-0.44929 0.0703,-0.6914 0.002,-0.0292 0.008,-0.0543 0.01,-0.084 2.9e-4,-0.004 -2.9e-4,-0.008 0,-0.0117 0.0399,-0.54795 0.0568,-1.16365 0.0586,-1.85742 v -11.18578 c -0.006,-1.26044 -1.16032,-2.32513 -2.09571,-3.1289 l -0.008,-0.006 -6.72986,-6.49196 c -1.51744,-1.36767 -2.56676,-2.02344 -4.64258,-2.02344 z"
-         id="path964-1-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccccccccccccccccsscccccccccccccccccccccccss" />
-      <path
-         style="opacity:0.3;fill:url(#linearGradient4316);fill-opacity:1;stroke:none;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 343.16802,134.07487 c -0.99147,0.035 -1.02734,0.0465 -1.02734,0.33594 0,0.10178 0.15173,0.31016 0.45898,0.64648 h 2.87891 c 0.15931,0 0.30929,0.0306 0.45312,0.0762 0.32342,0.02 0.64497,0.0487 0.96485,0.10352 0.0264,0.32124 0.0306,0.64828 0.0371,0.97461 0.0263,0.11154 0.0449,0.2259 0.0449,0.3457 v 2.61719 c 0.25501,0.21272 0.45277,0.36813 0.49023,0.36914 0.45172,0.0121 0.5059,-0.28833 0.46289,-2.54883 -0.0534,-2.80528 0.043,-2.67754 -2.15624,-2.83984 -0.86922,-0.0642 -2.04216,-0.1 -2.60743,-0.0801 z m -10.83984,0.0371 c -5.16676,0.002 -5.89229,0.0632 -6.90234,0.57617 -0.60351,0.30649 -1.03843,1.06517 -1.2461,2.17187 -0.24355,1.30043 -0.239,21.42491 0.006,22.5 0.4115,1.80781 1.06039,2.3312 3.18555,2.56446 0.49142,0.054 4.63516,0.0862 9.20703,0.0723 7.44102,-0.0226 8.39113,-0.0477 9.0625,-0.24023 1.20765,-0.3464 1.67604,-0.80148 2.02539,-1.96289 0.17841,-0.59326 0.21211,-1.68489 0.25391,-8.28321 0.0479,-7.5564 0.0468,-6.60393 -0.21875,-7.15257 -0.0736,-0.15205 -0.33859,-0.46265 -0.72266,-0.875 v 4.07422 c 0,0.12416 -0.0206,0.24218 -0.0488,0.35742 0.0246,3.83198 -0.0428,6.67596 -0.12305,10.47289 0.094,0.98908 -0.26416,2.20979 -1.37304,2.42969 -4.17852,0.21246 -8.39772,0.16055 -12.60547,0.18945 -2.09316,-0.0712 -4.2187,0.13385 -6.29102,-0.20117 -1.20786,-0.09 -1.37139,-1.432 -1.46679,-2.37696 -0.1751,-6.57883 -0.13104,-13.28191 -0.041,-19.88867 0.0853,-1.09208 -0.0376,-2.65795 1.18164,-3.16406 2.366,-0.42229 4.785,-0.2218 7.17578,-0.3125 0.61114,0.0344 0.29054,0.0147 0.94202,0.0117 0.059,-0.007 0.11677,-0.0176 0.17773,-0.0176 h 3.5918 c -0.42688,-0.30915 -0.78914,-0.52782 -1.16797,-0.68359 -0.60974,-0.25114 0.12581,-0.26372 -4.60217,-0.26172 z"
-         id="path4296"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cscscccscccccccccccccccccsccccccccccscccc" />
-    </g>
+       inkscape:label="Pictogram"
+       style="display:inline" />
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/libreoffice-writer.svg
+++ b/icons/src/fullcolor/default/apps/libreoffice-writer.svg
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="libreoffice-writer.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
      id="base"
-     pagecolor="#5f5f5f"
+     pagecolor="#ffffff"
      bordercolor="#000000"
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.4142136"
-     inkscape:cx="295.06525"
-     inkscape:cy="271.42976"
-     inkscape:current-layer="layer6"
+     inkscape:zoom="2"
+     inkscape:cx="209"
+     inkscape:cy="124"
+     inkscape:current-layer="layer2"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -50,7 +50,7 @@
      gridtolerance="10000"
      inkscape:object-nodes="true"
      inkscape:snap-grids="true"
-     showguides="false"
+     showguides="true"
      inkscape:guide-bbox="true"
      inkscape:window-maximized="1"
      inkscape:bbox-paths="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,682 +93,89 @@
   <defs
      id="defs3">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-5">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient3194"
-       x1="335.73108"
-       y1="62"
-       x2="352.26993"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="169.66859"
-       x2="4.4137931"
-       y1="386.30838"
-       x1="494.34482"
-       id="linearGradient4226-1"
-       xlink:href="#linearGradient4338"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.96286,268)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6646"
-       x="-0.01363613"
-       width="1.0272723"
-       y="-0.01071443"
-       height="1.0214289">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.0000135"
-         id="feGaussianBlur6648" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter6668"
-       x="-0.054544518"
-       width="1.109089"
-       y="-0.042857721"
-       height="1.0857154">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.000054"
-         id="feGaussianBlur6670" />
-    </filter>
-    <linearGradient
-       id="linearGradient19846">
-      <stop
-         id="stop19848"
-         style="stop-color:#259dd2;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop19850"
-         style="stop-color:#065d8d;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10292">
-      <stop
-         id="stop10294"
-         style="stop-color:#666666;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop10296"
-         style="stop-color:#333333;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient9153">
-      <stop
-         id="stop9155"
-         style="stop-color:#0369a3;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop9157"
-         style="stop-color:#047fc6;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="337.37491"
-       y1="-1311.3585"
-       x2="337.37491"
-       y2="-1304.4017"
-       id="linearGradient8633-8"
-       xlink:href="#linearGradient8627"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,-263)" />
-    <linearGradient
-       id="linearGradient8627">
-      <stop
-         id="stop8629"
-         style="stop-color:#666666;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8631"
-         style="stop-color:#666666;stop-opacity:0.5"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="-1535.3044"
-       cy="-842.90808"
-       r="10"
-       fx="-1535.3044"
-       fy="-842.90808"
-       id="radialGradient8546-3"
-       xlink:href="#linearGradient8548"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-3.31574,0,0,-7.58441,-3491.73,-6782.31)" />
-    <linearGradient
-       id="linearGradient8548">
-      <stop
-         id="stop8550"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8552"
-         style="stop-color:#00a8ff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="337.37491"
-       y1="-1311.3585"
-       x2="337.37491"
-       y2="-1299.649"
-       id="linearGradient8633-1-2"
-       xlink:href="#linearGradient8627"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,-263)" />
-    <linearGradient
-       x1="349.55026"
-       y1="-1308.946"
-       x2="349.55026"
-       y2="-1302.7262"
-       id="linearGradient8641-9"
-       xlink:href="#linearGradient8635"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,-263)" />
-    <linearGradient
-       id="linearGradient8635">
-      <stop
-         id="stop8637"
-         style="stop-color:#808080;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8639"
-         style="stop-color:#666666;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="349.55026"
-       y1="-1307.696"
-       x2="349.55026"
-       y2="-1301.2262"
-       id="linearGradient8641-8-9"
-       xlink:href="#linearGradient8635"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,-263)" />
-    <linearGradient
-       x1="337.375"
-       y1="-1293.6378"
-       x2="337.375"
-       y2="-1287.5115"
-       id="linearGradient9159-4"
-       xlink:href="#linearGradient9153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,-263)" />
-    <linearGradient
-       x1="445.69522"
-       y1="1103.5776"
-       x2="441.38797"
-       y2="1099.8198"
-       id="linearGradient10761-4"
-       xlink:href="#linearGradient10755"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient10755">
-      <stop
-         id="stop10757"
-         style="stop-color:#e9b913;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop10759"
-         style="stop-color:#ffff00;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-17"
-       y1="-1194.6378"
-       x2="144"
-       y2="-1194.6378"
-       id="linearGradient7410-3"
-       xlink:href="#linearGradient8074-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.524068,0,0,1,318.409,-356)" />
-    <linearGradient
-       id="linearGradient8074-2">
-      <stop
-         id="stop8076-1"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop8078-94"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.49305555" />
-      <stop
-         id="stop8080-0"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-17"
-       y1="-1194.6378"
-       x2="144"
-       y2="-1194.6378"
-       id="linearGradient7414-6"
-       xlink:href="#linearGradient8074-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.524068,0,0,1,318.409,-405)" />
-    <linearGradient
-       x1="387.49451"
-       y1="192.9848"
-       x2="405.17218"
-       y2="192.9848"
-       id="linearGradient8648-32"
-       xlink:href="#linearGradient8642-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-123,-1753.64)" />
-    <linearGradient
-       x1="-17"
-       y1="-1194.6378"
-       x2="144"
-       y2="-1194.6378"
-       id="linearGradient20129-0"
-       xlink:href="#linearGradient8074-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.298137,0,0,1,-1593.57,881.638)" />
-    <linearGradient
-       x1="-17"
-       y1="-1194.6378"
-       x2="144"
-       y2="-1194.6378"
-       id="linearGradient20133-6"
-       xlink:href="#linearGradient8074-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.298137,0,0,1,-1593.57,804.638)" />
-    <linearGradient
-       x1="-17"
-       y1="-1194.6378"
-       x2="144"
-       y2="-1194.6378"
-       id="linearGradient20141-1"
-       xlink:href="#linearGradient8074-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.298137,0,0,1,-1593.57,884.638)" />
-    <linearGradient
-       x1="-17"
-       y1="-1194.6378"
-       x2="144"
-       y2="-1194.6378"
-       id="linearGradient20145-5"
-       xlink:href="#linearGradient8074-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.524068,0,0,1,318.409,-353)" />
-    <linearGradient
-       x1="-17"
-       y1="-1194.6378"
-       x2="144"
-       y2="-1194.6378"
-       id="linearGradient20149-5"
-       xlink:href="#linearGradient8074-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.298137,0,0,1,-1593.57,801.638)" />
-    <linearGradient
-       id="linearGradient9364">
-      <stop
-         style="stop-color: rgb(99, 187, 238); stop-opacity: 1;"
-         offset="0"
-         id="stop9366" />
-      <stop
-         style="stop-color: rgb(170, 220, 247); stop-opacity: 1;"
-         offset="1"
-         id="stop9368" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4338">
-      <stop
-         style="stop-color:#f2f2f2;stop-opacity:1"
-         offset="0"
-         id="stop4340" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="1"
-         id="stop4342" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient19846"
-       id="linearGradient18935"
-       x1="352.77148"
-       y1="106.5"
-       x2="335.01425"
-       y2="61.500217"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath959-9">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 330.1929,133.99999 c -5.61538,0 -6.21958,0.57678 -6.19206,6.20352 v 7.79648 7.79648 c -0.0276,5.62673 0.57668,6.20351 6.19206,6.20351 h 11.615 c 5.6154,0 6.19208,-0.5767 6.19208,-6.20351 v -7.79648 -7.79648 c 0,-5.6268 -0.5767,-6.20352 -6.19208,-6.20352 z"
-         id="path961-3"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983-6">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985-0"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971-6">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1311"
-       x1="327.99951"
-       y1="188"
-       x2="335.99951"
-       y2="212"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientTransform="translate(4.9980746e-4)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient1309"
-       x1="332"
-       y1="236"
-       x2="324"
-       y2="252"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient9153"
-       id="linearGradient916"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05664062,-0.05663901,0,349.74506,214)"
-       x1="459.03448"
-       y1="419.23337"
-       x2="35.310345"
-       y2="207.36522" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient9153"
-       id="linearGradient920"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.03604403,-0.03604301,0,339.56482,252.90909)"
-       x1="459.03448"
-       y1="419.23337"
-       x2="35.310345"
-       y2="207.36522" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient19846"
-       id="linearGradient18935-0"
-       x1="352.77148"
-       y1="106.5"
-       x2="335.01425"
-       y2="61.500217"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient4316"
-       x1="372"
-       y1="134"
-       x2="372"
-       y2="162"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-37.000489)" />
-    <linearGradient
-       gradientTransform="matrix(0.67265869,0,0,0.64265845,104.54969,94.05684)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338"
-       id="linearGradient18935-0-8"
-       x1="336.64893"
-       y1="59.040947"
-       x2="348.54202"
-       y2="108.83411"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient19846"
-       id="linearGradient18820-3"
-       x1="201.07812"
-       y1="269.99988"
-       x2="102.92188"
-       y2="45.999878"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="_Linear19"
-       x1="0"
-       y1="0"
+       id="b"
        x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,200,-200,0,152,64)">
+       gradientTransform="matrix(0,-203.23056,203.23056,0,561.91611,254.13381)"
+       gradientUnits="userSpaceOnUse">
       <stop
+         stop-color="#0255a8"
          offset="0"
-         style="stop-color:rgb(3,105,163);stop-opacity:1"
-         id="stop333" />
+         id="stop27" />
       <stop
+         stop-color="#5f71fa"
          offset="1"
-         style="stop-color:rgb(4,127,198);stop-opacity:1"
-         id="stop335" />
+         id="stop29" />
     </linearGradient>
     <linearGradient
-       id="_Linear20"
-       x1="0"
-       y1="0"
+       id="a"
        x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,20.001,-20.001,0,206.995,128.991)">
+       gradientTransform="matrix(-0.00528208,-207.68288,207.68288,-0.00528208,235.61348,259.06168)"
+       gradientUnits="userSpaceOnUse">
       <stop
+         stop-color="#b7b4b4"
          offset="0"
-         style="stop-color:rgb(170,220,247);stop-opacity:1"
-         id="stop338" />
+         id="stop22" />
       <stop
+         stop-color="#f1f1f1"
          offset="1"
-         style="stop-color:rgb(170,220,247);stop-opacity:1"
-         id="stop340" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear9"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,40,-40,0,765,358)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(3,105,163);stop-opacity:1"
-         id="stop267" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(4,127,198);stop-opacity:1"
-         id="stop269" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear22"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,4,-4,0,354.994,78.998)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(170,220,247);stop-opacity:1"
-         id="stop348" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(170,220,247);stop-opacity:1"
-         id="stop350" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear10"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,31.867,-31.867,0,751.329,424.886)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(3,105,163);stop-opacity:1"
-         id="stop272" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(4,127,198);stop-opacity:1"
-         id="stop274" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear23"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,28,-28,0,757.286,428.6)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(3,105,163);stop-opacity:1"
-         id="stop353" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(4,127,198);stop-opacity:1"
-         id="stop355" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear24"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,2.5,-2.5,0,764,437.999)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(170,220,247);stop-opacity:1"
-         id="stop358" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(170,220,247);stop-opacity:1"
-         id="stop360" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear11"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,20,-20,0,753,484)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(3,105,163);stop-opacity:1"
-         id="stop277" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(4,127,198);stop-opacity:1"
-         id="stop279" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear25"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,20,-20,0,753,483)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(3,105,163);stop-opacity:1"
-         id="stop363" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(4,127,198);stop-opacity:1"
-         id="stop365" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear26"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.5,-1.5,0,758,489.999)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(170,220,247);stop-opacity:1"
-         id="stop368" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(170,220,247);stop-opacity:1"
-         id="stop370" />
-    </linearGradient>
-    <linearGradient
-       id="_Linear12"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,12,-12,0,749,530)">
-      <stop
-         offset="0"
-         style="stop-color:rgb(3,105,163);stop-opacity:1"
-         id="stop282" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(4,127,198);stop-opacity:1"
-         id="stop284" />
+         id="stop24" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#_Linear9"
-       id="linearGradient1210"
+       xlink:href="#b"
+       id="linearGradient423"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,40,-40,0,765,358)"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0" />
+       gradientTransform="matrix(0,-41.734847,41.734847,0,428.1792,104.15248)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#_Linear9"
-       id="linearGradient1212"
+       xlink:href="#a"
+       id="linearGradient425"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,40,-40,0,765,358)"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0" />
+       gradientTransform="matrix(-0.00108471,-42.649162,42.649162,-0.00108471,361.17062,105.16445)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient435"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-27.218378,27.218378,0,390.89945,161.14292)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient437"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-7.0741956e-4,-27.814671,27.814671,-7.0741956e-4,347.19821,161.8029)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient447"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-19.960145,19.960145,0,372.25957,209.63814)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient449"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.1877438e-4,-20.397427,20.397427,-5.1877438e-4,340.21199,210.12213)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient459"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-12.701913,12.701913,0,353.61975,250.13337)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient461"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.3012921e-4,-12.980183,12.980183,-3.3012921e-4,333.22583,250.44136)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -843,8 +251,7 @@
        style="display:none"
        inkscape:label="Baseplate"
        id="layer7"
-       inkscape:groupmode="layer"
-       sodipodi:insensitive="true">
+       inkscape:groupmode="layer">
       <text
          y="-8.2548828"
          xml:space="preserve"
@@ -868,7 +275,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">libreoffice-writer</tspan></text>
+           id="tspan924">libreoffice-writer</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -903,361 +310,129 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline"
-       sodipodi:insensitive="true">
+       id="layer2"
+       inkscape:label="Background"
+       style="display:inline">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.991584;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 342.28786,133.99591 c -0.0832,0 -0.1556,0.007 -0.2168,0.0156 l -0.0371,0.006 -0.0371,0.0117 c -1.02052,0.30458 -1.3544,1.66824 -0.54687,2.36914 0,0 0,0.002 0,0.002 l 5.08984,4.76563 0.006,0.004 c 0.44144,0.39204 1.03582,0.39851 1.50781,0.21874 0.47199,-0.17975 0.9171,-0.5946 0.94141,-1.18945 v -0.01 -1.35352 -0.002 c 0.006,-1.0363 0.0251,-1.82214 -0.0176,-2.45508 -0.0427,-0.63344 -0.14348,-1.14825 -0.47266,-1.55274 -0.32917,-0.40448 -0.82834,-0.59266 -1.42968,-0.68554 -0.60135,-0.0929 -1.35232,-0.1114 -2.36133,-0.13281 h -0.006 -2.26953 c -0.0478,-0.005 -0.0951,-0.0117 -0.15039,-0.0117 z m -7.25782,0.002 -4.95507,0.002 c -2.79936,0 -4.57517,0.10197 -5.71875,1.13282 -0.24259,0.21892 -0.43083,0.4754 -0.5879,0.74414 -0.0117,0.02 -0.0564,0.0782 -0.11132,0.1875 -0.0907,0.18027 -0.17065,0.37241 -0.23828,0.57617 -0.0671,0.20198 -0.12496,0.41859 -0.17383,0.65039 -0.0486,0.23023 -0.0869,0.47111 -0.11914,0.72851 v 0.002 c -0.0646,0.51578 -0.10015,1.09026 -0.11524,1.73633 -0.007,0.32198 -0.0116,0.66266 -0.01,1.02343 v 8.21875 8.22071 c -0.002,0.3594 0.002,0.69873 0.01,1.02148 0.0151,0.64603 0.0505,1.22236 0.11524,1.73828 0.0323,0.25754 0.0707,0.4986 0.11914,0.72852 0.0971,0.4603 0.23097,0.86702 0.41211,1.22656 0.18147,0.36018 0.41279,0.67544 0.69922,0.93359 0.14342,0.12929 0.30075,0.24284 0.46679,0.34375 0.33271,0.20222 0.70911,0.35057 1.12891,0.46094 v 0.002 c 1.04936,0.27537 2.37421,0.32422 4.12305,0.32422 h 11.85546 c 0.69562,0 1.32241,-0.0101 1.89063,-0.0371 h 0.002 c 0.23885,-0.0115 0.45772,-0.0289 0.66992,-0.0469 h 0.002 0.002 c 0.006,-5.4e-4 0.052,-0.004 0.0898,-0.006 h 0.0137 c 0.0155,-0.001 0.0141,-1.1e-4 0.0332,-0.002 h 0.002 c 0.51385,-0.0486 0.97388,-0.12251 1.38867,-0.23047 0.20576,-0.0536 0.4054,-0.11525 0.59571,-0.19141 0.18901,-0.0755 0.36479,-0.163 0.52929,-0.26172 0.1657,-0.0995 0.3216,-0.21271 0.46485,-0.33984 0.12928,-0.11465 0.24087,-0.23957 0.34179,-0.36524 0,2e-5 0.005,-0.005 0.006,-0.006 l 0.0215,-0.0215 0.0156,-0.0195 0.006,-0.008 0.002,-0.004 0.008,-0.008 0.008,-0.0137 c 4e-5,-7e-5 0.008,-0.016 0.0117,-0.0234 0.003,-0.004 0.009,-0.008 0.0117,-0.0117 -5.4e-4,7e-4 -0.007,0.003 -0.008,0.004 0.01,-0.0181 0.0172,-0.0306 0.0254,-0.0469 -0.006,0.0128 -0.01,0.0233 -0.0117,0.0273 0.095,-0.13149 0.18742,-0.26844 0.26562,-0.41992 0.0922,-0.17881 0.17175,-0.3686 0.24024,-0.56836 0.069,-0.20111 0.12594,-0.41283 0.17578,-0.63867 0.0501,-0.22709 0.0911,-0.46643 0.125,-0.71875 0.0307,-0.22912 0.0546,-0.4717 0.0742,-0.71875 l 0.002,-0.002 v -0.004 c -10e-4,0.0185 0.005,-0.009 0.01,-0.082 v -0.002 c 0.002,-0.0307 0.004,-0.0623 0,-0.006 v -0.002 -0.002 c 0.0411,-0.56466 0.0568,-1.18956 0.0586,-1.89062 v -0.004 -11.1875 c -0.007,-1.5618 -1.32097,-2.69049 -2.26758,-3.50391 l -0.01,-0.008 -0.002,-0.002 -6.71093,-6.47461 -0.008,-0.006 c -1.54333,-1.391 -2.79437,-2.15039 -4.97461,-2.15039 z"
-         id="path964-1-7-1"
-         inkscape:connector-curvature="0" />
+         d="m 247.78972,259.06168 -58.16888,-0.0674 V 51.545338 l 59.83429,-0.2166 c 10.39676,0.12515 15.59513,8.22114 15.59513,17.94885 V 240.27532 c 0.45245,10.68074 -6.60386,18.55532 -17.26054,18.78636 z"
+         fill="url(#a)"
+         id="path32"
+         style="display:inline;enable-background:new;fill:url(#a);stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.135116;marker:none;enable-background:accumulate"
-         d="m 332.8125,134.59375 c -2.20909,0.0869 -4.42784,-0.0911 -6.61133,0.28516 -1.38224,0.22431 -1.60142,1.82384 -1.60351,2.96875 -0.0917,6.62149 -0.0825,13.28775 -0.006,19.92773 0.0192,1.24398 0.13084,3.01841 1.61132,3.36523 1.8538,0.43957 3.7673,0.18789 5.6543,0.2754 4.45875,-0.0429 8.92792,0.078 13.36914,-0.14063 1.3211,-0.092 1.95219,-1.41568 2.00977,-2.5918 0.19393,-4.56145 0.0874,-9.12894 0.11719,-13.69336 -0.67163,-1.33956 -1.96127,-2.2232 -2.94336,-3.30664 -2.20736,-2.09576 -4.33245,-4.29283 -6.66211,-6.25195 -1.428,-1.07016 -3.3018,-0.76444 -4.93555,-0.83789 z"
-         id="rect4158-92-6-7-3"
-         inkscape:connector-curvature="0" />
+         d="m 155.74957,51.579038 79.47741,-7.45101 c 10.63261,-1.07337 15.27745,4.6304 15.35928,16.06202 L 249.9124,248.15471 C 249.71986,260.87149 244.03053,267.53311 232.81551,268 L 156.2694,259.06168 H 74.520105 c -10.44007,0 -21.04861,-8.50031 -21.10637,-21.74655 V 72.589138 c 0.3995,-15.23894 6.75308,-20.98122 21.99202,-21.2604 z"
+         fill="url(#b)"
+         id="path34"
+         style="display:inline;enable-background:new;fill:url(#b);stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.135116;marker:none;enable-background:accumulate"
-         d="m 342.43453,133.5 c -0.0499,0 -0.0992,0.005 -0.14846,0.0114 -0.63275,0.19268 -0.84778,1.10823 -0.35998,1.53887 l 5.15449,4.82872 c 0.52901,0.47937 1.38249,0.0699 1.41036,-0.62634 v -1.36063 c 0.0226,-4.21424 0.33006,-4.29412 -3.66401,-4.38062 h -2.24263 c -0.0493,-0.007 -0.0999,-0.0114 -0.14977,-0.0114 z m -12.63559,0.0804 c -5.53701,-3.3e-4 -6.32794,0.58227 -6.29884,6.26467 v 8.19515 8.19514 c -0.0291,5.68242 1.00827,6.26467 6.54528,6.26467 h 11.7978 c 5.49726,0 6.52858,-0.57993 6.54266,-6.15295 v -11.14923 c -0.006,-1.25658 -1.15546,-2.31787 -2.08629,-3.11916 l -0.008,-0.006 -6.70166,-6.47491 c -1.50985,-1.36345 -2.55339,-2.01695 -4.61908,-2.01707 z m 7.22852,2.4196 8.97205,8.99977 v 13.00023 c 0,0 -0.11213,1.17819 -0.44846,1.49951 -0.33633,0.32134 -1.56951,0.42847 -1.56951,0.42847 h -15.96407 c 0,0 -1.23318,-0.10713 -1.56951,-0.42847 -0.33632,-0.32132 -0.44845,-1.49951 -0.44845,-1.49951 l -0.018,-20.07203 c 0,0 0.11213,-1.17819 0.44845,-1.49951 0.33637,-0.32133 1.56955,-0.42846 1.56955,-0.42846 z"
-         id="rect4158-92-6-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 249.9124,248.15471 c -0.19254,12.71678 -5.88187,19.3784 -17.09689,19.84529 l -77.4125,-9.0394 V 51.612728 l 79.82397,-7.4847 c 10.63261,-1.07337 15.27745,4.6304 15.35928,16.06202 z"
+         fill-opacity="0.15"
+         id="path36"
+         style="display:inline;enable-background:new;stroke-width:4.81331" />
       <path
-         style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 323.49951,148 v 0.041 8.19531 c -0.0291,5.68242 1.00791,6.26367 6.54492,6.26367 h 11.79883 c 5.49726,0 6.52889,-0.57932 6.54297,-6.15234 v -8.34764 z"
-         id="rect4398"
-         inkscape:connector-curvature="0" />
+         d="m 363.6711,105.16445 -11.94539,-0.0138 V 62.549489 l 12.2874,-0.04448 c 2.13505,0.0257 3.20257,1.688269 3.20257,3.685924 v 35.115607 c 0.0929,2.19337 -1.35615,3.81047 -3.54458,3.85791 z"
+         fill="url(#a)"
+         id="path415"
+         style="display:inline;enable-background:new;fill:url(#linearGradient425);stroke-width:0.988448" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 353.50267,61.373185 c -0.13268,1.3e-4 -0.25604,0.01264 -0.36719,0.0293 l -0.0781,0.01172 -0.0762,0.02344 c -0.87574,0.279121 -1.39412,1.031903 -1.56445,1.792968 -0.1518,0.678132 0.0116,1.444638 0.51367,2.050782 l -0.36328,-0.363282 -0.01,-0.0078 -0.002,-0.0039 c 0,0 -0.002,0.0038 -0.002,0.0039 -0.28283,-0.267301 -0.55686,-0.524525 -0.83398,-0.767578 h -0.002 l -0.002,-0.0039 -0.002,-0.002 c 0,0 -0.006,-0.0019 -0.006,-0.002 -0.2711,-0.237536 -0.5406,-0.460957 -0.81055,-0.669923 0,0 -0.006,-0.0038 -0.006,-0.0039 -1.8e-4,-8.6e-5 -0.006,-0.0038 -0.006,-0.0039 -0.26922,-0.208011 -0.54257,-0.405967 -0.82617,-0.587891 h -0.002 l -0.002,-0.002 c 0,10e-7 -0.004,-0.0019 -0.004,-0.002 -0.27684,-0.177258 -0.55998,-0.341168 -0.85742,-0.488281 1e-5,0 -0.006,-0.0019 -0.006,-0.002 -0.29595,-0.146081 -0.60404,-0.275888 -0.92383,-0.386719 l -0.004,-0.002 h -0.002 -0.002 c -0.31787,-0.109783 -0.64897,-0.202793 -0.99414,-0.275391 0,-1e-6 -0.009,7.3e-5 -0.01,0 -0.34183,-0.07151 -0.69666,-0.126987 -1.07031,-0.162109 h -0.002 c -0.37669,-0.03533 -0.76878,-0.05072 -1.17774,-0.05078 h -0.002 -8.26738 c -4.1516,0 -6.86541,0.144562 -8.65234,1.832031 -0.89392,0.844181 -1.42053,2.015243 -1.71289,3.464843 -0.29235,1.449602 -0.3762,2.716182 -0.36524,4.956606 v 12.746094 12.751955 c -0.0108,2.23702 0.0732,4.00312 0.36524,5.45117 0.29236,1.44961 0.81896,2.62067 1.71289,3.46485 0.22046,0.20818 0.46372,0.3989 0.72656,0.5664 l 0.004,0.002 0.006,0.004 c 0,0 0.011,0.004 0.0117,0.004 0.24938,0.15738 0.51414,0.29744 0.79688,0.41797 l 0.006,0.002 c 10e-4,5.8e-4 0.003,0.003 0.004,0.004 h 0.002 c 0.001,2.9e-4 0.01,0.003 0.0117,0.004 0.28562,0.12045 0.58739,0.22665 0.90625,0.31446 h 0.002 0.002 c 0.31721,0.0872 0.65158,0.16192 1.00586,0.22265 h 0.004 0.002 0.002 c 0.35215,0.0602 0.71743,0.1063 1.10157,0.14453 2e-5,0 0.005,-1e-5 0.006,0 0.38435,0.0381 0.78775,0.0683 1.21289,0.0899 h 0.004 0.002 c 4.7e-4,1e-5 0.005,-1e-5 0.006,0 l 0.004,0.002 c 3.5e-4,1e-5 0.0746,-7e-5 0.0723,0 0.83602,0.0405 1.74479,0.0566 2.7539,0.0566 h 0.002 17.03691 c 4.12301,0 6.31601,-0.1421 8.10114,-1.80308 0.89298,-0.83017 1.42413,-1.9843 1.72461,-3.41016 0.30048,-1.42587 0.39702,-3.161318 0.40233,-5.359368 v -18.908211 -0.002 c -0.009,-1.901937 -1.18882,-3.38937 -2.32226,-4.541016 -0.37676,-0.382884 -0.75737,-0.733609 -1.10938,-1.050781 l -0.28515,-0.257813 h 0.0273 l -0.0117,-0.01172 h -0.002 l -0.0508,-0.05078 c 0.7203,0.562642 1.63961,0.613597 2.36523,0.31836 0.78035,-0.317514 1.50218,-1.045367 1.54102,-2.060547 v -0.01953 -2.13086 -0.0059 c 0.008,-1.627913 0.0362,-2.366723 -0.0274,-3.374573 -0.0638,-1.009375 -0.20581,-1.850441 -0.73634,-2.546875 -0.53052,-0.696434 -1.36221,-1.029214 -2.28514,-1.181641 -0.92293,-0.152428 -1.53491,-0.178809 -3.02302,-0.212543 h -0.0117 -3.34375 -0.002 c -0.073,-0.0069 -0.14393,-0.0174 -0.2207,-0.01758 z m -24.57206,43.876525 c 7.7e-4,4.2e-4 10e-4,0.002 0.002,0.002 -0.0334,0.003 -0.0689,0.006 -0.0684,0.006 5.2e-4,-8e-5 0.0335,-0.004 0.0664,-0.008 z m -0.0312,1.98438 c 0.005,2.6e-4 0.0335,0.004 0.0645,0.006 -0.0263,-10e-4 -0.0586,-0.004 -0.0586,-0.004 z"
-         id="path964-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccscccccccccccccccccccccccccccccccscsccccccccccccccccccsccccccccccccccc" />
+         d="m 344.77,62.556409 16.32126,-1.530118 c 2.18348,-0.220424 3.13733,0.950886 3.15413,3.298451 l -0.13838,38.599888 c -0.0395,2.61148 -1.20788,3.97949 -3.51097,4.07537 l -15.71929,-1.83555 h -16.7878 c -2.14394,0 -4.32248,-1.7456 -4.33434,-4.46581 V 66.870984 c 0.082,-3.129426 1.38679,-4.308644 4.51621,-4.365975 z"
+         fill="url(#b)"
+         id="path417"
+         style="display:inline;enable-background:new;fill:url(#linearGradient423);stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6668);enable-background:accumulate"
-         d="m 102.92188,46 c -35.29673,0 -38.92188,3.625611 -38.92188,38.994141 v 71.005859 2 71.00586 c 0,35.36853 3.625145,38.99414 38.92188,38.99414 h 98.15624 c 35.29673,0 39.09487,-3.62602 38.92188,-38.99414 v -100.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67689,-10.56116 -18.05782,-15.619141 -32.66602,-15.619141 z m 96.98242,0.08984 c -2.16918,2.775877 -2.38539,7.403545 0.20898,9.912109 l 28.4961,30.386719 c 3.72332,3.695483 11.11677,0.569048 11.38085,-4.777344 -0.11515,-29.584532 -4.14219,-34.875862 -31.35937,-35.521484 z"
-         id="path5316-1" />
+         d="m 364.10701,102.92463 c -0.0395,2.61148 -1.20788,3.97949 -3.51097,4.07537 l -15.89721,-1.8563 V 62.563328 l 16.39243,-1.537037 c 2.18348,-0.220424 3.13733,0.950886 3.15413,3.298451 z"
+         fill-opacity="0.15"
+         id="path419"
+         style="display:inline;enable-background:new;stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter6646);enable-background:accumulate"
-         d="m 102.92188,45 c -35.29673,0 -38.92188,3.625611 -38.92188,38.994141 v 72.005859 1 72.00586 c 0,35.36853 3.625145,38.99414 38.92188,38.99414 h 98.15624 c 35.29673,0 39.09487,-3.62602 38.92188,-38.99414 v -101.76563 c -0.044,-9.7329 -8.17907,-17.95561 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67689,-10.56116 -18.05782,-15.619141 -32.66602,-15.619141 z m 97.96874,0.08984 c -3.03973,2.502305 -3.72055,8.066242 -0.77734,10.912109 l 28.4961,30.386719 c 3.72846,3.700585 11.14006,0.561079 11.38476,-4.798828 -0.032,-30.448516 -3.84872,-35.847323 -31.36328,-36.5 z"
-         id="path5316-84" />
+         d="m 348.82895,161.8029 -7.79047,-0.009 v -27.78336 l 8.01352,-0.029 c 1.39243,0.0168 2.08864,1.10104 2.08864,2.40386 v 22.90148 c 0.0606,1.43046 -0.88445,2.48509 -2.31169,2.51603 z"
+         fill="url(#a)"
+         id="path427"
+         style="display:inline;enable-background:new;fill:url(#linearGradient437);stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -2.17574,0 -4.226353,0.01469 -6.167974,0.04883 -29.48187,0.527845 -32.667968,5.787316 -32.667968,38.945313 v 73.005857 73.00586 c 0,33.158 3.186098,38.41747 32.667968,38.94531 1.941621,0.0341 3.992234,0.0488 6.167974,0.0488 0.0303,10e-6 0.0556,0 0.0859,0 h 98.07031 c 2.20605,0 4.28918,-0.0136 6.25586,-0.0488 29.50026,-0.52789 32.8282,-5.7877 32.66602,-38.94531 v -102.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408197 c -10.67695,-10.561131 -18.05782,-15.619141 -32.66602,-15.619141 z m 99.73242,0.08984 c -4.47461,1.4924 -5.99062,8.576599 -2.54102,11.912109 l 28.4961,30.386719 c 3.74098,3.713002 11.1935,0.541237 11.39062,-4.851563 v -7.191406 c -0.63801,-24.955042 -5.76605,-29.650563 -31.2832,-30.255859 h -3.95313 z"
-         id="path5316-3" />
+         d="m 336.50215,134.01505 10.6443,-0.9979 c 1.42401,-0.14376 2.04608,0.62014 2.05704,2.15116 l -0.0902,25.17384 c -0.0258,1.70314 -0.78775,2.59532 -2.28976,2.65785 l -10.25171,-1.1971 h -10.94857 c -1.39822,0 -2.81901,-1.13843 -2.82674,-2.91248 V 136.8289 c 0.0535,-2.04093 0.90443,-2.80998 2.94535,-2.84737 z"
+         fill="url(#b)"
+         id="path429"
+         style="display:inline;enable-background:new;fill:url(#linearGradient435);stroke-width:0.64464" />
       <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
+         d="m 349.11324,160.34215 c -0.0258,1.70314 -0.78775,2.59532 -2.28976,2.65785 l -10.36775,-1.21063 v -27.76981 l 10.69072,-1.00241 c 1.42401,-0.14376 2.04608,0.62014 2.05704,2.15116 z"
+         fill-opacity="0.15"
+         id="path431"
+         style="display:inline;enable-background:new;stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44.000001 c -35.29672,0 -38.92188,3.62561 -38.92188,38.99414 v 73.005859 73.00586 c 0,35.36853 3.62516,38.99414 38.92188,38.99414 h 98.15625 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 v -102.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67686,-10.56118 -18.05785,-15.61912 -32.66605,-15.61912 z"
-         id="path5316"
-         inkscape:connector-curvature="0" />
+         d="m 341.40787,210.12213 -5.71301,-0.007 v -20.37447 l 5.87658,-0.0213 c 1.02111,0.0123 1.53167,0.80743 1.53167,1.76283 v 16.79442 c 0.0444,1.049 -0.64859,1.8224 -1.69524,1.84509 z"
+         fill="url(#a)"
+         id="path439"
+         style="display:inline;enable-background:new;fill:url(#linearGradient449);stroke-width:0.472736" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 v 2.89258 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 0.0896,-0.53386 0.10352,-1.11551 0.10352,-1.83594 v -3.89844 -2.89844 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 -0.5334,-0.0898 -1.11494,-0.10352 -1.83398,-0.10352 z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
+         d="m 332.36821,189.74437 7.80582,-0.73179 c 1.04428,-0.10543 1.50046,0.45477 1.5085,1.57751 l -0.0661,18.46082 c -0.0189,1.24897 -0.57768,1.90324 -1.67915,1.94909 l -7.51793,-0.87787 h -8.02895 c -1.02536,0 -2.06727,-0.83485 -2.07294,-2.13582 v -16.17845 c 0.0392,-1.49668 0.66325,-2.06065 2.15992,-2.08807 z"
+         fill="url(#b)"
+         id="path441"
+         style="display:inline;enable-background:new;fill:url(#linearGradient447);stroke-width:0.472736" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 340.67578,62.605469 c -3.43174,0.06671 -6.86579,-0.069 -10.28125,0.177734 -1.32146,0.230483 -2.74155,0.837212 -3.16797,2.238281 -0.87859,2.211152 -0.49287,4.527517 -0.61523,6.853516 0.003,9.465066 -0.0838,18.932506 0.0664,28.39648 0.0561,1.74679 0.59196,4.00988 2.50391,4.6211 2.4463,0.78224 5.04875,0.40493 7.57031,0.53515 6.62691,0.007 13.26903,0.0963 19.88282,-0.10742 1.55845,-0.18173 3.54212,-0.54692 4.08398,-2.26367 0.83397,-2.07296 0.59231,-4.283898 0.73437,-6.460937 0.12577,-6.347193 0.03,-12.733501 0.0195,-19.097656 -0.74992,-1.937142 -2.46763,-3.155268 -3.8086,-4.634766 -3.04987,-2.974052 -5.9379,-6.127731 -9.18359,-8.892578 -1.13665,-0.955156 -2.60356,-1.404066 -4.08008,-1.339844 -1.24133,-0.03533 -2.48292,-0.02713 -3.72461,-0.02539 z"
-         id="path964"
-         inkscape:connector-curvature="0" />
+         d="m 341.61635,209.05091 c -0.0189,1.24897 -0.57769,1.90324 -1.67916,1.94909 l -7.60302,-0.88779 v -20.36453 l 7.83986,-0.7351 c 1.04428,-0.10543 1.50046,0.45477 1.5085,1.57751 z"
+         fill-opacity="0.15"
+         id="path443"
+         style="display:inline;enable-background:new;stroke-width:0.472736" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18935);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.205504;marker:none;enable-background:accumulate"
-         d="m 353.5,61.375 c -0.0742,0 -0.1474,0.0066 -0.2207,0.01758 -0.94065,0.29981 -1.26034,1.724451 -0.53516,2.394531 l 7.51367,7.513672 c 0.78643,0.74591 2.35309,0.108771 2.39453,-0.974609 v -2.117188 c 0.0336,-6.55752 0.34204,-6.681806 -5.5957,-6.816406 h -3.33398 c -0.0733,-0.0113 -0.14848,-0.01758 -0.22266,-0.01758 z m -18.26953,0.125 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 v 12.751953 12.751953 c -0.0433,8.842037 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70563,-0.9024 9.72656,-9.574219 v -18.904297 c -0.009,-1.95527 -1.71775,-3.606675 -3.10156,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 c -2.24459,-2.121578 -3.79625,-3.138638 -6.8672,-3.138638 z m 11.26953,3.5 12.5,12.5 v 22.5 c 0,0 -0.1667,1.8333 -0.6667,2.3333 -0.5,0.5 -2.3333,0.6667 -2.3333,0.6667 h -24 c 0,0 -1.8333,-0.1667 -2.3333,-0.6667 -0.5,-0.5 -0.6667,-2.3333 -0.6667,-2.3333 v -32 c 0,0 0.1667,-1.8333 0.6667,-2.3333 0.5,-0.5 2.3333,-0.6667 2.3333,-0.6667 z"
-         id="rect4158-92-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccsscccccsscccsccsccscc" />
+         d="m 333.98684,250.44136 -3.63555,-0.004 v -12.96557 l 3.73964,-0.0135 c 0.6498,0.008 0.9747,0.51382 0.9747,1.1218 v 10.68736 c 0.0283,0.66754 -0.41273,1.15971 -1.07879,1.17415 z"
+         fill="url(#a)"
+         id="path451"
+         style="display:inline;enable-background:new;fill:url(#linearGradient461);stroke-width:0.300832" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.90435,236.5 c 0.71048,0 1.27344,0.0154 1.75195,0.0957 0.47851,0.0803 0.89671,0.23728 1.20703,0.54688 0.31032,0.30959 0.46726,0.7261 0.54688,1.20508 0.0796,0.47897 0.0933,1.04352 0.0898,1.75586 v 3.89648 3.89844 c 0.003,0.71121 -0.0103,1.27546 -0.0898,1.7539 -0.0796,0.47898 -0.23655,0.89549 -0.54688,1.20508 -0.31033,0.3096 -0.72851,0.46655 -1.20703,0.54688 -0.47852,0.0803 -1.04147,0.0957 -1.75195,0.0957 h -5.8086 c -0.71048,0 -1.27236,-0.0153 -1.75,-0.0957 -0.47763,-0.0804 -0.89584,-0.23713 -1.20508,-0.54688 -0.30921,-0.30975 -0.46469,-0.72681 -0.54492,-1.20508 -0.0802,-0.47826 -0.0957,-1.04201 -0.0957,-1.7539 v -3.89844 -3.89844 c 0,-0.71189 0.0155,-1.27564 0.0957,-1.7539 0.0802,-0.47827 0.2357,-0.89533 0.54492,-1.20508 0.30924,-0.30975 0.72745,-0.4665 1.20508,-0.54688 0.47764,-0.0804 1.03952,-0.0957 1.75,-0.0957 z"
-         id="path918"
-         inkscape:connector-curvature="0" />
+         d="m 328.23433,237.47369 4.96734,-0.46568 c 0.66455,-0.0671 0.95484,0.2894 0.95996,1.00387 l -0.0421,11.74779 c -0.012,0.7948 -0.36761,1.21116 -1.06855,1.24033 l -4.78413,-0.55864 h -5.10934 c -0.6525,0 -1.31553,-0.53127 -1.31914,-1.35916 v -10.29538 c 0.0249,-0.95243 0.42207,-1.31132 1.37449,-1.32877 z"
+         fill="url(#b)"
+         id="path453"
+         style="display:inline;enable-background:new;fill:url(#linearGradient459);stroke-width:0.300832" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 336.13453,188.5 c 1.11158,0 1.98683,0.0256 2.70703,0.14648 0.72019,0.1209 1.3105,0.34863 1.74218,0.7793 0.43169,0.43067 0.65954,1.01974 0.7793,1.74024 0.11977,0.72049 0.14217,1.59669 0.13672,2.71093 v 6.12305 6.125 c 0.005,1.1131 -0.017,1.989 -0.13672,2.70898 -0.11976,0.72051 -0.3476,1.30957 -0.7793,1.74024 -0.43169,0.43067 -1.02199,0.6584 -1.74218,0.7793 -0.7202,0.12089 -1.59545,0.14648 -2.70703,0.14648 h -8.26954 c -1.11158,0 -1.98637,-0.0255 -2.70507,-0.14648 -0.7187,-0.12095 -1.30623,-0.34848 -1.73633,-0.7793 -0.4301,-0.43083 -0.6566,-1.01849 -0.77735,-1.73828 -0.12074,-0.71979 -0.14648,-1.59713 -0.14648,-2.71094 v -6.125 -6.125 c 0,-1.11381 0.0257,-1.99115 0.14648,-2.71094 0.12075,-0.71979 0.34725,-1.30745 0.77735,-1.73828 0.4301,-0.43082 1.01763,-0.65835 1.73633,-0.7793 0.7187,-0.12094 1.59349,-0.14648 2.70507,-0.14648 z"
-         id="path914"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1309);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0962,238 c -0.6888,0 -1.1839,0.0205 -1.5039,0.0742 -0.30449,0.0511 -0.38369,0.11806 -0.39649,0.13086 -0.0131,0.0131 -0.0746,0.0855 -0.125,0.38867 -0.0529,0.31839 -0.0733,0.81274 -0.0703,1.50195 v 0.004 3.90039 3.90234 0.002 c -0.003,0.68916 0.0176,1.18495 0.0703,1.50195 0.0504,0.30317 0.1119,0.37557 0.125,0.38867 0.0128,0.0128 0.0918,0.0798 0.39649,0.13086 0.32002,0.0537 0.8151,0.0742 1.5039,0.0742 h 5.8086 c 0.68894,0 1.18348,-0.0206 1.50195,-0.0742 0.30433,-0.0512 0.38043,-0.1186 0.39063,-0.1289 0.0112,-0.0112 0.0774,-0.0858 0.1289,-0.39258 0.0536,-0.31974 0.0742,-0.81575 0.0742,-1.50586 v -3.89855 -3 l -3,-3 z"
-         id="path1291" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1311);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86573,190 c -1.08855,0 -1.90034,0.0312 -2.45898,0.125 -0.54887,0.0921 -0.79683,0.22878 -0.93164,0.36328 -0.13436,0.13404 -0.26642,0.37645 -0.35742,0.92383 -0.0925,0.55627 -0.12219,1.36674 -0.11719,2.45703 v 0.004 6.12695 6.12891 0.002 c -0.005,1.0898 0.0249,1.9019 0.11719,2.45703 0.091,0.5474 0.22306,0.78979 0.35742,0.92383 0.13484,0.13452 0.38277,0.27118 0.93164,0.36328 0.55862,0.0938 1.37043,0.125 2.45898,0.125 h 8.26954 c 1.08864,0 1.90078,-0.0314 2.45703,-0.125 0.54703,-0.0921 0.78777,-0.227 0.92187,-0.36133 0.13429,-0.13451 0.26913,-0.37646 0.36133,-0.92578 0.0936,-0.55811 0.125,-1.37233 0.125,-2.46303 v -6.125 -3 l -7.0005,-7 z"
-         id="path1293"
-         sodipodi:nodetypes="scccccccccccsscccscccs" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 323.0005,200 v 6.125 c -0.0217,4.42101 0.45314,4.875 4.86523,4.875 h 8.26954 c 4.41209,0 4.86523,-0.45393 4.86523,-4.875 v -6.125 z"
-         id="path1007"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 328.0005,237 v 14 h 2.9043 c 2.8077,0 3.0957,-0.28815 3.0957,-3.10156 v -3.89844 -3.89844 c 0,-2.8134 -0.28801,-3.10156 -3.0957,-3.10156 z"
-         id="path1009"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 322.0005,244 v 3.89844 c -0.0138,2.81337 0.28801,3.10156 3.0957,3.10156 h 5.8086 c 2.8077,0 3.0957,-0.28815 3.0957,-3.10156 v -3.89844 z"
-         id="path1016"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 332,188.5 v 23 h 4.13477 c 1.11158,0 1.98683,-0.0256 2.70703,-0.14648 0.72019,-0.1209 1.31049,-0.34863 1.74218,-0.7793 0.4317,-0.43067 0.65954,-1.01973 0.7793,-1.74024 0.11972,-0.71998 0.14172,-1.59588 0.13672,-2.70898 v -6.125 -6.12305 c 0.005,-1.11424 -0.017,-1.99044 -0.13672,-2.71093 -0.11976,-0.7205 -0.34761,-1.30957 -0.7793,-1.74024 -0.43168,-0.43067 -1.02199,-0.6584 -1.74218,-0.7793 -0.7202,-0.12088 -1.59545,-0.14648 -2.70703,-0.14648 z"
-         id="path914-7" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 325.50087,84 v 12.75195 c -0.0433,8.84203 1.49893,9.74805 9.73047,9.74805 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.57422 v -12.92578 z"
-         id="path964-0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient18820-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -35.296735,0 -38.92188,3.625611 -38.92188,38.994141 v 73.005859 73.00586 c 0,35.36853 3.625145,38.99414 38.92188,38.99414 h 98.15624 c 15.44232,0 24.85551,-0.69497 30.54493,-4.4375 0.40638,-0.26732 0.79483,-0.54837 1.16406,-0.84766 2.21537,-1.79573 3.77587,-4.183 4.86523,-7.3457 1.99716,-5.79828 2.40713,-14.20549 2.34766,-26.36328 v -102.76563 c -0.044,-9.7329 -8.17907,-17.95562 -14.76172,-24.16211 l -0.0488,-0.0508 -40.52343,-42.408199 c -10.67695,-10.561131 -18.05782,-15.619141 -32.66602,-15.619141 z m 99.73242,0.08984 c -4.47461,1.4924 -5.99062,8.576599 -2.54102,11.912109 l 28.4961,30.386719 c 3.73355,3.705631 11.16128,0.552964 11.38671,-4.820313 0.0482,-31.329014 -3.55328,-36.818783 -31.36523,-37.478515 h -3.86719 z m -83.08789,11.855468 c 11.374,0.0038 22.6305,0.04069 33.89843,0.246094 7.23783,-0.385044 13.8662,3.453877 18.85547,8.408203 16.10538,15.962833 31.4077,32.714028 47.27735,48.910165 3.41618,3.87653 8.26302,7.7632 8.17382,13.40039 0.36199,29.857 0.15427,59.71908 0.10547,89.57812 -0.26479,10.25015 0.39558,20.69609 -0.9082,30.96484 -0.54694,2.35759 -0.53276,6.03581 -3.5625,6.6504 -7.58888,1.84983 -15.51088,1.47 -23.26758,1.69726 -35.546,0.1779 -71.4284,0.29873 -106.976561,-0.13672 -4.70492,-0.41462 -9.87979,0.006 -14.11914,-2.38476 -2.82731,-3.81876 -2.108913,-9.00357 -2.445313,-13.48438 -0.58273,-48.6454 -0.702174,-97.30598 -0.583984,-145.972658 0.28307,-10.71667 -0.493631,-21.768475 1.568359,-32.4375 0.30831,-3.273361 3.855494,-4.007957 6.496094,-4.410157 11.78749,-1.12799 23.780885,-0.867611 35.488285,-1.029297 z"
-         id="rect4158-92-3" />
+         d="m 334.11951,249.75967 c -0.012,0.7948 -0.36762,1.21116 -1.06855,1.24033 l -4.83829,-0.56495 V 237.4758 l 4.989,-0.46779 c 0.66455,-0.0671 0.95484,0.2894 0.95996,1.00387 z"
+         fill-opacity="0.15"
+         id="path455"
+         style="display:inline;enable-background:new;stroke-width:0.300832" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,156 v 73.00683 c -0.17299,35.36812 3.62515,38.99317 38.921885,38.99317 h 98.15624 c 35.29672,0 38.00361,-3.63655 38.92188,-38.99317 v -73.00683 z"
-         id="path4255"
-         sodipodi:nodetypes="ccssscc" />
+         d="M 165.04888,213.99464 H 94.283575 c -1.57877,0 -2.84949,-0.48615 -2.84949,-1.09744 v -5.6412 c 0,-0.60167 1.27072,-1.09744 2.84949,-1.09744 h 70.765305 c 1.57877,0 2.84949,0.48615 2.84949,1.09744 v 5.6412 c 0,0.60167 -1.27072,1.09744 -2.84949,1.09744 z m 0,-16.39896 H 94.283575 c -1.57877,0 -2.84949,-0.48614 -2.84949,-1.09743 v -5.64121 c 0,-0.60166 1.27072,-1.09743 2.84949,-1.09743 h 70.765305 c 1.57877,0 2.84949,0.48614 2.84949,1.09743 v 5.64121 c 0,0.60166 -1.27072,1.09743 -2.84949,1.09743 z M 95.915285,172.28728 H 212.51777 c 2.48367,0 4.4812,0.48615 4.4812,1.09744 v 5.6412 c 0,0.60648 -1.99753,1.09744 -4.4812,1.09744 H 95.915285 c -2.48367,0 -4.4812,-0.48615 -4.4812,-1.09744 v -5.6412 c 0,-0.60166 1.99753,-1.09744 4.4812,-1.09744 z m 0,-15.28226 H 212.51777 c 2.48367,0 4.4812,0.48133 4.4812,1.09262 v 5.6412 c 0,0.60648 -1.99753,1.09744 -4.4812,1.09744 H 95.915285 c -2.48367,0 -4.4812,-0.48615 -4.4812,-1.09744 v -5.6412 c 0,-0.60166 1.99753,-1.09262 4.4812,-1.09262 z m 50.429065,-9.28488 H 93.292025 c -0.95303,0 -1.71835,-0.48133 -1.71835,-1.09262 v -5.64121 c 0,-0.60647 0.76532,-1.09743 1.71835,-1.09743 h 53.052325 c 0.94823,0 1.71836,0.48614 1.71836,1.09743 v 5.64121 c 0,0.60166 -0.77013,1.09262 -1.71836,1.09262 z m 63.28543,-9.05384 h -38.43911 c -2.66657,0 -4.8085,-2.16118 -4.8085,-4.80369 v -24.02324 c 0,-2.66658 2.14193,-4.8085 4.8085,-4.8085 h 38.43911 c 2.63289,0 4.80369,2.1708 4.80369,4.8085 v 24.02324 c 0,2.6377 -2.1708,4.80369 -4.80369,4.80369 z m -36.03727,-7.20553 h 33.63543 l -10.8107,-14.41587 -8.40886,10.8107 -6.00701,-7.20553 z m -27.35405,-0.23104 H 93.190945 c -0.95303,0 -1.71835,-0.48615 -1.71835,-1.09744 v -5.6412 c 0,-0.60166 0.76532,-1.09743 1.71835,-1.09743 h 53.047515 c 0.95304,0 1.72317,0.48614 1.72317,1.09743 v 5.6412 c 0,0.60167 -0.77013,1.09744 -1.72317,1.09744 z m -0.0674,-17.36162 H 93.118735 c -0.95303,0 -1.71835,-0.48614 -1.71835,-1.09743 v -5.64121 c 0,-0.60166 0.76532,-1.09743 1.71835,-1.09743 h 53.052325 c 0.95304,0 1.71836,0.48614 1.71836,1.09743 v 5.64121 c 0,0.60647 -0.76532,1.09743 -1.71836,1.09743 z"
+         fill="#f3f3f3"
+         fill-rule="nonzero"
+         id="path38"
+         style="display:inline;enable-background:new;stroke-width:4.81331" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 326.0004,84.000002 v 12.251948 c -0.0433,8.84203 0.90629,9.74805 9.73047,9.74805 h 16.53906 c 8.82418,0 9.73047,-0.90592 9.73047,-9.74805 v -12.251948 z"
-         id="path1006"
-         inkscape:connector-curvature="0" />
+         d="m 346.67968,95.909614 h -14.53216 c -0.32421,0 -0.58516,-0.09983 -0.58516,-0.225368 v -1.15846 c 0,-0.123558 0.26095,-0.225367 0.58516,-0.225367 h 14.53216 c 0.32421,0 0.58516,0.09983 0.58516,0.225367 v 1.15846 c 0,0.123558 -0.26095,0.225368 -0.58516,0.225368 z m 0,-3.367644 h -14.53216 c -0.32421,0 -0.58516,-0.09983 -0.58516,-0.225365 v -1.158462 c 0,-0.123555 0.26095,-0.225365 0.58516,-0.225365 h 14.53216 c 0.32421,0 0.58516,0.09983 0.58516,0.225365 v 1.158462 c 0,0.123555 -0.26095,0.225365 -0.58516,0.225365 z M 332.4826,87.344709 h 23.94516 c 0.51004,0 0.92024,0.09983 0.92024,0.225368 v 1.158461 c 0,0.124545 -0.4102,0.225367 -0.92024,0.225367 H 332.4826 c -0.51004,0 -0.92024,-0.09983 -0.92024,-0.225367 v -1.158461 c 0,-0.123555 0.4102,-0.225368 0.92024,-0.225368 z m 0,-3.138321 h 23.94516 c 0.51004,0 0.92024,0.09884 0.92024,0.224377 v 1.158462 c 0,0.124544 -0.4102,0.225367 -0.92024,0.225367 H 332.4826 c -0.51004,0 -0.92024,-0.09983 -0.92024,-0.225367 v -1.158462 c 0,-0.123554 0.4102,-0.224377 0.92024,-0.224377 z m 10.35597,-1.906716 H 331.9439 c -0.19571,0 -0.35288,-0.09884 -0.35288,-0.224378 v -1.158463 c 0,-0.124543 0.15717,-0.225365 0.35288,-0.225365 h 10.89467 c 0.19473,0 0.35288,0.09983 0.35288,0.225365 v 1.158463 c 0,0.123555 -0.15815,0.224378 -0.35288,0.224378 z m 12.99612,-1.859271 h -7.89375 c -0.5476,0 -0.98746,-0.443814 -0.98746,-0.986472 v -4.933343 c 0,-0.547602 0.43986,-0.98746 0.98746,-0.98746 h 7.89375 c 0.54068,0 0.98647,0.445788 0.98647,0.98746 v 4.933343 c 0,0.54167 -0.44579,0.986472 -0.98647,0.986472 z m -7.40051,-1.479707 h 6.90727 l -2.22005,-2.960402 -1.72682,2.220054 -1.23358,-1.479707 z m -5.61735,-0.04745 h -10.89369 c -0.19571,0 -0.35287,-0.09983 -0.35287,-0.225366 v -1.158462 c 0,-0.123555 0.15716,-0.225364 0.35287,-0.225364 h 10.89369 c 0.19571,0 0.35386,0.09983 0.35386,0.225364 v 1.158462 c 0,0.123556 -0.15815,0.225366 -0.35386,0.225366 z m -0.0138,-3.565332 h -10.89468 c -0.19571,0 -0.35287,-0.09983 -0.35287,-0.225366 v -1.158462 c 0,-0.123556 0.15716,-0.225366 0.35287,-0.225366 h 10.89468 c 0.19571,0 0.35287,0.09983 0.35287,0.225366 v 1.158462 c 0,0.124544 -0.15716,0.225366 -0.35287,0.225366 z"
+         fill="#f3f3f3"
+         fill-rule="nonzero"
+         id="path421"
+         style="display:inline;enable-background:new;stroke-width:0.988448" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.000395,227.00586 v 2 c -0.17299,35.36812 3.62515,38.99414 38.921885,38.99414 h 98.15624 c 35.29672,0 38.00361,-3.63752 38.92188,-38.99414 v -2 c -0.91827,35.35662 -3.62516,38.99414 -38.92188,38.99414 h -98.15624 c -35.296735,0 -39.094875,-3.62602 -38.921885,-38.99414 z"
-         id="path945"
-         inkscape:connector-curvature="0" />
+         d="m 337.74759,155.76714 h -9.47749 c -0.21144,0 -0.38163,-0.0651 -0.38163,-0.14698 v -0.75552 c 0,-0.0806 0.17019,-0.14698 0.38163,-0.14698 h 9.47749 c 0.21144,0 0.38163,0.0651 0.38163,0.14698 v 0.75552 c 0,0.0806 -0.17019,0.14698 -0.38163,0.14698 z m 0,-2.19629 h -9.47749 c -0.21144,0 -0.38163,-0.0651 -0.38163,-0.14698 v -0.75552 c 0,-0.0806 0.17019,-0.14697 0.38163,-0.14697 h 9.47749 c 0.21144,0 0.38163,0.0651 0.38163,0.14697 v 0.75552 c 0,0.0806 -0.17019,0.14698 -0.38163,0.14698 z m -9.25896,-3.38952 h 15.61641 c 0.33263,0 0.60015,0.0651 0.60015,0.14698 v 0.75552 c 0,0.0812 -0.26752,0.14698 -0.60015,0.14698 h -15.61641 c -0.33264,0 -0.60016,-0.0651 -0.60016,-0.14698 v -0.75552 c 0,-0.0806 0.26752,-0.14698 0.60016,-0.14698 z m 0,-2.04673 h 15.61641 c 0.33263,0 0.60015,0.0645 0.60015,0.14633 v 0.75552 c 0,0.0812 -0.26752,0.14698 -0.60015,0.14698 h -15.61641 c -0.33264,0 -0.60016,-0.0651 -0.60016,-0.14698 v -0.75552 c 0,-0.0806 0.26752,-0.14633 0.60016,-0.14633 z m 6.75389,-1.24351 h -7.10522 c -0.12764,0 -0.23014,-0.0645 -0.23014,-0.14633 v -0.75552 c 0,-0.0812 0.1025,-0.14698 0.23014,-0.14698 h 7.10522 c 0.127,0 0.23014,0.0651 0.23014,0.14698 v 0.75552 c 0,0.0806 -0.10314,0.14633 -0.23014,0.14633 z m 8.47573,-1.21257 h -5.1481 c -0.35713,0 -0.64399,-0.28944 -0.64399,-0.64335 v -3.2174 c 0,-0.35713 0.28686,-0.64399 0.64399,-0.64399 h 5.1481 c 0.35262,0 0.64335,0.29073 0.64335,0.64399 v 3.2174 c 0,0.35326 -0.29073,0.64335 -0.64335,0.64335 z m -4.82642,-0.96502 h 4.50474 l -1.44786,-1.9307 -1.12618,1.44786 -0.80451,-0.96503 z m -3.66349,-0.031 h -7.10458 c -0.12763,0 -0.23013,-0.0651 -0.23013,-0.14698 v -0.75552 c 0,-0.0806 0.1025,-0.14698 0.23013,-0.14698 h 7.10458 c 0.12764,0 0.23078,0.0651 0.23078,0.14698 v 0.75552 c 0,0.0806 -0.10314,0.14698 -0.23078,0.14698 z m -0.009,-2.32522 h -7.10522 c -0.12764,0 -0.23014,-0.0651 -0.23014,-0.14698 v -0.75552 c 0,-0.0806 0.1025,-0.14697 0.23014,-0.14697 h 7.10522 c 0.12764,0 0.23014,0.0651 0.23014,0.14697 v 0.75552 c 0,0.0812 -0.1025,0.14698 -0.23014,0.14698 z"
+         fill="#f3f3f3"
+         fill-rule="nonzero"
+         id="path433"
+         style="display:inline;enable-background:new;stroke-width:0.64464" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.08;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 180.0004,268 60,-60 v 22.48388 c -0.0523,33.99581 -3.80268,37.51612 -38.1741,37.51612 z"
-         id="path4254"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccsc" />
-      <g
-         transform="translate(-421.005,-292)"
-         id="g72"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 754,370 c -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 h 6 c 0.553,0 1,-0.448 1,-1 0,-0.552 -0.447,-1 -1,-1 z m 0,4 c -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 h 6 c 0.553,0 1,-0.448 1,-1 0,-0.552 -0.447,-1 -1,-1 z m 0,4 c -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 h 6 c 0.553,0 1,-0.448 1,-1 0,-0.552 -0.447,-1 -1,-1 z m 0,4 c -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 h 22 c 0.553,0 1,-0.448 1,-1 0,-0.552 -0.447,-1 -1,-1 z m 0,4 c -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 h 22 c 0.553,0 1,-0.448 1,-1 0,-0.552 -0.447,-1 -1,-1 z m 0,4 c -0.552,0 -1,0.448 -1,1 0,0.552 0.448,1 1,1 h 16 c 0.553,0 1,-0.448 1,-1 0,-0.552 -0.447,-1 -1,-1 z"
-           style="fill:url(#linearGradient1212);fill-rule:nonzero"
-           id="path70" />
-      </g>
-      <g
-         transform="translate(-421.005,-292)"
-         id="g80"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 749.5,437 c -0.277,0 -0.5,0.224 -0.5,0.5 0,0.276 0.223,0.5 0.5,0.5 h 5 c 0.276,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.224,-0.5 -0.5,-0.5 z m 0,2 c -0.277,0 -0.5,0.224 -0.5,0.5 0,0.276 0.223,0.5 0.5,0.5 h 5 c 0.276,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.224,-0.5 -0.5,-0.5 z m 0,2 c -0.277,0 -0.5,0.224 -0.5,0.5 0,0.276 0.223,0.5 0.5,0.5 h 5 c 0.276,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.224,-0.5 -0.5,-0.5 z m 0,2 c -0.277,0 -0.5,0.224 -0.5,0.5 0,0.276 0.223,0.5 0.5,0.5 h 5 c 0.276,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.224,-0.5 -0.5,-0.5 z m 0,2 c -0.277,0 -0.5,0.224 -0.5,0.5 0,0.276 0.223,0.5 0.5,0.5 h 15 c 0.276,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.224,-0.5 -0.5,-0.5 z m 0,2 c -0.277,0 -0.5,0.224 -0.5,0.5 0,0.276 0.223,0.5 0.5,0.5 h 15 c 0.276,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.224,-0.5 -0.5,-0.5 z m 0,2 c -0.277,0 -0.5,0.224 -0.5,0.5 0,0.276 0.223,0.5 0.5,0.5 h 11 c 0.276,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.224,-0.5 -0.5,-0.5 z"
-           style="fill:url(#_Linear10);fill-rule:nonzero"
-           id="path78" />
-      </g>
-      <g
-         transform="translate(-421.005,-292)"
-         id="g84"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 747.5,489 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 3 c 0.277,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.223,-0.5 -0.5,-0.5 z m 0,2 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 3 c 0.277,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.223,-0.5 -0.5,-0.5 z m 0,2 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 3 c 0.277,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.223,-0.5 -0.5,-0.5 z m 0,2 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 11 c 0.277,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.223,-0.5 -0.5,-0.5 z m 0,2 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 11 c 0.277,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.223,-0.5 -0.5,-0.5 z m 0,2 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 5 c 0.277,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.223,-0.5 -0.5,-0.5 z"
-           style="fill:url(#_Linear11);fill-rule:nonzero"
-           id="path82" />
-      </g>
-      <g
-         transform="translate(-421.005,-292)"
-         id="g88"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 745.5,533 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 5 c 0.277,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.223,-0.5 -0.5,-0.5 z m 0,2 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 7 c 0.277,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.223,-0.5 -0.5,-0.5 z m 0,2 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 7 c 0.277,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.223,-0.5 -0.5,-0.5 z m 0,2 c -0.276,0 -0.5,0.224 -0.5,0.5 0,0.276 0.224,0.5 0.5,0.5 h 5 c 0.277,0 0.5,-0.224 0.5,-0.5 0,-0.276 -0.223,-0.5 -0.5,-0.5 z"
-           style="fill:url(#_Linear12);fill-rule:nonzero"
-           id="path86" />
-      </g>
+         d="m 333.28154,205.6959 h -6.95016 c -0.15505,0 -0.27987,-0.0477 -0.27987,-0.10778 v -0.55405 c 0,-0.0591 0.12482,-0.10778 0.27987,-0.10778 h 6.95016 c 0.15505,0 0.27986,0.0477 0.27986,0.10778 v 0.55405 c 0,0.0591 -0.12481,0.10778 -0.27986,0.10778 z m 0,-1.61061 h -6.95016 c -0.15505,0 -0.27987,-0.0477 -0.27987,-0.10778 v -0.55405 c 0,-0.0591 0.12482,-0.10778 0.27987,-0.10778 h 6.95016 c 0.15505,0 0.27986,0.0477 0.27986,0.10778 v 0.55405 c 0,0.0591 -0.12481,0.10778 -0.27986,0.10778 z m -6.78991,-2.48565 h 11.45204 c 0.24393,0 0.44011,0.0477 0.44011,0.10779 v 0.55405 c 0,0.0595 -0.19618,0.10778 -0.44011,0.10778 h -11.45204 c -0.24393,0 -0.44012,-0.0477 -0.44012,-0.10778 v -0.55405 c 0,-0.0591 0.19619,-0.10779 0.44012,-0.10779 z m 0,-1.50093 h 11.45204 c 0.24393,0 0.44011,0.0473 0.44011,0.10731 v 0.55404 c 0,0.0596 -0.19618,0.10779 -0.44011,0.10779 h -11.45204 c -0.24393,0 -0.44012,-0.0477 -0.44012,-0.10779 v -0.55404 c 0,-0.0591 0.19619,-0.10731 0.44012,-0.10731 z m 4.95285,-0.91191 h -5.21049 c -0.0936,0 -0.16877,-0.0473 -0.16877,-0.10731 v -0.55405 c 0,-0.0595 0.0752,-0.10778 0.16877,-0.10778 h 5.21049 c 0.0931,0 0.16877,0.0477 0.16877,0.10778 v 0.55405 c 0,0.0591 -0.0756,0.10731 -0.16877,0.10731 z m 6.21554,-0.88922 h -3.77527 c -0.2619,0 -0.47226,-0.21225 -0.47226,-0.47179 v -2.35942 c 0,-0.2619 0.21036,-0.47226 0.47226,-0.47226 h 3.77527 c 0.25859,0 0.47179,0.2132 0.47179,0.47226 v 2.35942 c 0,0.25906 -0.2132,0.47179 -0.47179,0.47179 z m -3.53937,-0.70768 h 3.30347 l -1.06176,-1.41585 -0.82587,1.06177 -0.58997,-0.70769 z m -2.68656,-0.0227 h -5.21003 c -0.0936,0 -0.16876,-0.0477 -0.16876,-0.10779 v -0.55405 c 0,-0.0591 0.0752,-0.10778 0.16876,-0.10778 h 5.21003 c 0.0936,0 0.16923,0.0477 0.16923,0.10778 v 0.55405 c 0,0.0591 -0.0756,0.10779 -0.16923,0.10779 z m -0.007,-1.70516 h -5.2105 c -0.0936,0 -0.16877,-0.0477 -0.16877,-0.10779 v -0.55405 c 0,-0.0591 0.0752,-0.10777 0.16877,-0.10777 h 5.2105 c 0.0936,0 0.16877,0.0477 0.16877,0.10777 v 0.55405 c 0,0.0596 -0.0752,0.10779 -0.16877,0.10779 z"
+         fill="#f3f3f3"
+         fill-rule="nonzero"
+         id="path445"
+         style="display:inline;enable-background:new;stroke-width:0.472736" />
       <path
-         d="m 97,124 c -2.761,0 -5,2.239 -5,5 0,2.761 2.239,5 5,5 h 30 c 2.761,0 5,-2.239 5,-5 0,-2.761 -2.239,-5 -5,-5 z m 56,0 c -6.075,0 -11,4.925 -11,11 v 28 c 0,6.075 4.925,11 11,11 h 48 c 6.075,0 11,-4.925 11,-11 v -28 c 0,-6.075 -4.925,-11 -11,-11 z m -56,20 c -2.761,0 -5,2.239 -5,5 0,2.761 2.239,5 5,5 h 30 c 2.761,0 5,-2.239 5,-5 0,-2.761 -2.239,-5 -5,-5 z m 0,20 c -2.761,0 -5,2.239 -5,5 0,2.761 2.239,5 5,5 h 30 c 2.761,0 5,-2.239 5,-5 0,-2.761 -2.239,-5 -5,-5 z m 0,20 c -2.761,0 -5,2.239 -5,5 0,2.761 2.239,5 5,5 h 110 c 2.761,0 5,-2.239 5,-5 0,-2.761 -2.239,-5 -5,-5 z m 0,20 c -2.761,0 -5,2.239 -5,5 0,2.761 2.239,5 5,5 h 110 c 2.761,0 5,-2.239 5,-5 0,-2.761 -2.239,-5 -5,-5 z m 0,20 c -2.761,0 -5,2.239 -5,5 0,2.761 2.239,5 5,5 h 80 c 2.761,0 5,-2.239 5,-5 0,-2.761 -2.239,-5 -5,-5 z"
-         style="clip-rule:evenodd;fill:url(#_Linear19);fill-rule:nonzero"
-         id="path162" />
-      <path
-         id="path166"
-         style="clip-rule:evenodd;fill:url(#_Linear20);fill-rule:nonzero"
-         d="M 151.99414 129 C 149.23314 129 146.99414 131.239 146.99414 134 L 146.99414 164 C 146.99414 166.41675 148.71007 168.43231 150.98828 168.89844 C 148.71192 168.4307 147 166.41456 147 164 L 159.16797 144.88086 C 161.76697 140.79686 167.62566 140.5208 170.59766 144.3418 L 181.27148 158.06445 C 181.65148 158.55345 182.38278 158.58105 182.80078 158.12305 L 187.22656 153.27344 C 190.03756 150.19344 194.9013 150.23714 197.6543 153.36914 L 206.99414 163.99609 L 206.99414 134 C 206.99414 131.239 204.75514 129 201.99414 129 L 151.99414 129 z M 206.98047 164.27539 C 206.96631 164.5338 206.93672 164.78867 206.88477 165.03516 C 206.93677 164.78832 206.96635 164.53419 206.98047 164.27539 z M 206.65234 165.78125 C 206.62913 165.84184 206.61728 165.90737 206.5918 165.9668 C 206.61725 165.90737 206.62916 165.84184 206.65234 165.78125 z M 206.17969 166.72266 C 206.16329 166.74778 206.1516 166.77598 206.13477 166.80078 C 206.15165 166.77588 206.16324 166.74788 206.17969 166.72266 z M 205.61523 167.43164 C 205.58182 167.46683 205.5559 167.50876 205.52148 167.54297 C 205.55597 167.50866 205.58176 167.46693 205.61523 167.43164 z M 204.9375 168.02539 C 204.88276 168.06541 204.8357 168.11452 204.7793 168.15234 C 204.83567 168.11448 204.88279 168.06546 204.9375 168.02539 z M 204.12305 168.50977 C 204.05828 168.54033 203.99984 168.58154 203.93359 168.60938 C 203.9999 168.58146 204.05823 168.54042 204.12305 168.50977 z " />
-      <g
-         transform="translate(-421.005,-292)"
-         id="g192"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 765.2,370 c -1.215,0 -2.2,0.985 -2.2,2.2 v 5.6 c 0,1.215 0.985,2.2 2.2,2.2 h 9.6 c 1.215,0 2.2,-0.985 2.2,-2.2 v -5.6 c 0,-1.215 -0.985,-2.2 -2.2,-2.2 z"
-           style="fill:url(#linearGradient1210);fill-rule:nonzero"
-           id="path190" />
-      </g>
-      <path
-         id="path194"
-         style="clip-rule:evenodd;fill:url(#_Linear22);fill-rule:nonzero"
-         d="M 343.99414 79 C 343.44214 79 342.99414 79.448 342.99414 80 L 342.99414 86 L 345.42773 82.175781 C 345.94773 81.358781 347.11984 81.304359 347.71484 82.068359 L 349.84961 84.8125 C 349.92561 84.9105 350.0703 84.915219 350.1543 84.824219 L 351.03906 83.855469 C 351.60206 83.238469 352.57595 83.247047 353.12695 83.873047 L 354.99414 86 L 354.99414 80 C 354.99414 79.448 354.54614 79 353.99414 79 L 343.99414 79 z M 354.9375 86.279297 C 354.92635 86.316785 354.92738 86.359032 354.91211 86.394531 C 354.92752 86.358835 354.92628 86.316996 354.9375 86.279297 z M 343.2832 86.701172 C 343.35558 86.774566 343.44504 86.828616 343.53711 86.876953 C 343.44501 86.828559 343.35558 86.774665 343.2832 86.701172 z M 343.59766 86.916016 C 343.66289 86.944391 343.73703 86.948912 343.80859 86.962891 C 343.73739 86.948909 343.66259 86.944257 343.59766 86.916016 z " />
-      <g
-         transform="translate(-421.005,-292)"
-         id="g204"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 757.54,437 c -0.851,0 -1.54,0.689 -1.54,1.54 v 3.92 c 0,0.851 0.689,1.54 1.54,1.54 h 5.92 c 0.851,0 1.54,-0.689 1.54,-1.54 v -3.92 c 0,-0.851 -0.689,-1.54 -1.54,-1.54 z"
-           style="fill:url(#_Linear23);fill-rule:nonzero"
-           id="path202" />
-      </g>
-      <g
-         transform="translate(-421.005,-292)"
-         id="g208"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 763.3,438 h -5.6 c -0.387,0 -0.7,0.313 -0.7,0.7 v 3.6 c 0,0.387 0.313,0.7 0.7,0.7 h 5.6 c 0.387,0 0.7,-0.313 0.7,-0.7 v -3.6 c 0,-0.387 -0.313,-0.7 -0.7,-0.7 z"
-           style="fill:url(#_Linear24);fill-rule:nonzero"
-           id="path206" />
-      </g>
-      <g
-         transform="translate(-421.005,-292)"
-         id="g212"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 764.357,442.618 v -0.018 l -1.117,-1.383 c -0.387,-0.48 -1.117,-0.487 -1.513,-0.014 l -0.468,0.558 c -0.059,0.071 -0.168,0.066 -0.221,-0.008 l -1.265,-1.771 c -0.413,-0.579 -1.285,-0.539 -1.644,0.075 l -1.486,2.543 c 0,0.386 0.313,0.7 0.7,0.7 h 6.314 c 0.381,0 0.69,-0.304 0.7,-0.682 z"
-           style="fill:#0474b4"
-           id="path210" />
-      </g>
-      <g
-         transform="translate(-421.005,-292)"
-         id="g216"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 753.198,489 c -0.662,0 -1.198,0.536 -1.198,1.198 v 2.604 c 0,0.662 0.536,1.198 1.198,1.198 h 4.604 c 0.662,0 1.198,-0.536 1.198,-1.198 v -2.604 c 0,-0.662 -0.536,-1.198 -1.198,-1.198 z"
-           style="fill:url(#_Linear25);fill-rule:nonzero"
-           id="path214" />
-      </g>
-      <g
-         transform="translate(-421.005,-292)"
-         id="g220"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 757.456,490 h -3.912 c -0.3,0 -0.544,0.244 -0.544,0.544 v 1.912 c 0,0.3 0.244,0.544 0.544,0.544 h 3.912 c 0.3,0 0.544,-0.244 0.544,-0.544 v -1.912 c 0,-0.3 -0.244,-0.544 -0.544,-0.544 z"
-           style="fill:url(#_Linear26);fill-rule:nonzero"
-           id="path218" />
-      </g>
-      <g
-         transform="translate(-421.005,-292)"
-         id="g224"
-         style="clip-rule:evenodd;fill-rule:evenodd">
-        <path
-           d="m 757.993,492.829 -0.624,-0.762 c -0.301,-0.368 -0.863,-0.373 -1.171,-0.011 l -0.193,0.228 c -0.046,0.054 -0.13,0.05 -0.171,-0.007 l -0.698,-0.962 c -0.321,-0.444 -0.993,-0.413 -1.272,0.059 l -0.861,1.452 c 0.041,0.26 0.266,0.458 0.538,0.458 h 3.914 c 0.271,0 0.495,-0.197 0.538,-0.455 z"
-           style="fill:#0474b4"
-           id="path222" />
-      </g>
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline"
-       sodipodi:insensitive="true">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23242,61.5 c -4.11577,0 -6.55968,0.226752 -7.96875,1.558594 -0.28725,0.271486 -0.52183,0.601863 -0.72851,0.972656 -0.0468,0.08393 -0.10154,0.156606 -0.14454,0.246094 -2.5e-4,5.28e-4 2.6e-4,0.0014 0,0.002 -0.11616,0.241982 -0.2184,0.50414 -0.30859,0.789062 -0.0904,0.285534 -0.16955,0.593694 -0.23633,0.925782 -0.0668,0.332095 -0.1223,0.688232 -0.16797,1.070312 -0.0913,0.764147 -0.1422,1.632501 -0.16406,2.617188 -0.0109,0.492345 -0.0144,1.013779 -0.0117,1.566406 v 12.751906 12.751953 c -0.003,0.552627 8e-4,1.074061 0.0117,1.566406 0.0219,0.984686 0.0727,1.853041 0.16406,2.617191 0.0457,0.38208 0.1012,0.73821 0.16797,1.07031 0.13356,0.66417 0.31198,1.23197 0.54492,1.7168 0.23295,0.48482 0.52078,0.88581 0.87305,1.21875 0.17614,0.16648 0.36842,0.31556 0.57813,0.44921 0.41895,0.26701 0.90872,0.47238 1.47656,0.62891 6.2e-4,1.7e-4 0.001,-1.7e-4 0.002,0 1.42142,0.39113 3.3408,0.48047 5.91211,0.48047 h 17.53906 c 1.02156,0 1.93959,-0.015 2.76368,-0.0566 0.34097,-0.0172 0.65525,-0.0427 0.96484,-0.0703 0.0645,-0.006 0.13795,-0.007 0.20117,-0.0137 0.001,-1.4e-4 0.003,1.3e-4 0.004,0 0.73118,-0.0725 1.37505,-0.17995 1.93945,-0.33399 0.28273,-0.0772 0.54639,-0.16492 0.79102,-0.26758 0.24462,-0.10265 0.47066,-0.22006 0.67968,-0.35156 0.20903,-0.1315 0.40024,-0.27771 0.57618,-0.44141 0.15581,-0.14498 0.29602,-0.30775 0.42773,-0.48046 0.017,-0.0223 0.0381,-0.0397 0.0547,-0.0625 0.001,-0.002 0.003,-0.004 0.004,-0.006 0.14374,-0.19776 0.2725,-0.41443 0.38868,-0.6504 0.11725,-0.23815 0.22082,-0.49693 0.3125,-0.77734 0.0917,-0.28041 0.17164,-0.58218 0.24023,-0.9082 0.0686,-0.32602 0.12581,-0.6758 0.17383,-1.05078 0.0428,-0.33417 0.0752,-0.6967 0.10351,-1.072269 0.003,-0.04534 0.0104,-0.0849 0.0137,-0.130859 4.2e-4,-0.0061 -4.3e-4,-0.01341 0,-0.01953 0.059,-0.850021 0.0853,-1.80463 0.0879,-2.88086 v -18.904178 c -0.009,-1.95527 -1.71776,-3.606675 -3.10157,-4.853515 l -0.0117,-0.0098 -8.51758,-8.519531 c -2.24485,-2.121612 -3.79653,-3.138638 -6.86748,-3.138638 z"
-         id="path964-1"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.005859,227.00586 v 2 c -0.0022,0.44238 0.0048,0.82141 0.0039,1.25391 0.0013,0.45945 0.007,0.88359 0.0098,1.33203 -0.01134,-1.48776 -0.02159,-2.96803 -0.01367,-4.58594 z m 175.994141,0.75195 c -0.0555,34.63219 -3.88404,38.24219 -38.91602,38.24219 h -98.15625 c -32.934263,0 -38.440959,-3.18029 -38.890621,-32.33398 0.304544,24.87428 3.489356,31.9654 22.175782,33.76562 0.0033,3.2e-4 0.0064,-3.2e-4 0.0098,0 0.761225,0.073 1.548247,0.13868 2.361328,0.19531 0.002,1.4e-4 0.0039,-1.4e-4 0.0059,0 0.814659,0.0567 1.655065,0.10648 2.523437,0.14844 6.7e-4,3e-5 0.0013,-3e-5 0.002,0 0.579873,0.028 1.24712,0.0365 1.851563,0.0586 1.208255,0.0442 2.391096,0.0937 3.701172,0.11719 0.0014,3e-5 0.0025,-2e-5 0.0039,0 1.964377,0.0351 4.045339,0.0488 6.250009,0.0488 0.002,0 0.004,0 0.006,0 h 98.15039 c 3.67649,0 6.93682,-0.0556 9.96094,-0.16602 2.42031,-0.0885 4.71577,-0.20623 6.75196,-0.40234 19.49586,-1.8777 22.12352,-9.49921 22.20507,-37.08398 -8.2e-4,-0.46208 0.006,-0.86842 0.004,-1.3418 z"
-         id="path5316-8"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 353.49905,61.375285 c -0.0742,0 -0.14719,0.007 -0.22049,0.018 -0.94065,0.29981 -1.25935,1.72298 -0.53417,2.39306 l 7.51333,7.51498 c 0.78643,0.74591 2.35311,0.10873 2.39455,-0.97465 v -2.118 c 0.0336,-6.55752 0.34308,-6.68079 -5.59466,-6.81539 h -3.33561 c -0.0733,-0.0113 -0.14877,-0.018 -0.22295,-0.018 z"
-         id="rect4158-92-6-6"
-         sodipodi:nodetypes="scccccccs" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1004);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         clip-path="url(#clipPath994-5)"
-         d="m 335.23242,61.5 c -8.23154,0 -9.77372,0.906017 -9.73047,9.748047 v 12.751953 12.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.17242,0 9.70564,-0.9024 9.72657,-9.574219 v -17.903968 c -0.006,-1.214011 -0.66655,-2.310001 -1.49805,-3.265625 v 8.243812 12.251953 c 0,2.193451 -0.0614,3.870697 -0.26562,5.087887 -0.20419,1.2172 -0.52867,1.92435 -0.99805,2.39454 -0.46938,0.47016 -1.17436,0.79564 -2.38867,1 -1.21432,0.20434 -2.8892,0.26562 -5.07813,0.26562 h -16.53906 c -2.18893,0 -3.86589,-0.0612 -5.08399,-0.26562 -1.21809,-0.20448 -1.92877,-0.5295 -2.40039,-1 -0.47161,-0.47052 -0.79596,-1.17682 -0.99804,-2.39258 -0.20209,-1.21576 -0.25879,-2.893414 -0.24805,-5.085941 v -0.002 -12.253859 -12.253906 -0.002 c -0.0107,-2.192528 0.046,-3.870175 0.24805,-5.085938 0.20209,-1.215763 0.52643,-1.922078 0.99804,-2.392578 0.47161,-0.4705 1.18426,-0.79553 2.40235,-1 1.21809,-0.204376 2.8931,-0.265578 5.08203,-0.265578 h 12.26953 c -1.40176,-1.001118 -3.79892,-1.5 -5.922,-1.5 z"
-         id="path990"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssccccscccsscccccccccscscss" />
-      <path
-         inkscape:connector-curvature="0"
-         style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0441942;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 353.35547,61.876953 -0.14453,0.121094 c -0.28875,0.242959 -0.43321,0.748579 -0.31836,1.111328 0.007,0.0217 0.07,0.0936 0.11523,0.150391 0.056,-0.101219 0.12158,-0.193105 0.20313,-0.261719 l 0.14453,-0.121094 2.71875,0.02539 c 2.70745,0.02522 3.50936,0.05935 4.26562,0.185547 1.36683,0.228076 1.67801,0.658049 1.79102,2.474609 0.0245,0.393967 0.0317,1.552688 0.0352,2.636719 0.007,-1.466927 -5.4e-4,-3.080545 -0.0352,-3.636719 -0.11301,-1.81656 -0.42419,-2.246533 -1.79102,-2.474609 -0.75626,-0.126199 -1.55817,-0.160327 -4.26562,-0.185547 z"
-         id="path7025" />
-      <path
-         transform="translate(4.9980746e-4)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 v 6.12581 6.12581 c -0.0217,4.42101 0.45311,4.87419 4.8652,4.87419 h 8.2696 c 4.41209,0 4.8652,-0.45312 4.8652,-4.87419 v -6.12581 -6.12581 c 0,-4.42106 -0.45312,-4.87419 -4.86521,-4.87419 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971-6)" />
-      <path
-         id="path1085"
-         d="m 327.86573,188.5 c -1.11158,0 -1.98683,0.0256 -2.70703,0.14648 -0.72019,0.1209 -1.3105,0.34863 -1.74218,0.7793 -0.43169,0.43067 -0.65954,1.01974 -0.7793,1.74024 -0.11977,0.72049 -0.14217,1.59669 -0.13672,2.71093 v 6.12305 6.125 c -0.005,1.1131 0.017,1.989 0.13672,2.70898 0.11976,0.72051 0.3476,1.30957 0.7793,1.74024 0.43169,0.43067 1.02199,0.6584 1.74218,0.7793 0.7202,0.12089 1.59545,0.14648 2.70703,0.14648 h 8.26954 c 1.11158,0 1.98637,-0.0255 2.70507,-0.14648 0.7187,-0.12095 1.30623,-0.34848 1.73633,-0.7793 0.4301,-0.43083 0.6566,-1.01849 0.77735,-1.73828 0.12074,-0.71979 0.14648,-1.59713 0.14648,-2.71094 v -6.125 -6.125 c 0,-1.11381 -0.0257,-1.99115 -0.14648,-2.71094 -0.12075,-0.71979 -0.34725,-1.30745 -0.77735,-1.73828 -0.4301,-0.43082 -1.01763,-0.65835 -1.73633,-0.7793 -0.7187,-0.12094 -1.59349,-0.14648 -2.70507,-0.14648 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path1087"
-         d="m 325.0962,236.5 c -0.71048,0 -1.27344,0.0154 -1.75195,0.0957 -0.47851,0.0803 -0.89671,0.23728 -1.20703,0.54688 -0.31032,0.30959 -0.46726,0.7261 -0.54688,1.20508 -0.0796,0.47897 -0.0933,1.04352 -0.0898,1.75586 v 3.89648 3.89844 c -0.003,0.71121 0.0103,1.27546 0.0898,1.7539 0.0796,0.47898 0.23655,0.89549 0.54688,1.20508 0.31033,0.3096 0.72851,0.46655 1.20703,0.54688 0.47852,0.0803 1.04147,0.0957 1.75195,0.0957 h 5.8086 c 0.71048,0 1.27236,-0.0153 1.75,-0.0957 0.47763,-0.0804 0.89584,-0.23713 1.20508,-0.54688 0.30921,-0.30975 0.46469,-0.72681 0.54492,-1.20508 0.0802,-0.47826 0.0957,-1.04201 0.0957,-1.7539 v -3.89844 -3.89844 c 0,-0.71189 -0.0155,-1.27564 -0.0957,-1.7539 -0.0802,-0.47827 -0.2357,-0.89533 -0.54492,-1.20508 -0.30924,-0.30975 -0.72745,-0.4665 -1.20508,-0.54688 -0.47764,-0.0804 -1.03952,-0.0957 -1.75,-0.0957 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         transform="translate(4.9980746e-4)"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 v 3.89824 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 c 2.8077,0 3.09604,-0.28835 3.09604,-3.10176 v -3.89824 -3.89824 c 0,-2.8134 -0.28835,-3.10176 -3.09604,-3.10176 z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983-6)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.991584;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 342.28662,133.49219 c -0.0504,0 -0.10067,0.005 -0.15039,0.0117 -0.63831,0.19051 -0.85538,1.0957 -0.36328,1.52148 l 5.09961,4.77344 c 0.53367,0.47395 1.59687,0.0693 1.625,-0.61914 v -1.34571 c 0.0228,-4.16669 0.23241,-4.24454 -3.79688,-4.33007 h -2.26367 c -0.0498,-0.007 -0.10004,-0.0117 -0.15039,-0.0117 z m -12.21289,0.004 c -2.78209,0 -4.43425,0.14534 -5.38672,1.00391 -0.19416,0.175 -0.35249,0.38793 -0.49219,0.62695 -0.0316,0.054 -0.0686,0.10247 -0.0976,0.16016 -0.0785,0.156 -0.14802,0.3261 -0.20899,0.50977 -0.0611,0.18405 -0.11501,0.38162 -0.16015,0.5957 -0.0452,0.21409 -0.0824,0.44315 -0.11329,0.68945 -0.0617,0.49261 -0.0965,1.05274 -0.11132,1.6875 -0.007,0.31739 -0.01,0.65353 -0.008,1.00977 v 8.2206 8.2207 c -0.002,0.35623 3.5e-4,0.69239 0.008,1.00977 0.0148,0.63477 0.0495,1.19491 0.11132,1.6875 0.0309,0.24631 0.0682,0.47537 0.11329,0.68945 0.0903,0.42816 0.21168,0.79292 0.36914,1.10547 0.15746,0.31252 0.35171,0.57249 0.58984,0.78711 0.11906,0.10732 0.24887,0.20291 0.39062,0.28906 0.28319,0.17212 0.61423,0.30534 0.99805,0.40625 0.96081,0.25213 2.25995,0.3086 3.99805,0.3086 h 11.85547 c 0.69054,0 1.31013,-0.0106 1.86719,-0.0371 0.23047,-0.0111 0.44308,-0.0272 0.65234,-0.0449 0.0436,-0.004 0.094,-0.004 0.13672,-0.008 h 0.002 c 0.49424,-0.0467 0.92903,-0.11749 1.31055,-0.21679 0.19111,-0.0498 0.36981,-0.10571 0.53515,-0.17188 0.16536,-0.0661 0.31771,-0.14178 0.45899,-0.22656 0.14129,-0.0848 0.2717,-0.17962 0.39062,-0.28516 0.10532,-0.0934 0.20005,-0.19727 0.28907,-0.30859 0.0115,-0.0144 0.0259,-0.0264 0.0371,-0.041 6.7e-4,-0.001 9.5e-4,-0.003 0.002,-0.004 0.0971,-0.12749 0.18514,-0.26586 0.26367,-0.41797 0.0792,-0.15352 0.14897,-0.32121 0.21094,-0.50196 0.062,-0.18077 0.11573,-0.37576 0.16211,-0.58593 0.0464,-0.21016 0.0847,-0.43601 0.11718,-0.67774 0.0289,-0.21541 0.0511,-0.44929 0.0703,-0.6914 0.002,-0.0292 0.008,-0.0543 0.01,-0.084 2.9e-4,-0.004 -2.9e-4,-0.008 0,-0.0117 0.0399,-0.54795 0.0568,-1.16365 0.0586,-1.85742 v -11.18578 c -0.006,-1.26044 -1.16032,-2.32513 -2.09571,-3.1289 l -0.008,-0.006 -6.72986,-6.49196 c -1.51744,-1.36767 -2.56676,-2.02344 -4.64258,-2.02344 z"
-         id="path964-1-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccccccsscccccccccccccccccsscccccccccccccccccccccccss" />
-      <path
-         style="opacity:0.3;fill:url(#linearGradient4316);fill-opacity:1;stroke:none;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 343.16802,134.07487 c -0.99147,0.035 -1.02734,0.0465 -1.02734,0.33594 0,0.10178 0.15173,0.31016 0.45898,0.64648 h 2.87891 c 0.15931,0 0.30929,0.0306 0.45312,0.0762 0.32342,0.02 0.64497,0.0487 0.96485,0.10352 0.0264,0.32124 0.0306,0.64828 0.0371,0.97461 0.0263,0.11154 0.0449,0.2259 0.0449,0.3457 v 2.61719 c 0.25501,0.21272 0.45277,0.36813 0.49023,0.36914 0.45172,0.0121 0.5059,-0.28833 0.46289,-2.54883 -0.0534,-2.80528 0.043,-2.67754 -2.15624,-2.83984 -0.86922,-0.0642 -2.04216,-0.1 -2.60743,-0.0801 z m -10.83984,0.0371 c -5.16676,0.002 -5.89229,0.0632 -6.90234,0.57617 -0.60351,0.30649 -1.03843,1.06517 -1.2461,2.17187 -0.24355,1.30043 -0.239,21.42491 0.006,22.5 0.4115,1.80781 1.06039,2.3312 3.18555,2.56446 0.49142,0.054 4.63516,0.0862 9.20703,0.0723 7.44102,-0.0226 8.39113,-0.0477 9.0625,-0.24023 1.20765,-0.3464 1.67604,-0.80148 2.02539,-1.96289 0.17841,-0.59326 0.21211,-1.68489 0.25391,-8.28321 0.0479,-7.5564 0.0468,-6.60393 -0.21875,-7.15257 -0.0736,-0.15205 -0.33859,-0.46265 -0.72266,-0.875 v 4.07422 c 0,0.12416 -0.0206,0.24218 -0.0488,0.35742 0.0246,3.83198 -0.0428,6.67596 -0.12305,10.47289 0.094,0.98908 -0.26416,2.20979 -1.37304,2.42969 -4.17852,0.21246 -8.39772,0.16055 -12.60547,0.18945 -2.09316,-0.0712 -4.2187,0.13385 -6.29102,-0.20117 -1.20786,-0.09 -1.37139,-1.432 -1.46679,-2.37696 -0.1751,-6.57883 -0.13104,-13.28191 -0.041,-19.88867 0.0853,-1.09208 -0.0376,-2.65795 1.18164,-3.16406 2.366,-0.42229 4.785,-0.2218 7.17578,-0.3125 0.61114,0.0344 0.29054,0.0147 0.94202,0.0117 0.059,-0.007 0.11677,-0.0176 0.17773,-0.0176 h 3.5918 c -0.42688,-0.30915 -0.78914,-0.52782 -1.16797,-0.68359 -0.60974,-0.25114 0.12581,-0.26372 -4.60217,-0.26172 z"
-         id="path4296"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cscscccscccccccccccccccccsccccccccccscccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92188,44 c -2.50815,0 -4.811706,0.02551 -7.011724,0.07227 -1.569122,0.03332 -3.08576,0.07667 -4.505859,0.142578 -0.892728,0.04133 -1.761123,0.08803 -2.597656,0.144531 -0.07361,0.005 -0.155337,0.0086 -0.228516,0.01367 -0.03977,0.0028 -0.07364,0.0069 -0.113281,0.0098 -1.116046,0.0793 -2.169724,0.179402 -3.1875,0.291016 -0.281403,0.03076 -0.565733,0.06033 -0.839844,0.09375 -0.275699,0.03373 -0.547991,0.06893 -0.816406,0.105469 -0.386447,0.0524 -0.76317,0.107595 -1.134766,0.166015 -0.245075,0.0387 -0.493706,0.07575 -0.732422,0.117188 -0.386714,0.06682 -0.756639,0.14256 -1.126953,0.216797 -0.50787,0.102283 -1.000729,0.211021 -1.478515,0.328125 -0.190936,0.04659 -0.386033,0.09158 -0.572266,0.140625 -0.3252,0.08602 -0.638123,0.17771 -0.949219,0.271484 -0.174106,0.05225 -0.347814,0.105413 -0.517578,0.160157 -0.331564,0.107381 -0.657357,0.218707 -0.972656,0.335937 -0.08071,0.02989 -0.158622,0.06125 -0.238281,0.0918 -1.560013,0.600541 -2.923471,1.324701 -4.107422,2.205078 -0.0015,0.0011 -0.0024,0.0028 -0.0039,0.0039 -5.393508,4.01375 -7.137225,11.222093 -7.615234,23.919922 -0.02276,0.605632 -0.04136,1.232203 -0.05859,1.863281 -0.03025,1.104715 -0.05874,2.209903 -0.07422,3.394532 0.478455,-28.913628 6.046265,-32.087925 38.882808,-32.087925 h 62.52929 c -0.85989,-0.295464 -1.74582,-0.553137 -2.65429,-0.783203 -0.15701,-0.03958 -0.31205,-0.08153 -0.47071,-0.119141 -0.38771,-0.0924 -0.78156,-0.17709 -1.17969,-0.257812 -0.28362,-0.0571 -0.57205,-0.108998 -0.86132,-0.160156 -0.33217,-0.05924 -0.66192,-0.122415 -1.00196,-0.173829 -0.61547,-0.09216 -1.24344,-0.171651 -1.88672,-0.238281 -0.25531,-0.02678 -0.51929,-0.04563 -0.77929,-0.06836 -0.49344,-0.04258 -0.99476,-0.07925 -1.50586,-0.107422 -0.26087,-0.01459 -0.52138,-0.03022 -0.78711,-0.04102 -0.75738,-0.03032 -1.52534,-0.05078 -2.32422,-0.05078 z"
-         id="path7814" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 202.6543,44.089844 c -1.07122,0.357279 -1.96732,1.040077 -2.67188,1.910156 h 1.0957 c 34.15314,4e-6 38.64071,3.485189 38.89649,35.746094 0.003,-0.03836 0.0116,-0.07469 0.0137,-0.113282 -0.0538,-17.791919 -1.16737,-27.311888 -7.19531,-32.285156 -0.0612,-0.04994 -0.12336,-0.0994 -0.18555,-0.148437 -0.26948,-0.214754 -0.5509,-0.419295 -0.83984,-0.617188 -0.15131,-0.102604 -0.30423,-0.202591 -0.46094,-0.300781 -0.20346,-0.128728 -0.41408,-0.251698 -0.62695,-0.373047 -0.23799,-0.13444 -0.47866,-0.268909 -0.72852,-0.394531 -0.14196,-0.07198 -0.28962,-0.139823 -0.43555,-0.208984 -0.33143,-0.155843 -0.66556,-0.307266 -1.01757,-0.449219 -0.0474,-0.01925 -0.0968,-0.03764 -0.14453,-0.05664 -4.59757,-1.815644 -10.95134,-2.500623 -19.70704,-2.708984 h -0.0195 -3.86328 z"
-         id="path7812" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 64.011719,81.541016 c -0.0028,0.490545 -0.01172,0.940456 -0.01172,1.453125 v 2 c -0.006,-1.21826 0.0063,-2.314584 0.01172,-3.453125 z"
-         id="rect4158-92-3-3" />
+         d="m 328.81554,247.62467 h -4.42283 c -0.0987,0 -0.1781,-0.0304 -0.1781,-0.0686 v -0.35258 c 0,-0.0376 0.0794,-0.0686 0.1781,-0.0686 h 4.42283 c 0.0987,0 0.1781,0.0303 0.1781,0.0686 v 0.35258 c 0,0.0376 -0.0794,0.0686 -0.1781,0.0686 z m 0,-1.02494 h -4.42283 c -0.0987,0 -0.1781,-0.0303 -0.1781,-0.0686 v -0.35258 c 0,-0.0376 0.0794,-0.0686 0.1781,-0.0686 h 4.42283 c 0.0987,0 0.1781,0.0304 0.1781,0.0686 v 0.35258 c 0,0.0376 -0.0794,0.0686 -0.1781,0.0686 z m -4.32085,-1.58177 h 7.28766 c 0.15523,0 0.28007,0.0303 0.28007,0.0686 v 0.35258 c 0,0.0379 -0.12484,0.0686 -0.28007,0.0686 h -7.28766 c -0.15523,0 -0.28008,-0.0303 -0.28008,-0.0686 v -0.35258 c 0,-0.0376 0.12485,-0.0686 0.28008,-0.0686 z m 0,-0.95514 h 7.28766 c 0.15523,0 0.28007,0.0301 0.28007,0.0683 v 0.35257 c 0,0.0379 -0.12484,0.0686 -0.28007,0.0686 h -7.28766 c -0.15523,0 -0.28008,-0.0303 -0.28008,-0.0686 v -0.35257 c 0,-0.0376 0.12485,-0.0683 0.28008,-0.0683 z m 3.15181,-0.58031 h -3.31576 c -0.0596,0 -0.1074,-0.0301 -0.1074,-0.0683 v -0.35257 c 0,-0.0379 0.0478,-0.0686 0.1074,-0.0686 h 3.31576 c 0.0593,0 0.1074,0.0303 0.1074,0.0686 v 0.35257 c 0,0.0376 -0.0481,0.0683 -0.1074,0.0683 z m 3.95535,-0.56587 h -2.40245 c -0.16666,0 -0.30053,-0.13506 -0.30053,-0.30023 v -1.50145 c 0,-0.16666 0.13387,-0.30052 0.30053,-0.30052 h 2.40245 c 0.16456,0 0.30023,0.13567 0.30023,0.30052 v 1.50145 c 0,0.16486 -0.13567,0.30023 -0.30023,0.30023 z m -2.25233,-0.45034 h 2.10221 l -0.67566,-0.90099 -0.52556,0.67567 -0.37543,-0.45035 z m -1.70963,-0.0144 h -3.31547 c -0.0596,0 -0.10739,-0.0304 -0.10739,-0.0686 v -0.35257 c 0,-0.0376 0.0478,-0.0686 0.10739,-0.0686 h 3.31547 c 0.0596,0 0.10769,0.0303 0.10769,0.0686 v 0.35257 c 0,0.0376 -0.0481,0.0686 -0.10769,0.0686 z m -0.004,-1.08511 h -3.31578 c -0.0596,0 -0.10739,-0.0303 -0.10739,-0.0686 v -0.35258 c 0,-0.0376 0.0478,-0.0686 0.10739,-0.0686 h 3.31578 c 0.0596,0 0.1074,0.0304 0.1074,0.0686 v 0.35258 c 0,0.0379 -0.0479,0.0686 -0.1074,0.0686 z"
+         fill="#f3f3f3"
+         fill-rule="nonzero"
+         id="path457"
+         style="display:inline;enable-background:new;stroke-width:0.300832" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/log-viewer-app.svg
+++ b/icons/src/fullcolor/default/apps/log-viewer-app.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="log-viewer-app.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\log-viewer-app.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="-75"
-     inkscape:cy="21.5"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="2"
+     inkscape:cx="430.5"
+     inkscape:cy="167"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -92,201 +92,55 @@
   </sodipodi:namedview>
   <defs
      id="defs3">
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4346"
-       x="-0.014454287"
-       width="1.0289086"
-       y="-0.011357288"
-       height="1.0227146">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.120027"
-         id="feGaussianBlur4348" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4380"
-       x="-0.057817147"
-       width="1.1156343"
-       y="-0.045429151"
-       height="1.0908583">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="8.4801079"
-         id="feGaussianBlur4382" />
-    </filter>
     <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="169.65668"
-       x2="4.4137931"
-       y1="386.29544"
-       x1="494.34482"
-       id="linearGradient4226"
-       xlink:href="#linearGradient4245"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.957,268)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(0,-38.442841,38.442841,0,292.51964,44.56483)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#313738"
          offset="0"
-         id="stop923" />
+         id="stop2" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#535552"
          offset="1"
-         id="stop925" />
+         id="stop4" />
     </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient916"
+       xlink:href="#a"
+       id="linearGradient910"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05921519,0.05978336,0,313.2699,214.63635)"
-       x1="441.37936"
-       y1="240.30258"
-       x2="52.965523"
-       y2="386.30795" />
+       gradientTransform="matrix(0,-38.442841,38.442841,0,611.18764,103.23283)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient920"
+       xlink:href="#a"
+       id="linearGradient942"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.0386186,0.03904659,0,315.4715,253.54546)"
-       x1="441.37933"
-       y1="240.28154"
-       x2="52.9655"
-       y2="401.42957" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
+       gradientTransform="matrix(0,-25.071418,25.071418,0,510.25281,160.54315)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
+       xlink:href="#a"
+       id="linearGradient974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-19.221421,19.221421,0,465.59382,209.61642)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#a"
+       id="linearGradient1006"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-12.535709,12.535709,0,415.12641,250.27158)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient3194"
-       x1="335.23154"
-       y1="61.500046"
-       x2="352.27026"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004-8"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient3257"
-       x1="330.0751"
-       y1="133.5"
-       x2="341.92554"
-       y2="162.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4245"
-       inkscape:collect="always">
-      <stop
-         id="stop4241"
-         offset="0"
-         style="stop-color:#e8e8e8;stop-opacity:1" />
-      <stop
-         id="stop4243"
-         offset="1"
-         style="stop-color:#f5f5f5;stop-opacity:1" />
-    </linearGradient>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1060"
-       x="-0.024012255"
-       width="1.0480245"
-       y="-0.023987758"
-       height="1.0479755">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.5307812"
-         id="feGaussianBlur1062" />
-    </filter>
+       xlink:href="#a"
+       id="linearGradient1064"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-187.19992,187.19992,0,1453.0876,249.65552)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -386,7 +240,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">log-viewer-app</tspan></text>
+           id="tspan924">log-viewer-app</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -421,1148 +275,394 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86523,189 c -1.12014,0 -2.01524,0.0241 -2.79101,0.1543 -0.77577,0.13022 -1.48014,0.38763 -2.00977,0.91601 -0.52962,0.52838 -0.79079,1.23687 -0.91992,2.01367 -0.12912,0.77681 -0.15002,1.67169 -0.14453,2.79493 V 201 v 6.125 c -0.005,1.12104 0.0156,2.01529 0.14453,2.79102 0.12912,0.77681 0.39029,1.48529 0.91992,2.01367 0.52964,0.52838 1.234,0.78579 2.00977,0.91601 0.77577,0.13022 1.67087,0.1543 2.79101,0.1543 h 8.26954 c 1.12013,0 2.01264,-0.024 2.78711,-0.1543 0.77446,-0.13033 1.48001,-0.38927 2.00781,-0.91797 0.5278,-0.52869 0.78594,-1.23438 0.91601,-2.00976 C 341.97577,209.14258 342,208.24735 342,207.125 V 201 194.875 c 0,-1.12235 -0.0242,-2.01758 -0.1543,-2.79297 -0.13007,-0.77538 -0.38821,-1.48107 -0.91601,-2.00976 -0.5278,-0.5287 -1.23334,-0.78764 -2.00781,-0.91797 C 338.1474,189.02397 337.25491,189 336.13477,189 Z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         d="M 231.80801,44 C 249.57873,44 264,58.421267 264,76.191988 V 235.80801 C 264,253.57873 249.57873,268 231.80801,268 H 72.191988 C 54.421267,268 40,253.57873 40,235.80801 V 76.191988 C 40,58.421267 54.421267,44 72.191988,44 Z"
+         fill="url(#a)"
+         id="path7"
+         style="fill:url(#linearGradient1064);stroke-width:5.1689" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
+         d="M 40,81.50563 V 76.191988 C 40,58.421267 54.421267,44 72.191988,44 H 231.80801 C 249.57873,44 264,58.421267 264,76.191988 v 5.313642 z"
+         fill="#ebebeb"
+         fill-opacity="0.1"
+         id="path9"
+         style="stroke-width:5.1689" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 330.19336,134 c -1.42096,0 -2.54883,0.0308 -3.50586,0.19141 -0.95703,0.16064 -1.79146,0.4726 -2.41211,1.09179 -0.62065,0.61919 -0.93647,1.45612 -1.0957,2.41407 -0.15924,0.95795 -0.18666,2.08705 -0.17969,3.51171 V 149 v 7.79688 c -0.007,1.42131 0.0207,2.5495 0.17969,3.50585 0.15923,0.95796 0.47505,1.79488 1.0957,2.41407 0.62065,0.61919 1.45508,0.93115 2.41211,1.09179 0.95703,0.16065 2.0849,0.19141 3.50586,0.19141 h 11.61523 c 1.42097,0 2.54669,-0.0307 3.50196,-0.19141 0.95527,-0.16075 1.78779,-0.47425 2.40625,-1.09375 0.61845,-0.6195 0.93134,-1.45363 1.09179,-2.41015 C 348.96905,159.34816 349,158.22066 349,156.79688 V 149 141.20312 c 0,-1.42378 -0.031,-2.55128 -0.19141,-3.50781 -0.16045,-0.95653 -0.47334,-1.79065 -1.09179,-2.41015 -0.61846,-0.61951 -1.45098,-0.933 -2.40625,-1.09375 C 344.35528,134.03065 343.22956,134 341.80859,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
+         d="m 264,230.49437 v 5.31364 C 264,253.57873 249.57873,268 231.80801,268 H 72.191988 C 54.421267,268 40,253.57873 40,235.80801 v -5.31364 z"
+         fill-opacity="0.2"
+         id="path11"
+         style="stroke-width:5.1689" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.23093,61.500047 c -2.22316,0 -3.97368,0.05118 -5.41406,0.292969 -1.44039,0.241784 -2.61905,0.695299 -3.48243,1.55664 -0.86337,0.861342 -1.31906,2.039471 -1.55859,3.480469 -0.23953,1.440999 -0.28629,3.195341 -0.27539,5.423828 V 85 97.752143 c -0.0108,2.225063 0.0361,3.978517 0.27539,5.417967 0.23953,1.441 0.69522,2.61913 1.55859,3.48047 0.86338,0.86134 2.04204,1.31486 3.48243,1.55664 1.44039,0.24179 3.1909,0.29297 5.41406,0.29297 h 17.53883 c 2.22317,0 3.97276,-0.0511 5.41017,-0.29297 1.4374,-0.24189 2.61246,-0.69694 3.47265,-1.55859 0.8602,-0.86165 1.31319,-2.03894 1.55468,-3.47852 0.24149,-1.43957 0.29297,-3.190353 0.29297,-5.417967 V 85 72.248094 c 0,-2.227614 -0.0515,-3.978392 -0.29297,-5.417969 -0.24149,-1.439576 -0.69449,-2.616863 -1.55469,-3.478516 -0.86019,-0.861652 -2.03525,-1.316704 -3.47265,-1.558593 -1.4374,-0.24189 -3.187,-0.292969 -5.41016,-0.292969 z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
+         d="M 360.38914,61 C 364.03849,61 367,63.96151 367,67.610855 V 100.38915 C 367,104.03849 364.03849,107 360.38914,107 H 327.61085 C 323.96151,107 321,104.03849 321,100.38915 V 67.610855 C 321,63.96151 323.96151,61 327.61085,61 Z"
+         fill="url(#a)"
+         id="path880"
+         style="fill:url(#linearGradient910);stroke-width:1.06147" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
+         d="M 321,68.702049 V 67.610855 C 321,63.96151 323.96151,61 327.61085,61 h 32.77829 C 364.03849,61 367,63.96151 367,67.610855 v 1.091194 z"
+         fill="#ebebeb"
+         fill-opacity="0.1"
+         id="path882"
+         style="stroke-width:1.06147" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path4350"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 464,514.75001 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4380);enable-background:accumulate"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
+         d="m 367,99.297951 v 1.091199 C 367,104.03849 364.03849,107 360.38914,107 H 327.61085 C 323.96151,107 321,104.03849 321,100.38915 v -1.091199 z"
+         fill-opacity="0.2"
+         id="path884"
+         style="stroke-width:1.06147" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.02028775;marker:none;enable-background:accumulate"
-         d="M 101.8116,42 C 65.712789,42 61.828597,45.690158 62.005519,81.689842 V 156 230.31016 C 61.828597,266.30985 65.712789,270 101.8116,270 h 100.38732 c 36.09881,0 39.80608,-3.68973 39.80608,-39.68984 V 156 81.689842 C 242.005,45.689729 238.29773,42 202.19892,42 Z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 346.68857,133 c 2.38001,0 4.31143,1.93142 4.31143,4.31143 v 21.37714 C 351,161.06858 349.06858,163 346.68857,163 H 325.31143 C 322.93142,163 321,161.06858 321,158.68857 V 137.31143 C 321,134.93142 322.93142,133 325.31143,133 Z"
+         fill="url(#a)"
+         id="path912"
+         style="fill:url(#linearGradient942);stroke-width:0.692263" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 201.07298,44 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 156 229.00647 C 240.16759,264.37459 236.36971,268 201.07298,268 H 102.91622 C 67.619504,268 63.994604,264.375 63.994604,229.00647 V 156 82.99353 C 63.994604,47.624997 67.619504,44 102.91622,44 Z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 239.99414,216.00586 188,268 h 13.07227 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 z"
-         id="rect4158-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188,44 C 67.625152,44 63.82701,47.626029 64,82.994141 v 2 C 63.82701,49.626029 67.625152,46 102.92188,46 h 98.15624 C 236.37485,46 240,49.625608 240,84.994141 v -2 C 240,47.625608 236.37485,44 201.07812,44 Z"
-         id="path931"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
+         d="m 321,138.02307 v -0.71164 C 321,134.93142 322.93142,133 325.31143,133 h 21.37714 c 2.38001,0 4.31143,1.93142 4.31143,4.31143 v 0.71164 z"
+         fill="#ebebeb"
+         fill-opacity="0.1"
          id="path914"
-         d="m 327.636,188.49999 c -4.65703,0 -5.15812,0.47378 -5.1353,5.09575 v 6.40425 6.40426 c -0.0229,4.62196 0.47827,5.09574 5.1353,5.09574 h 8.72869 c 4.65703,0 5.1353,-0.47372 5.1353,-5.09574 v -6.40426 -6.40425 c 0,-4.62202 -0.47828,-5.09575 -5.13531,-5.09575 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+         style="stroke-width:0.692263" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.8545,236.50001 c -3.04166,0 -3.36894,0.30899 -3.35403,3.32331 v 4.17669 4.17668 c -0.0149,3.01433 0.31237,3.32332 3.35403,3.32332 h 6.29146 c 3.04167,0 3.35404,-0.30895 3.35404,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.31238,-3.32331 -3.35404,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 351,157.97692 v 0.71165 C 351,161.06858 349.06858,163 346.68857,163 H 325.31143 C 322.93142,163 321,161.06858 321,158.68857 v -0.71165 z"
+         fill-opacity="0.2"
+         id="path916"
+         style="stroke-width:0.692263" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92728,268 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 C 63.832405,262.37397 67.630549,266 102.92728,266 h 98.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 C 240.0054,264.37439 236.38025,268 201.08352,268 Z"
-         id="path931-8"
-         inkscape:connector-curvature="0" />
+         d="m 340.19457,188.5 c 1.82467,0 3.30543,1.48076 3.30543,3.30543 v 16.38914 c 0,1.82467 -1.48076,3.30543 -3.30543,3.30543 h -16.38914 c -1.82467,0 -3.30543,-1.48076 -3.30543,-3.30543 v -16.38914 c 0,-1.82467 1.48076,-3.30543 3.30543,-3.30543 z"
+         fill="url(#a)"
+         id="path944"
+         style="fill:url(#linearGradient974);stroke-width:0.530735" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 320.5,192.35102 v -0.54559 c 0,-1.82467 1.48076,-3.30543 3.30543,-3.30543 h 16.38914 c 1.82467,0 3.30543,1.48076 3.30543,3.30543 v 0.54559 z"
+         fill="#ebebeb"
+         fill-opacity="0.1"
+         id="path946"
+         style="stroke-width:0.530735" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3257);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 343.5,207.64898 v 0.54559 c 0,1.82467 -1.48076,3.30543 -3.30543,3.30543 h -16.38914 c -1.82467,0 -3.30543,-1.48076 -3.30543,-3.30543 v -0.54559 z"
+         fill-opacity="0.2"
+         id="path948"
+         style="stroke-width:0.530735" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 333.34429,236.5 c 1.19001,0 2.15571,0.96571 2.15571,2.15572 v 10.68857 c 0,1.19001 -0.9657,2.15571 -2.15571,2.15571 h -10.68857 c -1.19001,0 -2.15572,-0.9657 -2.15572,-2.15571 v -10.68857 c 0,-1.19001 0.96571,-2.15572 2.15572,-2.15572 z"
+         fill="url(#a)"
+         id="path976"
+         style="fill:url(#linearGradient1006);stroke-width:0.346132" />
       <path
-         transform="matrix(0.66664182,0,0,0.63636364,106.67522,94.545454)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004-8);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-1)" />
+         d="m 320.5,239.01154 v -0.35582 c 0,-1.19001 0.96571,-2.15572 2.15572,-2.15572 h 10.68857 c 1.19001,0 2.15571,0.96571 2.15571,2.15572 v 0.35582 z"
+         fill="#ebebeb"
+         fill-opacity="0.1"
+         id="path978"
+         style="stroke-width:0.346132" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:1.85638201;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983)"
-         transform="matrix(1.0833332,0,0,1.0714286,-27.333287,-17.428571)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 152,44 v 224 h 49.07227 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 156 82.994141 C 240.16713,47.626029 236.369,44 201.07227,44 Z"
-         id="rect4158-3"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 63.994141,156 v 73.00586 C 63.994141,264.37439 67.6193,268 102.91602,268 h 98.15625 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 156 Z"
-         id="rect4158-8"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 336.50849,211.51179 c 4.23214,0 5.02499,-0.46371 5.00275,-4.98757 v -6.5241 -6.52423 c 0.0222,-4.52386 -0.77061,-4.98757 -5.00275,-4.98757 h -9.01743 c -4.23108,0 -5.00275,0.46366 -5.00275,4.98757 v 6.52423 6.5241 c 0,4.52391 0.77167,4.98757 5.00275,4.98757 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.08651,251.51179 c 2.89732,0 3.44011,-0.30259 3.42488,-3.25454 v -4.25716 -4.25724 c 0.0152,-2.95195 -0.52756,-3.25453 -3.42488,-3.25453 h -6.17331 c -2.8966,0 -3.42488,0.30255 -3.42488,3.25453 v 4.25724 4.25716 c 0,2.95199 0.52828,3.25454 3.42488,3.25454 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 335.5,248.98847 v 0.35582 c 0,1.19001 -0.9657,2.15571 -2.15571,2.15571 h -10.68857 c -1.19001,0 -2.15572,-0.9657 -2.15572,-2.15571 v -0.35582 z"
+         fill-opacity="0.2"
+         id="path980"
+         style="stroke-width:0.346132" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135"
-         width="8"
-         height="8"
-         x="72"
-         y="56"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-7"
-         width="8"
-         height="8"
-         x="72"
-         y="72"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-8"
-         width="8"
-         height="8"
-         x="72"
-         y="88"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-5"
-         width="8"
-         height="8"
-         x="72"
-         y="104"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-73"
-         width="8"
-         height="8"
-         x="72"
-         y="120"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-2"
-         width="8"
-         height="8"
-         x="72"
-         y="136"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-4"
-         width="8"
-         height="8"
-         x="72"
-         y="152"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-71"
-         width="8"
-         height="8"
-         x="72"
-         y="168"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-89"
-         width="8"
-         height="8"
-         x="72"
-         y="184"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-0"
-         width="8"
-         height="8"
-         x="72"
-         y="200"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-3"
-         width="8"
-         height="8"
-         x="72"
-         y="216"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-88"
-         width="8"
-         height="8"
-         x="72"
-         y="232"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-76"
-         width="8"
-         height="8"
-         x="72"
-         y="248"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-9"
-         width="8"
-         height="8"
-         x="224"
-         y="56"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-7-7"
-         width="8"
-         height="8"
-         x="224"
-         y="72"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-8-1"
-         width="8"
-         height="8"
-         x="224"
-         y="88"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-5-6"
-         width="8"
-         height="8"
-         x="224"
-         y="104"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-73-2"
-         width="8"
-         height="8"
-         x="224"
-         y="120"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-2-3"
-         width="8"
-         height="8"
-         x="224"
-         y="136"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-4-7"
-         width="8"
-         height="8"
-         x="224"
-         y="152"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-71-4"
-         width="8"
-         height="8"
-         x="224"
-         y="168"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-89-9"
-         width="8"
-         height="8"
-         x="224"
-         y="184"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-0-1"
-         width="8"
-         height="8"
-         x="224"
-         y="200"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-3-0"
-         width="8"
-         height="8"
-         x="224"
-         y="216"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-88-3"
-         width="8"
-         height="8"
-         x="224"
-         y="232"
-         rx="2"
-         ry="2" />
-      <rect
-         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5135-76-2"
-         width="8"
-         height="8"
-         x="224"
-         y="248"
-         rx="2"
-         ry="2" />
       <path
-         style="display:inline;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 328,138.5 v 0.5 h 16 v -0.5 z m 0,2 v 0.5 h 16 v -0.5 z m 0,2 v 0.5 h 16 v -0.5 z m 0,2 v 0.5 h 16 v -0.5 z m 0,2 v 0.5 h 16 v -0.5 z m 0,2 v 0.5 h 16 v -0.5 z m 0,2 v 0.5 h 16 v -0.5 z m 0,2 v 0.5 h 16 v -0.5 z m 0,2 v 0.5 h 16 v -0.5 z m 0,2 v 0.5 h 16 v -0.5 z"
-         id="path1062"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccc" />
+         d="m 95.793243,177.35795 c 8.347797,0 15.129407,6.78161 15.129407,15.1294 0,8.3478 -6.78161,15.12941 -15.129407,15.12941 -8.347793,0 -15.129408,-6.78161 -15.129408,-15.12941 0,-8.34779 6.781615,-15.1294 15.129408,-15.1294 z m 0,-38.90641 c 8.347797,0 15.129407,6.78161 15.129407,15.12941 0,8.34779 -6.78161,15.1294 -15.129407,15.1294 -8.347793,0 -15.129408,-6.78161 -15.129408,-15.1294 0,-8.3478 6.781615,-15.12941 15.129408,-15.12941 z"
+         fill="#eff0f1"
+         id="path21"
+         style="display:inline;enable-background:new;stroke-width:5.1689" />
       <path
-         style="display:inline;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 332,69 v 1 h 24 v -1 z m 0,3 v 1 h 24 v -1 z m 0,3 v 1 h 24 v -1 z m 0,3 v 1 h 24 v -1 z m 0,3 v 1 h 24 v -1 z m 0,3 v 1 h 24 v -1 z m 0,3 v 1 h 24 v -1 z m 0,3 v 1 h 24 v -1 z m 0,3 v 1 h 24 v -1 z m 0,3 v 1 h 24 v -1 z"
-         id="rect1105"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccc" />
+         d="m 95.793243,181.67916 c 5.964927,0 10.808197,4.84327 10.808197,10.80819 0,5.96493 -4.84327,10.8082 -10.808197,10.8082 -5.964925,0 -10.808195,-4.84327 -10.808195,-10.8082 0,-5.96492 4.84327,-10.80819 10.808195,-10.80819 z m 0,-38.90641 c 5.964927,0 10.808197,4.84328 10.808197,10.8082 0,5.96493 -4.84327,10.8082 -10.808197,10.8082 -5.964925,0 -10.808195,-4.84327 -10.808195,-10.8082 0,-5.96492 4.84327,-10.8082 10.808195,-10.8082 z"
+         fill="#3daefd"
+         id="path23"
+         style="display:inline;enable-background:new;stroke-width:5.1689" />
       <path
-         style="display:inline;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 327,193.5 v 0.5 h 10 v -0.5 z m 0,2 v 0.5 h 10 v -0.5 z m 0,2 v 0.5 h 10 v -0.5 z m 0,2 v 0.5 h 10 v -0.5 z m 0,2 v 0.5 h 10 v -0.5 z m 0,2 v 0.5 h 10 v -0.5 z m 0,2 v 0.5 h 10 v -0.5 z"
-         id="path1052"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccc" />
+         d="m 123.89662,108.18756 v 4.32121 h -8.64759 v -4.32121 z m 17.29001,0 v 4.32121 h -12.9688 v -4.32121 z"
+         fill="#da4453"
+         id="path25"
+         style="display:inline;enable-background:new;stroke-width:5.1689" />
       <path
-         style="display:inline;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 325,241.5 v 0.5 h 6 v -0.5 z m 0,2 v 0.5 h 6 v -0.5 z m 0,2 v 0.5 h 6 v -0.5 z m 0,2 v 0.5 h 6 v -0.5 z"
-         id="path1078"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccccccccc" />
+         d="m 145.51301,194.65313 v 4.32121 h -30.26398 v -4.32121 z m -17.29518,-38.91158 v 4.32122 h -12.9688 v -4.32122 z m 4.32638,-38.91157 v 4.32121 h -17.29518 v -4.32121 z m 12.9688,0 v 4.32121 h -8.64758 v -4.32121 z"
+         fill="#bdc3c7"
+         id="path27"
+         style="display:inline;enable-background:new;stroke-width:5.1689" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 88,80.074229 v 4 h 128 v -4 z"
-         id="path5686" />
+         d="m 193.06701,194.65313 h 8.64759 v 4.32121 h -8.64759 z m -4.32121,4.32121 h -34.58519 v -4.32121 h 34.58519 z m 34.58519,-8.64759 h -8.64759 v -4.32121 h 8.64759 z m -12.9688,0 h -12.9688 v -4.32121 h 12.9688 z m -17.29001,0 h -38.91157 v -4.32121 h 38.91157 z m -25.94277,-30.26398 h -12.9688 v -4.32122 h 12.9688 z m 8.64242,0 h -4.32121 v -4.32122 h 4.32121 z m 25.94277,0 h -21.61639 v -4.32122 h 21.61639 z m -21.61639,-12.96881 h 17.29518 v 4.32121 h -17.29518 z m 21.61639,0 h 21.61639 v 4.32121 H 201.7146 Z m -30.25881,4.32121 h -17.29518 v -4.32121 h 17.29518 z m 17.29001,-30.26398 h -34.58519 v -4.32121 h 34.58519 z m -21.61639,-8.64242 h -12.9688 v -4.32121 h 12.9688 z m 56.20675,0 h -17.29518 v -4.32121 h 17.29518 z m -21.62156,0 H 175.777 v -4.32121 h 25.9376 z"
+         fill="#e5fdff"
+         id="path29"
+         style="display:inline;enable-background:new;stroke-width:5.1689" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 88,96.07423 v 4 h 128 v -4 z"
-         id="path5684" />
+         d="m 136.86543,186.00554 v 4.32121 h -21.6164 v -4.32121 z m -12.96881,-38.91158 v 4.32121 h -8.64759 v -4.32121 z m 17.29001,0 v 4.32121 h -12.9688 v -4.32121 z"
+         fill="#3daefd"
+         id="path31"
+         style="display:inline;enable-background:new;stroke-width:5.1689" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="M 88,112.00001 V 116 h 128 v -3.99999 z"
-         id="path5682" />
+         d="m 95.798414,99.203987 -15.134579,6.342253 c 0,0 1.80395,8.22374 3.747462,12.98431 0.976927,2.38287 2.165773,4.85361 3.845671,6.99354 1.679897,2.13993 4.171313,4.27986 7.541446,4.27986 3.375301,0 5.856376,-2.13993 7.536276,-4.27986 1.67989,-2.13993 2.86874,-4.61067 3.84567,-6.99354 1.94868,-4.76057 3.75263,-12.98431 3.75263,-12.98431 z"
+         fill="#eff0f1"
+         id="path33"
+         style="display:inline;enable-background:new;stroke-width:5.1689" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 88,128 v 4 h 128 v -4 z"
-         id="path5680" />
+         d="m 84.985048,108.18756 10.808195,-4.32638 10.808197,4.32638 c 0,0 -4.00591,17.29001 -10.808197,17.29001 -6.791953,0 -10.808195,-17.29001 -10.808195,-17.29001 z"
+         fill="#da4453"
+         id="path35"
+         style="display:inline;enable-background:new;stroke-width:5.1689" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.687471;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1198"
+         cx="74.392349"
+         cy="62.752815"
+         r="13.167902" />
+      <circle
+         r="13.167902"
+         cy="62.752815"
+         cx="113.1961"
+         id="circle1200"
+         style="display:inline;enable-background:new;fill:#ffbe2f;fill-opacity:1;fill-rule:evenodd;stroke:#dfa22a;stroke-width:0.687471;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <circle
+         style="display:inline;enable-background:new;fill:#28ca40;fill-opacity:1;fill-rule:evenodd;stroke:#1bac2c;stroke-width:0.687471;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1202"
+         cx="152"
+         cy="62.752815"
+         r="13.167902" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 88,144 v 4 l 128,0.0742 v -4 z"
-         id="path5678" />
+         d="m 332.45754,88.386007 c 1.71428,0 3.10693,1.392653 3.10693,3.106932 0,1.714279 -1.39265,3.106932 -3.10693,3.106932 -1.71428,0 -3.10693,-1.392653 -3.10693,-3.106932 0,-1.714279 1.39265,-3.106932 3.10693,-3.106932 z m 0,-7.989708 c 1.71428,0 3.10693,1.392652 3.10693,3.106932 0,1.714279 -1.39265,3.106931 -3.10693,3.106931 -1.71428,0 -3.10693,-1.392652 -3.10693,-3.106931 0,-1.71428 1.39265,-3.106932 3.10693,-3.106932 z"
+         fill="#eff0f1"
+         id="path886"
+         style="display:inline;enable-background:new;stroke-width:1.06147" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 88,160 v 4 h 128 v -4 z"
-         id="path5676" />
+         d="m 332.45754,89.273399 c 1.22494,0 2.21954,0.9946 2.21954,2.21954 0,1.22494 -0.9946,2.21954 -2.21954,2.21954 -1.22494,0 -2.21954,-0.9946 -2.21954,-2.21954 0,-1.22494 0.9946,-2.21954 2.21954,-2.21954 z m 0,-7.989709 c 1.22494,0 2.21954,0.994601 2.21954,2.219541 0,1.22494 -0.9946,2.21954 -2.21954,2.21954 -1.22494,0 -2.21954,-0.9946 -2.21954,-2.21954 0,-1.22494 0.9946,-2.219541 2.21954,-2.219541 z"
+         fill="#3daefd"
+         id="path888"
+         style="display:inline;enable-background:new;stroke-width:1.06147" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 88,176 v 4 h 128 v -4 z"
-         id="path5674" />
+         d="m 338.22877,74.181373 v 0.887392 h -1.77584 v -0.887392 z m 3.55063,0 v 0.887392 h -2.66324 v -0.887392 z"
+         fill="#da4453"
+         id="path890"
+         style="display:inline;enable-background:new;stroke-width:1.06147" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 88,192 v 4 l 128,0.0742 v -4 z"
-         id="path5672" />
+         d="m 342.66785,91.937696 v 0.887392 h -6.21492 v -0.887392 z m -3.55169,-7.99077 v 0.887392 h -2.66323 v -0.887392 z m 0.88845,-7.990769 v 0.887391 h -3.55168 v -0.887391 z m 2.66324,0 v 0.887391 h -1.77584 v -0.887391 z"
+         fill="#bdc3c7"
+         id="path892"
+         style="display:inline;enable-background:new;stroke-width:1.06147" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 88,208 v 4 h 128 v -4 z"
-         id="path5670" />
+         d="m 352.4334,91.937696 h 1.77585 v 0.887392 h -1.77585 z m -0.88739,0.887392 h -7.10231 v -0.887392 h 7.10231 z m 7.10232,-1.775845 h -1.77585 v -0.887391 h 1.77585 z m -2.66324,0 h -2.66323 v -0.887391 h 2.66323 z m -3.55062,0 h -7.99077 v -0.887391 h 7.99077 z m -5.32754,-6.214925 h -2.66323 v -0.887392 h 2.66323 z m 1.77478,0 h -0.88739 v -0.887392 h 0.88739 z m 5.32754,0 h -4.43908 v -0.887392 h 4.43908 z m -4.43908,-2.663236 h 3.55169 v 0.887391 h -3.55169 z m 4.43908,0 h 4.43908 v 0.887391 h -4.43908 z m -6.21387,0.887391 h -3.55168 v -0.887391 h 3.55168 z m 3.55063,-6.214925 h -7.10231 v -0.887391 h 7.10231 z m -4.43908,-1.774783 h -2.66323 v -0.887392 h 2.66323 z m 11.54246,0 h -3.55169 v -0.887392 h 3.55169 z m -4.44014,0 h -5.32647 v -0.887392 h 5.32647 z"
+         fill="#e5fdff"
+         id="path894"
+         style="display:inline;enable-background:new;stroke-width:1.06147" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 88,224 v 4 h 128 v -4 z"
-         id="path1032" />
+         d="m 340.89201,90.161852 v 0.887391 h -4.43908 v -0.887391 z m -2.66324,-7.99077 v 0.887391 h -1.77584 v -0.887391 z m 3.55063,0 v 0.887391 h -2.66324 v -0.887391 z"
+         fill="#3daefd"
+         id="path896"
+         style="display:inline;enable-background:new;stroke-width:1.06147" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:11.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1060);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 143.87487,83.00001 c -35.29804,0 -64,28.70196 -64,63.99999 0,35.29804 28.70196,64 64,64 15.45232,0 29.63935,-5.50209 40.70898,-14.64844 l 6.89063,6.89063 -1.41406,1.41406 31.49999,31.5 11.31445,-11.3125 -31.49999,-31.5 -1.41406,1.41406 -6.88086,-6.88086 C 202.31152,176.78253 207.87487,162.5323 207.87487,147 c 0,-35.29803 -28.70196,-63.99999 -64,-63.99999 z m 0,8.136719 c 30.90124,0 55.86523,24.962031 55.86523,55.863271 0,30.90124 -24.96399,55.86523 -55.86523,55.86523 -30.90124,0 -55.86523,-24.96399 -55.86523,-55.86523 0,-30.90124 24.96399,-55.863271 55.86523,-55.863271 z"
-         id="path1030"
-         inkscape:connector-curvature="0" />
-      <g
-         style="display:inline;enable-background:new"
-         transform="matrix(0.1,0,0,0.1,302.19306,137.15412)"
-         id="g988">
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path978"
-           d="m 380.06781,150.4619 -12.00001,-12"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#888888;stroke-width:11.99999905;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:15.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 418.0678,188.4619 -40,-40"
-           id="path980"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <g
-           style="display:inline;enable-background:new"
-           id="g982"
-           transform="matrix(-1,0,0,1,495,-64.578123)" />
-        <circle
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:#666666;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           id="circle984"
-           cx="318.06778"
-           cy="88.461899"
-           r="65" />
-        <circle
-           r="20"
-           cy="68.461899"
-           cx="298.06781"
-           id="circle986"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:none;stroke-width:7.76698923;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      </g>
-      <g
-         style="display:inline;enable-background:new"
-         id="g1125"
-         transform="translate(-1.99984,4.0000072)">
-        <g
-           transform="matrix(-1,0,0,1,319.8747,3.1e-4)"
-           id="g1131"
-           style="display:inline;enable-background:new">
-          <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4480"
-             d="m 116.15722,195.99999 12.00001,-12"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#888888;stroke-width:11.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <path
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:15.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-             d="m 88.657217,223.49999 31.500013,-31.5"
-             id="path4478"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
-        </g>
-        <g
-           transform="matrix(-1,0,0,1,317.8747,3.1e-4)"
-           id="g1087"
-           style="display:inline;enable-background:new" />
-        <circle
-           r="59.932201"
-           cy="140.00032"
-           cx="147.87471"
-           id="path4260"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:#666666;stroke-width:8.13559246;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      </g>
-      <rect
-         style="opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect5282"
-         width="2"
-         height="2"
-         x="328"
-         y="65"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-1"
-         width="2"
-         height="2"
-         x="328"
-         y="69"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6"
-         width="2"
-         height="2"
-         x="328"
-         y="73"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-1"
-         width="2"
-         height="2"
-         x="328"
-         y="77"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-2"
-         width="2"
-         height="2"
-         x="328"
-         y="81"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-4"
-         width="2"
-         height="2"
-         x="328"
-         y="85"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-0"
-         width="2"
-         height="2"
-         x="328"
-         y="89"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-49"
-         width="2"
-         height="2"
-         x="328"
-         y="93"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-3"
-         width="2"
-         height="2"
-         x="328"
-         y="97"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-19"
-         width="2"
-         height="2"
-         x="328"
-         y="101"
-         rx="0.5"
-         ry="0.5" />
-      <g
-         transform="matrix(0.20789396,0,0,0.20789397,273.2307,65.057053)"
-         id="g1064"
-         style="display:inline;stroke-width:0.48101443;enable-background:new">
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path1054"
-           d="m 376.46053,127.17058 -12.00001,-12"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#888888;stroke-width:9.62028885;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:14.43043327;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 404.46052,155.17058 -30,-30"
-           id="path1056"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <g
-           style="display:inline;stroke-width:0.48101443;enable-background:new"
-           id="g1058"
-           transform="matrix(-1,0,0,1,495,-64.578123)" />
-        <circle
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:#666666;stroke-width:9.62028885;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           id="circle1060"
-           cx="325.97937"
-           cy="76.68943"
-           r="52.911591" />
-        <circle
-           r="14.430433"
-           cy="62.258999"
-           cx="311.54892"
-           id="circle1062"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:none;stroke-width:3.73603368;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      </g>
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-9"
-         width="2"
-         height="2"
-         x="358"
-         y="65"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-1-5"
-         width="2"
-         height="2"
-         x="358"
-         y="69"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-18"
-         width="2"
-         height="2"
-         x="358"
-         y="73"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-1-1"
-         width="2"
-         height="2"
-         x="358"
-         y="77"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-2-3"
-         width="2"
-         height="2"
-         x="358"
-         y="81"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-4-2"
-         width="2"
-         height="2"
-         x="358"
-         y="85"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-0-0"
-         width="2"
-         height="2"
-         x="358"
-         y="89"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-49-1"
-         width="2"
-         height="2"
-         x="358"
-         y="93"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-3-7"
-         width="2"
-         height="2"
-         x="358"
-         y="97"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-6-19-3"
-         width="2"
-         height="2"
-         x="358"
-         y="101"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-2"
-         width="2"
-         height="2"
-         x="325"
-         y="137"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-63"
-         width="2"
-         height="2"
-         x="325"
-         y="141"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-28"
-         width="2"
-         height="2"
-         x="325"
-         y="145"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-5"
-         width="2"
-         height="2"
-         x="325"
-         y="149"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-68"
-         width="2"
-         height="2"
-         x="325"
-         y="153"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-10"
-         width="2"
-         height="2"
-         x="325"
-         y="157"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-2-2"
-         width="2"
-         height="2"
-         x="345"
-         y="137"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-63-1"
-         width="2"
-         height="2"
-         x="345"
-         y="141"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-28-7"
-         width="2"
-         height="2"
-         x="345"
-         y="145"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-5-1"
-         width="2"
-         height="2"
-         x="345"
-         y="149"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-68-0"
-         width="2"
-         height="2"
-         x="345"
-         y="153"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-10-5"
-         width="2"
-         height="2"
-         x="345"
-         y="157"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-10-9"
-         width="2"
-         height="2"
-         x="324"
-         y="191"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-10-3"
-         width="2"
-         height="2"
-         x="324"
-         y="195"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-10-30"
-         width="2"
-         height="2"
-         x="324"
-         y="199"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-10-0"
-         width="2"
-         height="2"
-         x="324"
-         y="203"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-10-36"
-         width="2"
-         height="2"
-         x="324"
-         y="207"
-         rx="0.5"
-         ry="0.5" />
-      <g
-         style="display:inline;enable-background:new"
-         id="g1050"
-         transform="matrix(0.1,0,0,0.1,298.19306,191.15412)">
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#888888;stroke-width:11.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 380.06781,130.4619 -12.00001,-12"
-           id="path4480-9"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4478-1"
-           d="m 408.0678,158.4619 -30,-30"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:15.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <g
-           transform="matrix(-1,0,0,1,495,-64.578123)"
-           id="g1087-2"
-           style="display:inline;enable-background:new" />
-        <circle
-           r="55"
-           cy="78.461899"
-           cx="328.06778"
-           id="path4260-0"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:#666666;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <circle
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:none;stroke-width:7.76698875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           id="circle4415-6"
-           cx="313.06781"
-           cy="63.461899"
-           r="15" />
-      </g>
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-10-9-7"
-         width="2"
-         height="2"
-         x="338"
-         y="191"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-10-3-0"
-         width="2"
-         height="2"
-         x="338"
-         y="195"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-10-30-5"
-         width="2"
-         height="2"
-         x="338"
-         y="199"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-10-0-5"
-         width="2"
-         height="2"
-         x="338"
-         y="203"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5282-10-36-7"
-         width="2"
-         height="2"
-         x="338"
-         y="207"
-         rx="0.5"
-         ry="0.5" />
-      <rect
-         style="opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect5588"
-         width="1"
-         height="1"
-         x="323"
-         y="238"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-7"
-         width="1"
-         height="1"
-         x="323"
-         y="240"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-2"
-         width="1"
-         height="1"
-         x="323"
-         y="242"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-28"
-         width="1"
-         height="1"
-         x="323"
-         y="244"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-26"
-         width="1"
-         height="1"
-         x="323"
-         y="246"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-6"
-         width="1"
-         height="1"
-         x="323"
-         y="248"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-63"
-         width="1"
-         height="1"
-         x="323"
-         y="250"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-5"
-         width="1"
-         height="1"
-         x="332"
-         y="238"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-7-0"
-         width="1"
-         height="1"
-         x="332"
-         y="240"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-2-0"
-         width="1"
-         height="1"
-         x="332"
-         y="242"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-28-8"
-         width="1"
-         height="1"
-         x="332"
-         y="244"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-26-6"
-         width="1"
-         height="1"
-         x="332"
-         y="246"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-6-9"
-         width="1"
-         height="1"
-         x="332"
-         y="248"
-         rx="0.25"
-         ry="0.25" />
-      <rect
-         style="display:inline;opacity:0.3;fill:#000000;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="rect5588-63-5"
-         width="1"
-         height="1"
-         x="332"
-         y="250"
-         rx="0.25"
-         ry="0.25" />
-      <g
-         style="display:inline;enable-background:new"
-         transform="matrix(0.1,0,0,0.1,295.19306,237.15412)"
-         id="g1252">
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path1242"
-           d="m 350.06781,90.4619 -7.50566,-7"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#888888;stroke-width:11.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:15.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 368.0678,108.4619 -20,-20"
-           id="path1244"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <g
-           style="display:inline;enable-background:new"
-           id="g1246"
-           transform="matrix(-1,0,0,1,495,-64.578123)" />
-        <circle
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:#666666;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           id="circle1248"
-           cx="318.06778"
-           cy="58.461903"
-           r="35" />
-        <circle
-           r="10"
-           cy="48.461899"
-           cx="308.06781"
-           id="circle1250"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.54292345;fill-rule:nonzero;stroke:none;stroke-width:7.76698875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      </g>
+         d="m 332.4586,72.336533 -3.10799,1.302428 c 0,0 0.37045,1.688803 0.76957,2.66642 0.20062,0.489339 0.44475,0.996723 0.78973,1.436173 0.34498,0.43945 0.85661,0.8789 1.54869,0.8789 0.69314,0 1.20265,-0.43945 1.54763,-0.8789 0.34498,-0.43945 0.58912,-0.946834 0.78974,-1.436173 0.40017,-0.977617 0.77063,-2.66642 0.77063,-2.66642 z"
+         fill="#eff0f1"
+         id="path898"
+         style="display:inline;enable-background:new;stroke-width:1.06147" />
+      <path
+         d="m 330.238,74.181373 2.21954,-0.888453 2.21954,0.888453 c 0,0 -0.82264,3.550628 -2.21954,3.550628 -1.39477,0 -2.21954,-3.550628 -2.21954,-3.550628 z"
+         fill="#da4453"
+         id="path900"
+         style="display:inline;enable-background:new;stroke-width:1.06147" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.141177;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle902"
+         cx="328.06271"
+         cy="64.851021"
+         r="2.7041228" />
+      <circle
+         r="2.7041228"
+         cy="64.851021"
+         cx="336.03134"
+         id="circle904"
+         style="display:inline;enable-background:new;fill:#ffbe2f;fill-opacity:1;fill-rule:evenodd;stroke:#dfa22a;stroke-width:0.141177;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <circle
+         style="display:inline;enable-background:new;fill:#28ca40;fill-opacity:1;fill-rule:evenodd;stroke:#1bac2c;stroke-width:0.141177;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle906"
+         cx="344"
+         cy="64.851021"
+         r="2.7041228" />
+      <path
+         d="m 328.47231,150.86044 c 1.11801,0 2.02626,0.90825 2.02626,2.02626 0,1.11801 -0.90825,2.02626 -2.02626,2.02626 -1.11801,0 -2.02626,-0.90825 -2.02626,-2.02626 0,-1.11801 0.90825,-2.02626 2.02626,-2.02626 z m 0,-5.21068 c 1.11801,0 2.02626,0.90825 2.02626,2.02626 0,1.11801 -0.90825,2.02626 -2.02626,2.02626 -1.11801,0 -2.02626,-0.90825 -2.02626,-2.02626 0,-1.11801 0.90825,-2.02626 2.02626,-2.02626 z"
+         fill="#eff0f1"
+         id="path918"
+         style="display:inline;enable-background:new;stroke-width:0.692263" />
+      <path
+         d="m 328.47231,151.43917 c 0.79887,0 1.44752,0.64865 1.44752,1.44753 0,0.79887 -0.64865,1.44752 -1.44752,1.44752 -0.79888,0 -1.44753,-0.64865 -1.44753,-1.44752 0,-0.79888 0.64865,-1.44753 1.44753,-1.44753 z m 0,-5.21068 c 0.79887,0 1.44752,0.64866 1.44752,1.44753 0,0.79887 -0.64865,1.44753 -1.44752,1.44753 -0.79888,0 -1.44753,-0.64866 -1.44753,-1.44753 0,-0.79887 0.64865,-1.44753 1.44753,-1.44753 z"
+         fill="#3daefd"
+         id="path920"
+         style="display:inline;enable-background:new;stroke-width:0.692263" />
+      <path
+         d="m 332.23615,141.59655 v 0.57873 h -1.15816 v -0.57873 z m 2.31563,0 v 0.57873 h -1.73689 v -0.57873 z"
+         fill="#da4453"
+         id="path922"
+         style="display:inline;enable-background:new;stroke-width:0.692263" />
+      <path
+         d="m 335.13121,153.17676 v 0.57873 h -4.05322 v -0.57873 z m -2.31632,-5.21137 v 0.57873 h -1.7369 v -0.57873 z m 0.57942,-5.21138 v 0.57874 h -2.31632 v -0.57874 z m 1.7369,0 v 0.57874 h -1.15816 v -0.57874 z"
+         fill="#bdc3c7"
+         id="path924"
+         style="display:inline;enable-background:new;stroke-width:0.692263" />
+      <path
+         d="m 341.50005,153.17676 h 1.15816 v 0.57873 h -1.15816 z m -0.57874,0.57873 h -4.63194 v -0.57873 h 4.63194 z m 4.63195,-1.15816 h -1.15816 v -0.57873 h 1.15816 z m -1.7369,0 h -1.73689 v -0.57873 h 1.73689 z m -2.31562,0 h -5.21137 v -0.57873 h 5.21137 z m -3.47448,-4.05321 h -1.73689 v -0.57873 h 1.73689 z m 1.15747,0 h -0.57874 v -0.57873 h 0.57874 z m 3.47448,0 h -2.89506 v -0.57873 h 2.89506 z m -2.89506,-1.73689 h 2.31632 v 0.57873 h -2.31632 z m 2.89506,0 h 2.89505 v 0.57873 h -2.89505 z m -4.05252,0.57873 h -2.31632 v -0.57873 h 2.31632 z m 2.31562,-4.05321 h -4.63194 v -0.57874 h 4.63194 z m -2.89505,-1.15747 h -1.73689 v -0.57873 h 1.73689 z m 7.52769,0 h -2.31632 v -0.57873 h 2.31632 z m -2.89574,0 h -3.47379 v -0.57873 h 3.47379 z"
+         fill="#e5fdff"
+         id="path926"
+         style="display:inline;enable-background:new;stroke-width:0.692263" />
+      <path
+         d="m 333.97305,152.0186 v 0.57873 h -2.89506 v -0.57873 z m -1.7369,-5.21137 v 0.57873 h -1.15816 v -0.57873 z m 2.31563,0 v 0.57873 h -1.73689 v -0.57873 z"
+         fill="#3daefd"
+         id="path928"
+         style="display:inline;enable-background:new;stroke-width:0.692263" />
+      <path
+         d="m 328.473,140.39339 -2.02695,0.84941 c 0,0 0.2416,1.10139 0.50189,1.73897 0.13084,0.31913 0.29006,0.65004 0.51505,0.93663 0.22498,0.2866 0.55865,0.5732 1.01001,0.5732 0.45205,0 0.78434,-0.2866 1.00932,-0.5732 0.22499,-0.28659 0.38421,-0.6175 0.51505,-0.93663 0.26098,-0.63758 0.50258,-1.73897 0.50258,-1.73897 z"
+         fill="#eff0f1"
+         id="path930"
+         style="display:inline;enable-background:new;stroke-width:0.692263" />
+      <path
+         d="m 327.02478,141.59655 1.44753,-0.57943 1.44752,0.57943 c 0,0 -0.5365,2.31562 -1.44752,2.31562 -0.90964,0 -1.44753,-2.31562 -1.44753,-2.31562 z"
+         fill="#da4453"
+         id="path932"
+         style="display:inline;enable-background:new;stroke-width:0.692263" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.092072;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle934"
+         cx="325.60611"
+         cy="135.51154"
+         r="1.7635583" />
+      <circle
+         r="1.7635583"
+         cy="135.51154"
+         cx="330.80304"
+         id="circle936"
+         style="display:inline;enable-background:new;fill:#ffbe2f;fill-opacity:1;fill-rule:evenodd;stroke:#dfa22a;stroke-width:0.092072;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <circle
+         style="display:inline;enable-background:new;fill:#28ca40;fill-opacity:1;fill-rule:evenodd;stroke:#1bac2c;stroke-width:0.092072;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle938"
+         cx="336"
+         cy="135.51154"
+         r="1.7635583" />
+      <path
+         d="m 326.22877,202.193 c 0.85714,0 1.55347,0.69633 1.55347,1.55347 0,0.85714 -0.69633,1.55347 -1.55347,1.55347 -0.85714,0 -1.55347,-0.69633 -1.55347,-1.55347 0,-0.85714 0.69633,-1.55347 1.55347,-1.55347 z m 0,-3.99485 c 0.85714,0 1.55347,0.69633 1.55347,1.55347 0,0.85713 -0.69633,1.55346 -1.55347,1.55346 -0.85714,0 -1.55347,-0.69633 -1.55347,-1.55346 0,-0.85714 0.69633,-1.55347 1.55347,-1.55347 z"
+         fill="#eff0f1"
+         id="path950"
+         style="display:inline;enable-background:new;stroke-width:0.530735" />
+      <path
+         d="m 326.22877,202.6367 c 0.61247,0 1.10977,0.4973 1.10977,1.10977 0,0.61247 -0.4973,1.10977 -1.10977,1.10977 -0.61247,0 -1.10977,-0.4973 -1.10977,-1.10977 0,-0.61247 0.4973,-1.10977 1.10977,-1.10977 z m 0,-3.99486 c 0.61247,0 1.10977,0.49731 1.10977,1.10978 0,0.61247 -0.4973,1.10977 -1.10977,1.10977 -0.61247,0 -1.10977,-0.4973 -1.10977,-1.10977 0,-0.61247 0.4973,-1.10978 1.10977,-1.10978 z"
+         fill="#3daefd"
+         id="path952"
+         style="display:inline;enable-background:new;stroke-width:0.530735" />
+      <path
+         d="m 329.11439,195.09069 v 0.44369 h -0.88793 v -0.44369 z m 1.77531,0 v 0.44369 h -1.33162 v -0.44369 z"
+         fill="#da4453"
+         id="path954"
+         style="display:inline;enable-background:new;stroke-width:0.530735" />
+      <path
+         d="m 331.33393,203.96885 v 0.44369 h -3.10747 v -0.44369 z m -1.77585,-3.99539 v 0.4437 h -1.33162 v -0.4437 z m 0.44423,-3.99538 v 0.44369 h -1.77585 v -0.44369 z m 1.33162,0 v 0.44369 H 330.446 v -0.44369 z"
+         fill="#bdc3c7"
+         id="path956"
+         style="display:inline;enable-background:new;stroke-width:0.530735" />
+      <path
+         d="m 336.2167,203.96885 h 0.88792 v 0.44369 h -0.88792 z m -0.44369,0.44369 h -3.55116 v -0.44369 h 3.55116 z m 3.55115,-0.88792 h -0.88792 v -0.44369 h 0.88792 z m -1.33161,0 h -1.33162 v -0.44369 h 1.33162 z m -1.77532,0 h -3.99538 v -0.44369 h 3.99538 z m -2.66376,-3.10746 h -1.33162 v -0.4437 h 1.33162 z m 0.88739,0 h -0.4437 v -0.4437 h 0.4437 z m 2.66376,0 h -2.21954 v -0.4437 h 2.21954 z m -2.21954,-1.33162 h 1.77585 v 0.4437 h -1.77585 z m 2.21954,0 h 2.21954 v 0.4437 h -2.21954 z m -3.10693,0.4437 h -1.77584 v -0.4437 h 1.77584 z m 1.77532,-3.10747 h -3.55116 v -0.44369 h 3.55116 z m -2.21954,-0.88739 h -1.33162 v -0.44369 h 1.33162 z m 5.77123,0 h -1.77585 v -0.44369 h 1.77585 z m -2.22008,0 h -2.66323 v -0.44369 h 2.66323 z"
+         fill="#e5fdff"
+         id="path958"
+         style="display:inline;enable-background:new;stroke-width:0.530735" />
+      <path
+         d="m 330.446,203.08093 v 0.44369 h -2.21954 v -0.44369 z m -1.33161,-3.99539 v 0.4437 h -0.88793 v -0.4437 z m 1.77531,0 v 0.4437 h -1.33162 v -0.4437 z"
+         fill="#3daefd"
+         id="path960"
+         style="display:inline;enable-background:new;stroke-width:0.530735" />
+      <path
+         d="m 326.2293,194.16827 -1.554,0.65121 c 0,0 0.18523,0.8444 0.38479,1.33321 0.10031,0.24467 0.22238,0.49836 0.39487,0.71809 0.17249,0.21972 0.4283,0.43945 0.77434,0.43945 0.34657,0 0.60133,-0.21973 0.77381,-0.43945 0.17249,-0.21973 0.29456,-0.47342 0.39487,-0.71809 0.20009,-0.48881 0.38532,-1.33321 0.38532,-1.33321 z"
+         fill="#eff0f1"
+         id="path962"
+         style="display:inline;enable-background:new;stroke-width:0.530735" />
+      <path
+         d="m 325.119,195.09069 1.10977,-0.44423 1.10977,0.44423 c 0,0 -0.41132,1.77531 -1.10977,1.77531 -0.69739,0 -1.10977,-1.77531 -1.10977,-1.77531 z"
+         fill="#da4453"
+         id="path964"
+         style="display:inline;enable-background:new;stroke-width:0.530735" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.0705885;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle966"
+         cx="324.03137"
+         cy="190.42551"
+         r="1.3520614" />
+      <circle
+         r="1.3520614"
+         cy="190.42551"
+         cx="328.01569"
+         id="circle968"
+         style="display:inline;enable-background:new;fill:#ffbe2f;fill-opacity:1;fill-rule:evenodd;stroke:#dfa22a;stroke-width:0.0705885;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <circle
+         style="display:inline;enable-background:new;fill:#28ca40;fill-opacity:1;fill-rule:evenodd;stroke:#1bac2c;stroke-width:0.0705885;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle970"
+         cx="332"
+         cy="190.42551"
+         r="1.3520614" />
+      <path
+         d="m 324.23616,245.43022 c 0.559,0 1.01313,0.45413 1.01313,1.01313 0,0.55901 -0.45413,1.01313 -1.01313,1.01313 -0.559,0 -1.01313,-0.45412 -1.01313,-1.01313 0,-0.559 0.45413,-1.01313 1.01313,-1.01313 z m 0,-2.60534 c 0.559,0 1.01313,0.45413 1.01313,1.01313 0,0.55901 -0.45413,1.01313 -1.01313,1.01313 -0.559,0 -1.01313,-0.45412 -1.01313,-1.01313 0,-0.559 0.45413,-1.01313 1.01313,-1.01313 z"
+         fill="#eff0f1"
+         id="path982"
+         style="display:inline;enable-background:new;stroke-width:0.346132" />
+      <path
+         d="m 324.23616,245.71959 c 0.39944,0 0.72376,0.32433 0.72376,0.72376 0,0.39944 -0.32432,0.72377 -0.72376,0.72377 -0.39944,0 -0.72376,-0.32433 -0.72376,-0.72377 0,-0.39943 0.32432,-0.72376 0.72376,-0.72376 z m 0,-2.60534 c 0.39944,0 0.72376,0.32433 0.72376,0.72376 0,0.39944 -0.32432,0.72377 -0.72376,0.72377 -0.39944,0 -0.72376,-0.32433 -0.72376,-0.72377 0,-0.39943 0.32432,-0.72376 0.72376,-0.72376 z"
+         fill="#3daefd"
+         id="path984"
+         style="display:inline;enable-background:new;stroke-width:0.346132" />
+      <path
+         d="m 326.11808,240.79828 v 0.28937 H 325.539 v -0.28937 z m 1.15782,0 v 0.28937 h -0.86845 v -0.28937 z"
+         fill="#da4453"
+         id="path986"
+         style="display:inline;enable-background:new;stroke-width:0.346132" />
+      <path
+         d="m 327.56561,246.58838 v 0.28937 H 325.539 v -0.28937 z m -1.15816,-2.60568 v 0.28937 H 325.539 v -0.28937 z m 0.28971,-2.60569 v 0.28937 H 325.539 v -0.28937 z m 0.86845,0 v 0.28937 h -0.57908 v -0.28937 z"
+         fill="#bdc3c7"
+         id="path988"
+         style="display:inline;enable-background:new;stroke-width:0.346132" />
+      <path
+         d="m 330.75003,246.58838 h 0.57908 v 0.28937 h -0.57908 z m -0.28937,0.28937 h -2.31597 v -0.28937 h 2.31597 z m 2.31597,-0.57908 h -0.57908 v -0.28937 h 0.57908 z m -0.86844,0 h -0.86845 v -0.28937 h 0.86845 z m -1.15782,0 h -2.60568 v -0.28937 h 2.60568 z m -1.73724,-2.0266 h -0.86844 v -0.28937 h 0.86844 z m 0.57874,0 h -0.28937 v -0.28937 h 0.28937 z m 1.73724,0 h -1.44753 v -0.28937 h 1.44753 z m -1.44753,-0.86845 h 1.15816 v 0.28937 h -1.15816 z m 1.44753,0 h 1.44752 v 0.28937 h -1.44752 z m -2.02626,0.28937 h -1.15816 v -0.28937 h 1.15816 z m 1.15781,-2.02661 h -2.31597 v -0.28937 h 2.31597 z m -1.44753,-0.57873 h -0.86844 v -0.28937 h 0.86844 z m 3.76385,0 h -1.15816 v -0.28937 h 1.15816 z m -1.44787,0 h -1.7369 v -0.28937 h 1.7369 z"
+         fill="#e5fdff"
+         id="path990"
+         style="display:inline;enable-background:new;stroke-width:0.346132" />
+      <path
+         d="m 326.98653,246.0093 v 0.28937 H 325.539 v -0.28937 z m -0.86845,-2.60568 v 0.28937 H 325.539 v -0.28937 z m 1.15782,0 v 0.28937 h -0.86845 v -0.28937 z"
+         fill="#3daefd"
+         id="path992"
+         style="display:inline;enable-background:new;stroke-width:0.346132" />
+      <path
+         d="m 324.23651,240.1967 -1.01348,0.42471 c 0,0 0.1208,0.55069 0.25095,0.86948 0.0654,0.15957 0.14503,0.32502 0.25752,0.46832 0.11249,0.1433 0.27933,0.2866 0.50501,0.2866 0.22602,0 0.39216,-0.1433 0.50466,-0.2866 0.11249,-0.1433 0.1921,-0.30875 0.25752,-0.46832 0.13049,-0.31879 0.25129,-0.86948 0.25129,-0.86948 z"
+         fill="#eff0f1"
+         id="path994"
+         style="display:inline;enable-background:new;stroke-width:0.346132" />
+      <path
+         d="m 323.5124,240.79828 0.72376,-0.28971 0.72376,0.28971 c 0,0 -0.26825,1.15781 -0.72376,1.15781 -0.45482,0 -0.72376,-1.15781 -0.72376,-1.15781 z"
+         fill="#da4453"
+         id="path996"
+         style="display:inline;enable-background:new;stroke-width:0.346132" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.046036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle998"
+         cx="322.80307"
+         cy="237.75577"
+         r="0.88177919" />
+      <circle
+         r="0.88177919"
+         cy="237.75577"
+         cx="325.40152"
+         id="circle1000"
+         style="display:inline;enable-background:new;fill:#ffbe2f;fill-opacity:1;fill-rule:evenodd;stroke:#dfa22a;stroke-width:0.046036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <circle
+         style="display:inline;enable-background:new;fill:#28ca40;fill-opacity:1;fill-rule:evenodd;stroke:#1bac2c;stroke-width:0.046036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1002"
+         cx="328"
+         cy="237.75577"
+         r="0.88177919" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/maps-app.svg
+++ b/icons/src/fullcolor/default/apps/maps-app.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="maps-app.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -32,17 +32,17 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:zoom="2"
-     inkscape:cx="75"
-     inkscape:cy="162.75"
-     inkscape:current-layer="layer8"
+     inkscape:cx="338"
+     inkscape:cy="78"
+     inkscape:current-layer="layer2"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -92,184 +92,153 @@
   </sodipodi:namedview>
   <defs
      id="defs3">
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4346"
-       x="-0.014454287"
-       width="1.0289086"
-       y="-0.011357288"
-       height="1.0227146">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.120027"
-         id="feGaussianBlur4348" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4380"
-       x="-0.057817147"
-       width="1.1156343"
-       y="-0.045429151"
-       height="1.0908583">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="8.4801079"
-         id="feGaussianBlur4382" />
-    </filter>
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(0,-43.3373,43.3373,0,201.9,45.6687)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#bb9073"
          offset="0"
-         id="stop923" />
+         id="stop282" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#baa994"
          offset="1"
-         id="stop925" />
+         id="stop284" />
     </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="66.000679"
-       x2="344"
-       y2="102.00067"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,344,84)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="331.99966"
-       y1="191.00034"
-       x2="331.99966"
-       y2="209.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,331.99966,200)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="238.00043"
-       x2="328"
-       y2="250"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,328,244)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004-8"
-       x1="344"
-       y1="65.144272"
-       x2="344"
-       y2="102.85715"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.04758,0.95458104,0,263.81519,444.36752)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       gradientTransform="translate(-307.22615,125.39245)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4311"
-       id="linearGradient4317"
-       x1="667.97504"
-       y1="-19.787647"
-       x2="667.97504"
-       y2="282.68454"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4311">
+       id="b"
+       x2="1"
+       gradientTransform="matrix(14.2858,-822.857,822.857,14.2858,220,961.897)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#000000;stop-opacity:0"
+         stop-color="#00b344"
          offset="0"
-         id="stop4313" />
+         id="stop287" />
       <stop
-         id="stop4319"
-         offset="0.50383204"
-         style="stop-color:#000000;stop-opacity:1" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
+         stop-color="#52c462"
          offset="1"
-         id="stop4315" />
+         id="stop289" />
     </linearGradient>
-    <filter
+    <linearGradient
+       id="c"
+       x2="1"
+       gradientTransform="matrix(0.150483,-20.4809,20.4809,0.150483,29.9434,27.5847)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#001c71"
+         offset="0"
+         id="stop292" />
+      <stop
+         stop-color="#005cff"
+         offset="1"
+         id="stop294" />
+    </linearGradient>
+    <linearGradient
        inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4321"
-       x="-0.1380356"
-       width="1.2760712"
-       y="-0.073589879"
-       height="1.1471798">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="9.3237456"
-         id="feGaussianBlur4323" />
-    </filter>
-    <filter
+       xlink:href="#a"
+       id="linearGradient564"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-45.972628,45.972628,0,532.71805,106.98637)"
+       x2="1" />
+    <linearGradient
        inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4398"
-       x="-0.01725445"
-       width="1.0345089"
-       y="-0.0091987349"
-       height="1.0183975">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1654682"
-         id="feGaussianBlur4400" />
-    </filter>
+       xlink:href="#b"
+       id="linearGradient566"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(15.154515,-872.89469,872.89469,15.154515,551.9187,1078.9302)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.15963383,-21.726337,21.726337,0.15963383,350.30482,87.802684)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient596"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-29.982149,29.982149,0,459.07699,162.99111)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient598"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(9.8833796,-569.27915,569.27915,9.8833796,471.59915,796.86755)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.10410902,-14.169351,14.169351,0.10410902,340.11183,150.48001)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient628"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-22.986315,22.986315,0,426.35902,211.49318)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient630"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(7.5772577,-436.44735,436.44735,7.5772577,435.95935,697.46512)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient632"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07981691,-10.863169,10.863169,0.07981691,335.1524,201.90134)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient660"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-14.991075,14.991075,0,389.5338,251.49555)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient662"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.9416898,-284.63957,284.63957,4.9416898,395.79489,568.43377)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient664"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05205451,-7.0846753,7.0846753,0.05205451,330.05123,245.24)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient690"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-223.86671,223.86671,0,1070.9748,267.93362)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient692"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(73.795901,-4250.6177,4250.6177,73.795901,1164.4737,5000.8777)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient694"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.77734734,-105.79782,105.79782,0.77734734,182.70172,174.51742)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -369,7 +338,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">maps-app</tspan></text>
+           id="tspan924">maps-app</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -404,397 +373,329 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.49972,241.59598 c 0,-0.71904 -0.0139,-1.30185 -0.10352,-1.83593 -0.0897,-0.53409 -0.27628,-1.0683 -0.68359,-1.47657 -0.4073,-0.40826 -0.94323,-0.59657 -1.47851,-0.68554 -0.53529,-0.089 -1.12048,-0.10119 -1.8418,-0.0977 h -2.89258 -3.89844 c -0.71816,-0.003 -1.30235,0.009 -1.83594,0.0977 -0.53528,0.089 -1.07121,0.27727 -1.47851,0.68554 -0.40731,0.40827 -0.59394,0.94248 -0.68359,1.47657 -0.0897,0.53408 -0.10352,1.11689 -0.10352,1.83593 v 5.8086 c 0,0.71904 0.0137,1.30058 0.10352,1.83398 0.0898,0.53341 0.27792,1.06768 0.68554,1.47461 0.40762,0.40693 0.94271,0.59404 1.47656,0.68359 0.53386,0.0896 1.11551,0.10352 1.83594,0.10352 h 3.89844 2.89844 c 0.72043,0 1.30208,-0.014 1.83594,-0.10352 0.53385,-0.0895 1.06894,-0.27666 1.47656,-0.68359 0.40762,-0.40693 0.59578,-0.9412 0.68554,-1.47461 0.0898,-0.5334 0.10352,-1.11494 0.10352,-1.83398 z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 343.99961,196.86562 c 0,-1.12014 -0.0241,-2.01524 -0.1543,-2.79101 -0.13022,-0.77577 -0.38763,-1.48014 -0.91601,-2.00977 -0.52838,-0.52962 -1.23687,-0.79079 -2.01367,-0.91992 -0.77681,-0.12912 -1.67169,-0.15002 -2.79493,-0.14453 h -6.12109 -6.125 c -1.12104,-0.005 -2.01529,0.0156 -2.79102,0.14453 -0.77681,0.12912 -1.48529,0.39029 -2.01367,0.91992 -0.52838,0.52964 -0.78579,1.234 -0.91601,2.00977 -0.13022,0.77577 -0.1543,1.67087 -0.1543,2.79101 v 8.26954 c 0,1.12013 0.024,2.01264 0.1543,2.78711 0.13033,0.77446 0.38927,1.48001 0.91797,2.00781 0.52869,0.5278 1.23438,0.78594 2.00976,0.91601 0.77539,0.13007 1.67062,0.1543 2.79297,0.1543 h 6.125 6.125 c 1.12235,0 2.01758,-0.0242 2.79297,-0.1543 0.77538,-0.13007 1.48107,-0.38821 2.00976,-0.91601 0.5287,-0.5278 0.78764,-1.23334 0.91797,-2.00781 0.13033,-0.77448 0.1543,-1.66697 0.1543,-2.78711 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 350.99951,143.19385 c 0,-1.42096 -0.0308,-2.54883 -0.19141,-3.50586 -0.16064,-0.95703 -0.4726,-1.79146 -1.09179,-2.41211 -0.61919,-0.62065 -1.45612,-0.93647 -2.41407,-1.0957 -0.95795,-0.15924 -2.08705,-0.18666 -3.51171,-0.17969 h -7.79102 -7.79688 c -1.42131,-0.007 -2.5495,0.0207 -3.50585,0.17969 -0.95796,0.15923 -1.79488,0.47505 -2.41407,1.0957 -0.61919,0.62065 -0.93115,1.45508 -1.09179,2.41211 -0.16065,0.95703 -0.19141,2.0849 -0.19141,3.50586 v 11.61523 c 0,1.42097 0.0307,2.54669 0.19141,3.50196 0.16075,0.95527 0.47425,1.78779 1.09375,2.40625 0.6195,0.61845 1.45363,0.93134 2.41015,1.09179 0.95653,0.16046 2.08403,0.19141 3.50781,0.19141 h 7.79688 7.79688 c 1.42378,0 2.55128,-0.031 3.50781,-0.19141 0.95653,-0.16045 1.79065,-0.47334 2.41015,-1.09179 0.61951,-0.61846 0.933,-1.45098 1.09375,-2.40625 0.16076,-0.95527 0.19141,-2.08099 0.19141,-3.50196 z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 367.49969,76.231427 c 0,-2.22316 -0.0512,-3.97368 -0.29297,-5.41406 -0.24178,-1.44039 -0.69529,-2.61905 -1.55664,-3.48243 -0.86134,-0.86337 -2.03947,-1.31906 -3.48046,-1.55859 -1.441,-0.23953 -3.19535,-0.28629 -5.42383,-0.27539 H 343.99974 331.2476 c -2.22507,-0.0108 -3.97852,0.0361 -5.41797,0.27539 -1.441,0.23953 -2.61913,0.69522 -3.48047,1.55859 -0.86134,0.86338 -1.31486,2.04204 -1.55664,3.48243 -0.24179,1.44039 -0.29297,3.1909 -0.29297,5.41406 v 17.53883 c 0,2.22317 0.0511,3.97276 0.29297,5.41017 0.24189,1.437403 0.69694,2.612463 1.55859,3.472653 0.86165,0.8602 2.03894,1.31319 3.47852,1.55468 1.43957,0.24149 3.19035,0.29297 5.41797,0.29297 h 12.75214 12.75191 c 2.22761,0 3.97839,-0.0515 5.41797,-0.29297 1.43957,-0.24149 2.61686,-0.69449 3.47851,-1.55469 0.86165,-0.86019 1.31671,-2.03525 1.55859,-3.472653 0.24189,-1.4374 0.29297,-3.187 0.29297,-5.41016 z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0,0.5,-0.5,0,300.9973,13.002698)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path4350"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 464,514.75001 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4380);enable-background:accumulate"
-         transform="matrix(0,0.5,-0.5,0,300.9973,13.002698)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.02028775;marker:none;enable-background:accumulate"
-         d="m 266.0025,105.8091 c 0,-36.098811 -3.69016,-39.983003 -39.68984,-39.806081 H 152.0025 77.69234 C 41.69265,65.826097 38.0025,69.710289 38.0025,105.8091 v 100.38732 c 0,36.09881 3.68973,39.80608 39.68984,39.80608 h 74.31016 74.31016 c 36.00011,0 39.68984,-3.70727 39.68984,-39.80608 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="display:inline;opacity:1;fill:#6dc7f1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 78.990234 67.998047 C 43.621704 67.998047 39.998047 71.621249 39.998047 106.91797 L 39.998047 205.07617 C 39.998047 240.3729 43.622114 244.17104 78.990234 243.99805 L 151.99805 243.99805 L 225.00391 243.99805 C 260.37202 244.17104 263.99805 240.3729 263.99805 205.07617 L 263.99805 106.91797 C 263.99805 71.621249 260.37244 67.998047 225.00391 67.998047 L 151.99805 67.998047 L 78.990234 67.998047 z "
-         id="rect877" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e3dfd5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         clip-path="none"
-         d="M 158.69727 67.998047 L 121.85156 214.46484 L 149.91016 243.99805 L 151.99805 243.99805 L 225.00391 243.99805 C 260.37202 244.17104 263.99805 240.3729 263.99805 205.07617 L 263.99805 106.91797 C 263.99805 71.621249 260.37244 67.998047 225.00391 67.998047 L 158.69727 67.998047 z "
-         id="path4267" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a6d74f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         d="M 78.990234 67.998047 C 43.621704 67.998047 39.998047 71.621249 39.998047 106.91797 L 39.998047 129.81836 L 124.58203 216.89648 L 258.08398 74.578125 C 252.8334 68.95499 243.06238 67.998047 225.00391 67.998047 L 151.99805 67.998047 L 78.990234 67.998047 z "
-         id="path4208" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         d="M 39.998047 115.27539 L 39.998047 144.30859 L 137.4707 243.99805 L 151.99805 243.99805 L 165.85547 243.99805 L 39.998047 115.27539 z "
-         id="rect4236" />
-      <path
-         style="display:inline;opacity:1;fill:#6dc7f1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 331.24805 65.5 C 322.40602 65.4567 321.5 66.998929 321.5 75.230469 L 321.5 92.769531 C 321.5 100.99903 322.40592 102.5 331.24805 102.5 L 344 102.5 L 356.75195 102.5 C 365.59408 102.5 366.5 100.99904 366.5 92.769531 L 366.5 75.230469 C 366.5 66.998929 365.59398 65.45675 356.75195 65.5 L 344 65.5 L 331.24805 65.5 z "
-         id="path888" />
-      <path
-         style="display:inline;opacity:1;fill:#6dc7f1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 327.7832 135.5 C 322.08502 135.4707 321.5 136.51247 321.5 142.07422 L 321.5 153.92578 C 321.5 159.48615 322.08496 160.5 327.7832 160.5 L 336 160.5 L 344.2168 160.5 C 349.91504 160.5 350.5 159.48615 350.5 153.92578 L 350.5 142.07422 C 350.5 136.51247 349.91498 135.47077 344.2168 135.5 L 336 135.5 L 327.7832 135.5 z "
-         id="path942" />
-      <path
-         style="display:inline;opacity:1;fill:#6dc7f1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 323.82422 237.5 C 322.06587 237.49131 321.24054 237.61745 320.84766 238.3125 C 320.57806 239.08157 320.5 240.15925 320.5 241.68359 L 320.5 245.31641 C 320.5 249.8527 321.14892 250.5 325.68945 250.5 L 328 250.5 L 330.31055 250.5 C 334.8511 250.5 335.5 249.8527 335.5 245.31641 L 335.5 241.68359 C 335.5 240.15925 335.42193 239.08157 335.15234 238.3125 C 334.75946 237.61745 333.93413 237.4913 332.17578 237.5 L 328 237.5 L 323.82422 237.5 z "
-         id="path946" />
-      <path
-         style="display:inline;opacity:1;fill:#6dc7f1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 325.5957 190.5 C 323.62817 190.49025 322.41749 190.58067 321.66992 191.04102 C 320.72658 192.16516 320.5 194.06614 320.5 197.27539 L 320.5 202.72461 C 320.5 205.92074 320.72462 207.81935 321.6582 208.94531 C 322.40485 209.40988 323.61874 209.5 325.5957 209.5 L 332 209.5 L 338.4043 209.5 C 340.38125 209.5 341.59515 209.40988 342.3418 208.94531 C 343.27538 207.81935 343.5 205.92074 343.5 202.72461 L 343.5 197.27539 C 343.5 194.06614 343.27342 192.16515 342.33008 191.04102 C 341.58251 190.58068 340.37183 190.49029 338.4043 190.5 L 332 190.5 L 325.5957 190.5 z "
-         id="path948" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="M 112 67.998047 L 112 243.99805 L 151.99805 243.99805 L 192 243.99805 L 192 67.998047 L 151.99805 67.998047 L 112 67.998047 z "
-         id="rect4277-3" />
-      <path
-         style="display:inline;opacity:0.15;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 39.998047 156 L 39.998047 205.07617 C 39.998047 240.3729 43.622114 244.17104 78.990234 243.99805 L 151.99805 243.99805 L 225.00391 243.99805 C 260.37202 244.17104 263.99805 240.3729 263.99805 205.07617 L 263.99805 156 L 39.998047 156 z "
-         id="path1026" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e3dfd5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         clip-path="none"
-         d="M 345.75781 65.5 L 338.34766 94.962891 L 345.50781 102.5 L 356.75195 102.5 C 365.59408 102.5 366.5 100.99904 366.5 92.769531 L 366.5 75.230469 C 366.5 66.998929 365.59398 65.45675 356.75195 65.5 L 345.75781 65.5 z "
-         id="path922" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a6d74f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         d="M 331.24805 65.5 C 322.40602 65.4567 321.5 66.998929 321.5 75.230469 L 321.5 77.546875 L 338.85938 95.417969 L 365.08984 67.455078 C 363.79656 65.897518 361.3558 65.477481 356.75195 65.5 L 344 65.5 L 331.24805 65.5 z "
-         id="path924" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         d="M 321.50781 74.837891 C 321.50721 74.978893 321.5 75.085335 321.5 75.230469 L 321.5 80.273438 L 343.23242 102.5 L 344 102.5 L 348.55273 102.5 L 321.50781 74.837891 z "
-         id="path926" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fdc92b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.01255703;marker:none;enable-background:accumulate"
-         d="M 364.07422 66.595703 L 328.07812 102.40039 C 329.00411 102.46891 330.0467 102.5 331.24805 102.5 L 333.36328 102.5 L 366.14648 69.890625 C 365.82116 68.311327 365.20148 67.264835 364.07422 66.595703 z "
-         id="path928" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e3dfd5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         clip-path="none"
-         d="M 337.21484 135.5 L 332.23242 155.30859 L 337.16406 160.5 L 344.2168 160.5 C 349.91504 160.5 350.5 159.48615 350.5 153.92578 L 350.5 142.07422 C 350.5 136.51247 349.91498 135.47077 344.2168 135.5 L 337.21484 135.5 z "
-         id="path932" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a6d74f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         d="M 327.7832 135.5 C 322.08502 135.4707 321.5 136.51247 321.5 142.07422 L 321.5 144.21289 L 332.57227 155.61133 L 349.84375 137.19922 C 349.09315 135.83215 347.51257 135.48309 344.2168 135.5 L 336 135.5 L 327.7832 135.5 z "
-         id="path934" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         d="M 321.5 142.39844 L 321.5 146.02734 L 335.65039 160.5 L 336 160.5 L 339.19727 160.5 L 321.5 142.39844 z "
-         id="path936" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fdc92b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.01255703;marker:none;enable-background:accumulate"
-         d="M 349.2832 136.49609 L 325.26562 160.38672 C 325.96952 160.46602 326.7957 160.5 327.7832 160.5 L 328.74023 160.5 L 350.34961 139.00586 C 350.19628 137.845 349.88915 137.02839 349.2832 136.49609 z "
-         id="path938" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e3dfd5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         clip-path="none"
-         d="M 332.94336 190.5 L 329.17383 205.48047 L 332.99219 209.5 L 338.4043 209.5 C 343.02632 209.5 343.5 209.02226 343.5 204.36523 L 343.5 195.63672 C 343.5 190.97969 343.02627 190.47718 338.4043 190.5 L 332.94336 190.5 z "
-         id="path943" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a6d74f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         d="M 325.5957 190.5 C 320.97373 190.4771 320.5 190.97969 320.5 195.63672 L 320.5 196.51562 L 329.42969 205.70898 L 342.80078 191.45508 C 342.13514 190.62988 340.85643 190.48789 338.4043 190.5 L 332 190.5 L 325.5957 190.5 z "
-         id="path945" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         d="M 320.50781 195.16992 C 320.50629 195.3328 320.5 195.46238 320.5 195.63672 L 320.5 197.88086 L 331.85938 209.5 L 332 209.5 L 334.51953 209.5 L 320.50781 195.16992 z "
-         id="path947" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fdc92b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.01255703;marker:none;enable-background:accumulate"
-         d="M 342.30859 191.0293 L 323.79297 209.44531 C 324.31596 209.48023 324.89468 209.5 325.5957 209.5 L 326.42969 209.5 L 343.31836 192.70117 C 343.1566 191.88073 342.8541 191.35657 342.30859 191.0293 z "
-         id="path949-8" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e3dfd5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         clip-path="none"
-         d="M 328.66992 237.5 L 326.11523 247.6543 L 328.81836 250.5 L 332.17578 250.5 C 335.19013 250.5 335.5 250.18814 335.5 247.14648 L 335.5 240.85547 C 335.5 237.81381 335.1901 237.48509 332.17578 237.5 L 328.66992 237.5 z "
-         id="path953" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a6d74f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         d="M 323.82422 237.5 C 320.8099 237.4851 320.5 237.81381 320.5 240.85547 L 320.5 241.84961 L 326.28711 247.80664 L 335.16992 238.33789 C 334.78363 237.61801 333.95722 237.49119 332.17578 237.5 L 328 237.5 L 323.82422 237.5 z "
-         id="path956" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:2.00627851;marker:none;enable-background:accumulate"
-         d="M 320.5 240.94336 L 320.5 242.75781 L 328.07031 250.5 L 329.84375 250.5 L 320.5 240.94336 z "
-         id="path958-65" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fdc92b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.01255703;marker:none;enable-background:accumulate"
-         d="M 334.9043 237.98828 L 322.38672 250.43945 C 322.78468 250.48032 323.24116 250.5 323.82422 250.5 L 324.11914 250.5 L 335.42383 239.25391 C 335.34916 238.65658 335.19681 238.24894 334.9043 237.98828 z "
-         id="path960" />
-      <path
-         style="display:inline;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 322 84 L 322 92.269531 C 322 101.09371 322.90592 102 331.74805 102 L 344 102 L 356.25195 102 C 365.09408 102 366 101.09371 366 92.269531 L 366 84 L 322 84 z "
-         id="path1243" />
-      <path
-         style="display:inline;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 322 148 L 322 153.51367 C 322 159.39624 322.57631 160 328.20312 160 L 336 160 L 343.79688 160 C 349.42369 160 350 159.39624 350 153.51367 L 350 148 L 322 148 z "
-         id="path1245" />
-      <path
-         style="display:inline;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 321 200 L 321 204.13477 C 321 208.54686 321.45198 209 325.87305 209 L 332 209 L 338.125 209 C 342.54606 209 343 208.54686 343 204.13477 L 343 200 L 321 200 z "
-         id="path1247" />
-      <path
-         style="display:inline;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:24;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 336 65.5 L 336 102.5 L 344 102.5 L 352 102.5 L 352 65.5 L 344 65.5 L 336 65.5 z "
-         id="rect1258" />
-      <path
-         style="display:inline;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:24;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 331 135.5 L 331 160.5 L 336 160.5 L 341 160.5 L 341 135.5 L 336 135.5 L 331 135.5 z "
-         id="rect1260" />
-      <rect
-         style="display:inline;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:24;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="rect1262"
-         width="8"
-         height="20"
-         x="328"
-         y="190" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fdc92b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.01255703;marker:none;enable-background:accumulate"
-         d="M 251.66406 70.535156 L 77.285156 243.99219 C 77.86848 243.99168 78.388684 244.00099 78.990234 243.99805 L 105.99023 243.99805 L 263.13477 87.685547 C 261.84345 78.074855 258.74359 73.081115 251.66406 70.535156 z "
-         id="path969" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer6"
-       inkscape:label="Pictograms"
-       style="display:inline">
-      <path
-         inkscape:transform-center-y="-151.90341"
-         inkscape:transform-center-x="0.2769014"
-         id="path1073"
-         d="m 350.97257,68.01332 c -4.4165,0 -7.9968,3.580309 -7.9968,7.996841 0,0.876934 0.148,1.718357 0.4088,2.507876 0.026,0.08029 0.047,0.162566 0.076,0.241707 0.2037,0.674004 3.1892,10.469521 7.52,19.253575 10e-4,0 0,-7.89e-4 0,-0.002 0,-7.89e-4 0,-0.0027 0,-0.0044 0,-0.0018 0,-0.0034 0.01,-0.0046 0,-0.0012 0,-0.0023 0,-0.0023 4.6271,-9.593707 7.5683,-19.481849 7.5683,-19.481849 v 0 c 0.2605,-0.789085 0.4035,-1.631605 0.4035,-2.507981 0,-4.41656 -3.5803,-7.996869 -7.9968,-7.996869 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.99999976;marker:none;enable-background:accumulate"
-         d="m 340.93337,137.00002 c -2.9444,0 -5.3313,2.38687 -5.3313,5.33123 0,0.58462 0.099,1.14557 0.2726,1.67192 0.018,0.0535 0.032,0.10837 0.051,0.16113 0.1357,0.44934 2.1261,6.97968 5.0133,12.83572 6e-4,0 0,-5.3e-4 0,-0.001 0.001,-5.3e-4 0,-0.002 0,-0.003 0.001,-10e-4 0,-0.002 0,-0.003 0.001,-8e-4 0,-0.002 0,-0.002 3.0847,-6.3958 5.0455,-12.9879 5.0455,-12.9879 h -10e-4 c 0.1737,-0.52605 0.269,-1.08773 0.269,-1.67198 10e-5,-2.94438 -2.3868,-5.33125 -5.3312,-5.33125 z"
-         id="path1075"
-         inkscape:transform-center-x="0.2769014"
-         inkscape:transform-center-y="-151.90341" />
-      <path
-         inkscape:transform-center-y="-151.90341"
-         inkscape:transform-center-x="0.2769014"
-         id="path1077"
-         d="m 335.98717,192.00623 c -2.0611,0 -3.7319,1.67081 -3.7319,3.73186 0,0.40923 0.069,0.8019 0.1908,1.17034 0.012,0.0375 0.022,0.0759 0.036,0.1128 0.095,0.31453 1.4883,4.88577 3.5093,8.985 5e-4,0 10e-4,-3.7e-4 0,-9.4e-4 9e-4,-3.6e-4 10e-4,-0.001 0,-0.002 9e-4,-8.4e-4 10e-4,-0.002 0,-0.002 9e-4,-5.6e-4 10e-4,-0.001 0,-0.001 2.1593,-4.47706 3.5319,-9.09153 3.5319,-9.09153 h -9e-4 c 0.1215,-0.36824 0.1883,-0.76141 0.1883,-1.17039 0,-2.06106 -1.6708,-3.73187 -3.7319,-3.73187 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.99999976;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;filter:url(#filter4398);enable-background:accumulate"
-         d="m 344.62023,104 c -44.76554,0 -81.05518,36.28966 -81.05518,81.05519 0,8.88851 1.49956,17.4171 4.14327,25.41957 0.26885,0.81383 0.48141,1.64776 0.77513,2.44993 2.06461,6.83163 32.32582,106.11802 76.22181,195.15231 0.0123,0 0.0303,-0.007 0.0445,-0.0201 0.0175,-0.009 0.0336,-0.027 0.0496,-0.0448 0.0175,-0.0175 0.0338,-0.0345 0.0504,-0.0462 0.0175,-0.0123 0.0338,-0.0236 0.0473,-0.0236 46.90025,-97.24086 76.71206,-197.46607 76.71206,-197.46607 h -0.0236 c 2.64047,-7.99809 4.08981,-16.53778 4.08981,-25.42064 2.1e-4,-44.76582 -36.28945,-81.05548 -81.05497,-81.05548 z"
-         id="path4394"
-         inkscape:transform-center-x="0.2769014"
-         inkscape:transform-center-y="-151.90341"
-         transform="matrix(0.5,0,0,0.5,23.99997,28.00002)" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#linearGradient4317);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;filter:url(#filter4321);enable-background:accumulate"
-         d="m 344.62023,104 c -44.76554,0 -81.05518,36.28966 -81.05518,81.05519 0,8.88851 1.49956,17.4171 4.14327,25.41957 0.26885,0.81383 0.48141,1.64776 0.77513,2.44993 2.06461,6.83163 32.32582,106.11802 76.22181,195.15231 0.0123,0 0.0303,-0.007 0.0445,-0.0201 0.0175,-0.009 0.0336,-0.027 0.0496,-0.0448 0.0175,-0.0175 0.0338,-0.0345 0.0504,-0.0462 0.0175,-0.0123 0.0338,-0.0236 0.0473,-0.0236 46.90025,-97.24086 76.71206,-197.46607 76.71206,-197.46607 h -0.0236 c 2.64047,-7.99809 4.08981,-16.53778 4.08981,-25.42064 2.1e-4,-44.76582 -36.28945,-81.05548 -81.05497,-81.05548 z"
-         id="path4307"
-         inkscape:transform-center-x="0.2769014"
-         inkscape:transform-center-y="-151.90341"
-         transform="matrix(0.5,0,0,0.5,23.99997,28.00002)" />
-      <path
-         inkscape:transform-center-y="-151.90341"
-         inkscape:transform-center-x="0.2769014"
-         id="path4789"
-         d="m 196.31007,79.00002 c -22.3828,0 -40.5276,18.14483 -40.5276,40.52759 0,4.44426 0.7498,8.70855 2.0716,12.70979 0.1344,0.40691 0.2407,0.82388 0.3876,1.22496 1.0323,3.41582 16.1629,53.05901 38.1109,97.57616 0.01,0 0.015,-0.004 0.022,-0.0101 0.01,-0.004 0.017,-0.0135 0.025,-0.0224 0.01,-0.009 0.017,-0.0172 0.025,-0.0231 0.01,-0.006 0.017,-0.0118 0.024,-0.0118 23.4501,-48.62043 38.356,-98.73304 38.356,-98.73304 h -0.012 c 1.3203,-3.99904 2.0449,-8.26889 2.0449,-12.71032 1e-4,-22.382905 -18.1447,-40.527735 -40.5275,-40.527735 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f22c42;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <circle
-         inkscape:transform-center-y="-219.429"
-         inkscape:transform-center-x="0.2725578"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#bc1938;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="path4793"
-         cx="195.99997"
-         cy="120.00002"
-         r="20" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f22c42;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 350.97257,69.01332 c -4.4165,0 -7.9968,3.580309 -7.9968,7.996841 0,0.876934 0.148,1.718357 0.4088,2.507876 0.026,0.08029 0.047,0.162566 0.076,0.241707 0.2037,0.674004 3.1892,10.469521 7.52,19.253575 10e-4,0 0,-7.89e-4 0,-0.002 0,-7.89e-4 0,-0.0027 0,-0.0044 0,-0.0018 0,-0.0034 0.01,-0.0046 0,-0.0012 0,-0.0023 0,-0.0023 4.6271,-9.593707 7.5683,-19.481849 7.5683,-19.481849 v 0 c 0.2605,-0.789085 0.4035,-1.631605 0.4035,-2.507981 0,-4.41656 -3.5803,-7.996869 -7.9968,-7.996869 z"
-         id="path1012"
-         inkscape:transform-center-x="0.2769014"
-         inkscape:transform-center-y="-151.90341" />
-      <circle
-         r="3.9463687"
-         cy="77.103378"
-         cx="350.91147"
-         id="circle1014"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#bc1938;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.99999988;marker:none;enable-background:accumulate"
-         inkscape:transform-center-x="0.2725578"
-         inkscape:transform-center-y="-219.429" />
-      <path
-         inkscape:transform-center-y="-151.90341"
-         inkscape:transform-center-x="0.2769014"
-         id="path1047"
-         d="m 340.93337,138.00002 c -2.9444,0 -5.3313,2.38687 -5.3313,5.33123 0,0.58462 0.099,1.14557 0.2726,1.67192 0.018,0.0535 0.032,0.10837 0.051,0.16113 0.1357,0.44934 2.1261,6.97968 5.0133,12.83572 6e-4,0 0,-5.3e-4 0,-0.001 0.001,-5.3e-4 0,-0.002 0,-0.003 0.001,-10e-4 0,-0.002 0,-0.003 0.001,-8e-4 0,-0.002 0,-0.002 3.0847,-6.3958 5.0455,-12.9879 5.0455,-12.9879 h -10e-4 c 0.1737,-0.52605 0.269,-1.08773 0.269,-1.67198 10e-5,-2.94438 -2.3868,-5.33125 -5.3312,-5.33125 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f22c42;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.99999976;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <circle
-         inkscape:transform-center-y="-219.429"
-         inkscape:transform-center-x="0.2725578"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#bc1938;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.99999988;marker:none;enable-background:accumulate"
-         id="circle1049"
-         cx="340.89255"
-         cy="143.3934"
-         r="2.6309125" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f22c42;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.99999976;marker:none;enable-background:accumulate"
-         d="m 335.98717,193.00623 c -2.0611,0 -3.7319,1.67081 -3.7319,3.73186 0,0.40923 0.069,0.8019 0.1908,1.17034 0.012,0.0375 0.022,0.0759 0.036,0.1128 0.095,0.31453 1.4883,4.88577 3.5093,8.985 5e-4,0 10e-4,-3.7e-4 0,-9.4e-4 9e-4,-3.6e-4 10e-4,-0.001 0,-0.002 9e-4,-8.4e-4 10e-4,-0.002 0,-0.002 9e-4,-5.6e-4 10e-4,-0.001 0,-0.001 2.1593,-4.47706 3.5319,-9.09153 3.5319,-9.09153 h -9e-4 c 0.1215,-0.36824 0.1883,-0.76141 0.1883,-1.17039 0,-2.06106 -1.6708,-3.73187 -3.7319,-3.73187 z"
-         id="path1053"
-         inkscape:transform-center-x="0.2769014"
-         inkscape:transform-center-y="-151.90341" />
-      <circle
-         r="1.8416388"
-         cy="196.78159"
-         cx="335.95859"
-         id="circle1055"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#bc1938;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         inkscape:transform-center-x="0.2725578"
-         inkscape:transform-center-y="-219.429" />
-      <path
-         inkscape:transform-center-y="-151.90341"
-         inkscape:transform-center-x="0.2769014"
-         id="path1059"
-         d="m 330.99167,239.00401 c -1.3249,0 -2.399,1.07409 -2.399,2.39905 0,0.26308 0.044,0.51551 0.1226,0.75237 0.01,0.0241 0.014,0.0488 0.023,0.0725 0.061,0.2022 0.9568,3.14085 2.256,5.77607 3e-4,0 9e-4,-2.4e-4 0.001,-6e-4 6e-4,-2.4e-4 9e-4,-8.1e-4 0,-0.001 6e-4,-5.4e-4 9e-4,-0.001 10e-4,-0.001 6e-4,-3.6e-4 9e-4,-6.9e-4 0,-6.9e-4 1.3882,-2.87811 2.2705,-5.84455 2.2705,-5.84455 h -6e-4 c 0.078,-0.23673 0.1211,-0.48949 0.1211,-0.7524 0,-1.32497 -1.0741,-2.39906 -2.3991,-2.39906 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f22c42;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.99999976;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <circle
-         inkscape:transform-center-y="-219.429"
-         inkscape:transform-center-x="0.2725578"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#bc1938;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="circle1061"
-         cx="330.97336"
-         cy="241.43103"
-         r="1.1839106" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 196.31047,79.00002 c -22.3828,0 -40.5273,18.144584 -40.5273,40.52734 0,0.37362 0.011,0.74421 0.021,1.11524 0.4722,-21.972822 18.4197,-39.64258 40.5058,-39.64258 22.0861,0 40.0337,17.669619 40.5059,39.64258 0.01,-0.3709 0.022,-0.74185 0.022,-1.11524 1e-4,-22.382901 -18.1446,-40.52734 -40.5274,-40.52734 z"
-         id="path994"
-         inkscape:connector-curvature="0" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer2"
-       inkscape:label="Highlights"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.990234,67.998047 c -35.36853,0 -38.992187,3.623202 -38.992187,38.919923 v 98.1582 c 0,0.0882 0.0019,0.16224 0.002,0.25 V 108.91602 C 40,73.6193 43.625611,69.994141 78.994141,69.994141 H 152 225.00586 c 35.28016,0 38.97394,3.621035 38.99219,38.671879 v -1.74805 c 0,-35.296721 -3.62561,-38.919923 -38.99414,-38.919923 h -73.00586 z"
-         id="rect4158-78"
-         inkscape:connector-curvature="0" />
+         d="m 263.93,76.241869 c 0,-17.759615 -14.41225,-32.171868 -32.17187,-32.171868 H 72.241869 c -17.759615,0 -32.171868,14.412253 -32.171868,32.171868 V 235.75813 c 0,17.75962 14.412253,32.17187 32.171868,32.17187 H 231.75813 c 17.75962,0 32.17187,-14.41225 32.17187,-32.17187 z"
+         fill="url(#a)"
+         id="path297"
+         style="fill:url(#linearGradient690);stroke-width:5.16568" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 39.998047,203.07617 v 2 c 0,35.29673 3.624067,39.09487 38.992187,38.92188 h 73.007816 73.00586 c 35.36811,0.17299 38.99414,-3.62515 38.99414,-38.92188 v -2 c 0,35.29673 -3.62603,39.09487 -38.99414,38.92188 H 151.99805 78.990234 c -35.36812,0.17299 -38.992187,-3.62515 -38.992187,-38.92188 z"
-         id="rect4158-6"
-         inkscape:connector-curvature="0" />
+         d="M 72.241869,44.070001 H 231.75813 l 6.71022,0.702532 C 253.00975,47.861611 263.93,60.780982 263.93,76.241869 v 62.127661 c 0,10.71879 -223.859999,88.1317 -223.859999,71.88046 V 76.241869 c 0,-9.804465 4.390829,-18.586124 11.312843,-24.485333 6.400281,-5.046872 13.379117,-7.485074 20.859025,-7.686535 z"
+         fill="url(#b)"
+         id="path299"
+         style="fill:url(#linearGradient692);stroke-width:5.16568" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983)"
-         transform="rotate(90,328,244)" />
+         d="m 199.9272,44.070001 h -88.4933 l 0.26345,155.430209 88.22985,-15.67268 z"
+         fill="#089f48"
+         id="path301"
+         style="stroke-width:5.16568" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.51173,240.91355 c 0,-2.89732 -0.30259,-3.44011 -3.25454,-3.42488 h -4.25716 -4.25724 c -2.95195,-0.0152 -3.25453,0.52756 -3.25453,3.42488 v 6.17331 c 0,2.8966 0.30255,3.42488 3.25453,3.42488 h 4.25724 4.25716 c 2.95199,0 3.25454,-0.52828 3.25454,-3.42488 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 110.7417,267.93 0.95565,-68.42979 88.38999,-18.05406 -0.0517,86.48385 z"
+         fill="#947e67"
+         id="path303"
+         style="stroke-width:5.16568" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 343.51172,195.49156 c 0,-4.23214 -0.46371,-5.02499 -4.98757,-5.00275 h -6.5241 -6.52423 c -4.52386,-0.0222 -4.98757,0.77061 -4.98757,5.00275 v 9.01743 c 0,4.23108 0.46366,5.00275 4.98757,5.00275 h 6.52423 6.5241 c 4.52391,0 4.98757,-0.77167 4.98757,-5.00275 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 366.98563,67.621098 c 0,-3.647064 -2.95966,-6.606723 -6.60673,-6.606723 h -32.7578 c -3.64706,0 -6.60672,2.959659 -6.60672,6.606723 V 100.3789 c 0,3.64707 2.95966,6.60672 6.60672,6.60672 h 32.7578 c 3.64707,0 6.60673,-2.95965 6.60673,-6.60672 z"
+         fill="url(#a)"
+         id="path538"
+         style="fill:url(#linearGradient564);stroke-width:1.06081" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971)"
-         transform="rotate(90,331.99966,200)" />
+         d="m 327.6211,61.014375 h 32.7578 l 1.378,0.14427 c 2.98618,0.634365 5.22873,3.28745 5.22873,6.462453 v 12.758358 c 0,2.20118 -45.97125,18.098475 -45.97125,14.761167 V 67.621098 c 0,-2.013417 0.90169,-3.816793 2.32317,-5.028238 1.31434,-1.036411 2.7475,-1.537113 4.28355,-1.578485 z"
+         fill="url(#b)"
+         id="path540"
+         style="fill:url(#linearGradient566);stroke-width:1.06081" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 350.50001,142.07508 c 0,-5.56175 -0.58409,-6.6037 -6.28227,-6.57447 h -8.21765 -8.21781 c -5.69818,-0.0293 -6.28227,1.01272 -6.28227,6.57447 v 11.85044 c 0,5.56037 0.58403,6.57447 6.28227,6.57447 h 8.21781 8.21765 c 5.69824,0 6.28227,-1.0141 6.28227,-6.57447 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 353.8422,61.014375 h -18.17274 l 0.0541,31.918703 18.11863,-3.218496 z"
+         fill="#089f48"
+         id="path542"
+         style="stroke-width:1.06081" />
       <path
-         transform="matrix(0,0.66664182,-0.63636364,0,389.45455,-81.324786)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004-8);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-1)" />
+         d="m 335.52732,106.98562 0.19625,-14.052542 18.15151,-3.70753 -0.0106,17.760072 z"
+         fill="#947e67"
+         id="path544"
+         style="stroke-width:1.06081" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 366.50065,75.231076 c 0,-8.23154 -0.90635,-9.77365 -9.74838,-9.7304 H 344.0007 331.24889 c -8.84203,-0.0433 -9.74838,1.49886 -9.74838,9.7304 v 17.53897 c 0,8.229494 0.90625,9.730394 9.74838,9.730394 h 12.75181 12.75157 c 8.84213,0 9.74838,-1.5009 9.74838,-9.730404 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 350.99062,137.31811 c 0,-2.37852 -1.93021,-4.30874 -4.30873,-4.30874 h -21.36378 c -2.37852,0 -4.30874,1.93022 -4.30874,4.30874 v 21.36378 c 0,2.37852 1.93022,4.30873 4.30874,4.30873 h 21.36378 c 2.37852,0 4.30873,-1.93021 4.30873,-4.30873 z"
+         fill="url(#a)"
+         id="path570"
+         style="fill:url(#linearGradient596);stroke-width:0.691832" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994)"
-         transform="rotate(90,344,84)" />
+         d="m 325.31811,133.00937 h 21.36378 l 0.89869,0.0941 c 1.94751,0.41372 3.41004,2.14399 3.41004,4.21465 v 8.32066 c 0,1.43556 -29.98125,11.80336 -29.98125,9.62685 v -17.94751 c 0,-1.3131 0.58806,-2.48922 1.51512,-3.27929 0.85718,-0.67592 1.79184,-1.00247 2.79362,-1.02945 z"
+         fill="url(#b)"
+         id="path572"
+         style="fill:url(#linearGradient598);stroke-width:0.691832" />
+      <path
+         d="m 342.41882,133.00937 h -11.85178 l 0.0353,20.81655 11.8165,-2.09902 z"
+         fill="#089f48"
+         id="path574"
+         style="stroke-width:0.691832" />
+      <path
+         d="m 330.47433,162.99062 0.12799,-9.1647 11.83795,-2.41796 -0.007,11.58266 z"
+         fill="#947e67"
+         id="path576"
+         style="stroke-width:0.691832" />
+      <path
+         d="m 343.49281,191.81055 c 0,-1.82354 -1.47983,-3.30337 -3.30336,-3.30337 h -16.3789 c -1.82354,0 -3.30337,1.47983 -3.30337,3.30337 v 16.3789 c 0,1.82353 1.47983,3.30336 3.30337,3.30336 h 16.3789 c 1.82353,0 3.30336,-1.47983 3.30336,-3.30336 z"
+         fill="url(#a)"
+         id="path602"
+         style="fill:url(#linearGradient628);stroke-width:0.530405" />
+      <path
+         d="m 323.81055,188.50718 h 16.3789 l 0.68899,0.0721 c 1.49309,0.31718 2.61437,1.64372 2.61437,3.23123 v 6.37917 c 0,1.10059 -22.98563,9.04924 -22.98563,7.38059 v -13.75976 c 0,-1.00671 0.45085,-1.9084 1.16159,-2.51412 0.65717,-0.51821 1.37375,-0.76856 2.14178,-0.78925 z"
+         fill="url(#b)"
+         id="path604"
+         style="fill:url(#linearGradient630);stroke-width:0.530405" />
+      <path
+         d="m 336.92109,188.50718 h -9.08636 l 0.0271,15.95936 9.05931,-1.60925 z"
+         fill="#089f48"
+         id="path606"
+         style="stroke-width:0.530405" />
+      <path
+         d="m 327.76365,211.49281 0.0981,-7.02627 9.07576,-1.85377 -0.005,8.88004 z"
+         fill="#947e67"
+         id="path608"
+         style="stroke-width:0.530405" />
+      <path
+         d="m 335.49062,238.65905 c 0,-1.18926 -0.9651,-2.15436 -2.15436,-2.15436 h -10.6819 c -1.18926,0 -2.15436,0.9651 -2.15436,2.15436 v 10.6819 c 0,1.18926 0.9651,2.15436 2.15436,2.15436 h 10.6819 c 1.18926,0 2.15436,-0.9651 2.15436,-2.15436 z"
+         fill="url(#a)"
+         id="path634"
+         style="fill:url(#linearGradient660);stroke-width:0.345916" />
+      <path
+         d="m 322.65436,236.50469 h 10.6819 l 0.44934,0.047 c 0.97375,0.20686 1.70502,1.072 1.70502,2.10732 v 4.16034 c 0,0.71777 -14.99062,5.90167 -14.99062,4.81342 v -8.97376 c 0,-0.65655 0.29403,-1.2446 0.75755,-1.63964 0.42859,-0.33796 0.89593,-0.50123 1.39681,-0.51472 z"
+         fill="url(#b)"
+         id="path636"
+         style="fill:url(#linearGradient662);stroke-width:0.345916" />
+      <path
+         d="m 331.20472,236.50469 h -5.92589 l 0.0176,10.40827 5.90825,-1.04951 z"
+         fill="#089f48"
+         id="path638"
+         style="stroke-width:0.345916" />
+      <path
+         d="m 325.23248,251.49531 0.064,-4.58235 5.91897,-1.20898 -0.003,5.79133 z"
+         fill="#947e67"
+         id="path640"
+         style="stroke-width:0.345916" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictogram"
+       style="display:inline">
+      <path
+         d="M 40.070001,233.72802 111.69735,199.50021 V 170.76869 L 40.070001,203.87554 Z"
+         fill="#efefef"
+         id="path305"
+         style="display:inline;enable-background:new;stroke-width:5.16568" />
+      <path
+         d="M 42.735493,63.410314 C 48.479731,51.601565 56.982444,45.898652 67.44295,44.519415 l 44.07877,52.318028 0.17563,47.854877 z"
+         fill="#efefef"
+         id="path307"
+         style="display:inline;enable-background:new;stroke-width:5.16568" />
+      <path
+         d="m 111.69735,170.76869 10.36752,-1.4464 -10.36752,-24.62997 -0.17563,-47.854877 36.3354,68.729397 52.21988,-4.27718 v 31.6553 l -88.37965,6.55525 z"
+         fill="#d8d8d8"
+         id="path309"
+         style="display:inline;enable-background:new;stroke-width:5.16568" />
+      <path
+         d="m 200.1047,192.84805 63.76647,-45.85463 0.19883,-33.02084 -64.1428,47.3576 z"
+         fill="#efefef"
+         id="path311"
+         style="display:inline;enable-background:new;stroke-width:4.72121" />
+      <path
+         d="m 183.47967,68.720636 c -20.56975,0 -37.24457,16.674821 -37.24457,37.244564 0,1.57037 0.12914,3.10458 0.32027,4.62845 3.18206,29.09313 34.50676,62.62357 34.50676,62.62357 0.55789,0.62505 1.09512,1.00731 1.61169,1.28625 l 0.0258,0.0155 1.04347,0.3306 1.04346,-0.3306 0.0258,-0.0155 c 0.52174,-0.27894 1.05897,-0.68187 1.61686,-1.28625 0,0 30.87012,-33.59243 33.97986,-62.69072 0.18596,-1.50321 0.31511,-3.02192 0.31511,-4.57163 -0.0103,-20.559413 -16.67483,-37.234234 -37.24457,-37.234234 z m 0,61.197834 c -13.20865,0 -23.95844,-10.74978 -23.95844,-23.95327 0,-13.208646 10.74979,-23.95843 23.95844,-23.95843 13.20865,0 23.9481,10.749784 23.9481,23.95843 0,13.20349 -10.73945,23.95327 -23.9481,23.95327 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path313"
+         style="display:inline;enable-background:new;fill:url(#linearGradient694);stroke-width:5.16568" />
+      <path
+         d="m 140.17059,175.65026 c 1.76666,-2.22641 5.18634,-2.13343 6.84969,-0.51141 1.66852,1.62203 1.58587,4.77826 -0.21179,7.88283 -1.26043,2.33489 -4.40116,4.62329 -7.00467,6.1265 -2.51568,-1.64785 -5.53244,-4.09638 -6.66372,-6.49326 -1.62203,-3.19756 -1.53938,-6.35379 0.21179,-7.88283 1.75633,-1.53421 5.17085,-1.44123 6.8187,0.87817 z m 2.91861,1.58069 c 0.82134,0.13948 1.48772,0.69221 1.47222,1.50838 -0.0258,0.80585 -0.71803,1.4154 -1.55487,1.42057 -0.97115,0.005 -1.49288,-0.69737 -1.47222,-1.49805 0.0207,-0.81618 0.56306,-1.5962 1.55487,-1.4309 z m -5.95603,-0.1498 c 0.95565,-0.13431 1.49805,0.70253 1.47222,1.51354 -0.0207,0.80068 -0.35644,1.38441 -1.54971,1.42057 -0.83167,0.0207 -1.49288,-0.69737 -1.47738,-1.50838 0.0258,-0.81101 0.72836,-1.30692 1.55487,-1.42573 z"
+         fill="#cb3434"
+         id="path315"
+         style="display:inline;enable-background:new;stroke-width:5.16568" />
+      <path
+         d="m 74.607751,159.10458 h -0.640544 c -0.604385,0 -1.084794,-0.49591 -1.084794,-1.09513 v -1.84415 c -2.598338,-0.65087 -3.342196,-2.19541 -3.342196,-5.36198 0,-4.66977 3.791611,-8.46138 8.466553,-8.46138 4.669777,0 8.461387,3.79161 8.461387,8.46138 0,3.12008 -0.790349,4.65945 -3.331865,5.33099 v 1.86481 c 0,0.60955 -0.490739,1.10029 -1.095124,1.10029 h -0.635379 c -0.604385,0 -1.095125,-0.49074 -1.095125,-1.10029 v -1.46705 c -0.289278,0.0258 -0.578556,0.031 -0.888497,0.0465 v 1.43089 c 0,0.59922 -0.49074,1.08996 -1.095125,1.08996 h -0.635379 c -0.604384,0 -1.095124,-0.49074 -1.095124,-1.08996 v -1.42573 c -0.309941,-0.0103 -0.609551,-0.0207 -0.898829,-0.0362 v 1.46189 c 0,0.59922 -0.49074,1.09513 -1.089959,1.09513 z m -0.113645,-11.7416 c 1.441225,0.56306 2.603504,1.12612 2.603504,2.52085 0,1.38957 -0.940154,1.65819 -2.603504,2.51569 -1.270758,0.66121 -2.598338,-1.12612 -2.598338,-2.51569 0,-1.39473 1.260427,-3.04258 2.598338,-2.52085 z m 6.984002,0 c 1.384403,-0.39259 2.598338,1.12612 2.598338,2.52085 0,1.38957 -1.36374,3.24922 -2.598338,2.51569 -1.513544,-0.89883 -2.598338,-1.12612 -2.598338,-2.51569 0,-1.39473 1.012474,-2.07144 2.598338,-2.52085 z"
+         fill="#ededed"
+         id="path317"
+         style="display:inline;enable-background:new;stroke-width:5.16568" />
+      <path
+         d="m 66.978039,122.90864 2.546681,2.69132 4.029232,-3.81744 3.223386,3.39902 -4.029232,3.81227 2.551847,2.69649 c 0.867834,0.91433 0.857503,2.33489 -0.02066,3.1614 -0.878166,0.83167 -2.293563,0.76452 -3.156232,-0.14981 l -2.551847,-2.69132 -4.044729,3.82261 -3.21822,-3.39386 4.044729,-3.63147 -2.551847,-2.89278 c -0.873,-0.91433 -0.857503,-2.32972 0.0155,-3.1614 0.878166,-0.83167 2.293563,-0.76452 3.161398,0.15497 z"
+         fill="#ffffff"
+         id="path319"
+         style="display:inline;enable-background:new;stroke-width:5.16568" />
+      <path
+         d="m 321.01438,99.962003 14.70919,-7.028925 v -5.900223 l -14.70919,6.798729 z"
+         fill="#efefef"
+         id="path546"
+         style="display:inline;enable-background:new;stroke-width:1.06081" />
+      <path
+         d="m 321.56176,64.986047 c 1.17962,-2.425011 2.92571,-3.596145 5.07385,-3.879381 l 9.05189,10.74388 0.0361,9.827341 z"
+         fill="#efefef"
+         id="path548"
+         style="display:inline;enable-background:new;stroke-width:1.06081" />
+      <path
+         d="m 335.72357,87.032855 2.12904,-0.297027 -2.12904,-5.057941 -0.0361,-9.827341 7.46173,14.114073 10.72373,-0.87835 v 6.500642 l -18.14939,1.346167 z"
+         fill="#d8d8d8"
+         id="path550"
+         style="display:inline;enable-background:new;stroke-width:1.06081" />
+      <path
+         d="m 353.87865,91.56701 13.0949,-9.416576 0.0408,-6.781064 -13.17218,9.725221 z"
+         fill="#efefef"
+         id="path552"
+         style="display:inline;enable-background:new;stroke-width:0.969534" />
+      <path
+         d="m 350.46458,66.076559 c -4.22415,0 -7.64844,3.424294 -7.64844,7.648438 0,0.322486 0.0265,0.637547 0.0658,0.950486 0.65346,5.97448 7.08621,12.860196 7.08621,12.860196 0.11457,0.128358 0.22489,0.206857 0.33097,0.264141 l 0.005,0.0032 0.21429,0.06789 0.21428,-0.06789 0.005,-0.0032 c 0.10714,-0.05728 0.21746,-0.140027 0.33203,-0.264141 0,0 6.3394,-6.898446 6.97801,-12.873987 0.0382,-0.308696 0.0647,-0.620574 0.0647,-0.938817 -0.002,-4.222022 -3.4243,-7.646316 -7.64844,-7.646316 z m 0,12.567413 c -2.71249,0 -4.92004,-2.207545 -4.92004,-4.918975 0,-2.71249 2.20755,-4.920035 4.92004,-4.920035 2.71249,0 4.91791,2.207545 4.91791,4.920035 0,2.71143 -2.20542,4.918975 -4.91791,4.918975 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path554"
+         style="display:inline;enable-background:new;fill:url(#linearGradient568);stroke-width:1.06081" />
+      <path
+         d="m 341.57075,88.03532 c 0.3628,-0.457209 1.06505,-0.438115 1.40663,-0.10502 0.34264,0.333094 0.32567,0.981249 -0.0435,1.618795 -0.25884,0.479486 -0.90381,0.949425 -1.43846,1.258121 -0.51661,-0.338399 -1.13613,-0.841222 -1.36844,-1.333438 -0.3331,-0.656641 -0.31612,-1.304796 0.0435,-1.618796 0.36068,-0.31506 1.06187,-0.295966 1.40027,0.180338 z m 0.59936,0.324608 c 0.16866,0.02864 0.30551,0.142148 0.30233,0.309756 -0.005,0.165486 -0.14746,0.290662 -0.31931,0.291723 -0.19943,0.0011 -0.30657,-0.14321 -0.30233,-0.307635 0.004,-0.167608 0.11563,-0.32779 0.31931,-0.293844 z m -1.22312,-0.03076 c 0.19625,-0.02758 0.30764,0.14427 0.30233,0.310817 -0.004,0.164426 -0.0732,0.284297 -0.31824,0.291723 -0.17079,0.0042 -0.30657,-0.143209 -0.30339,-0.309756 0.005,-0.166547 0.14957,-0.268385 0.3193,-0.292784 z"
+         fill="#cb3434"
+         id="path556"
+         style="display:inline;enable-background:new;stroke-width:1.06081" />
+      <path
+         d="m 328.10695,84.637546 h -0.13154 c -0.12411,0 -0.22277,-0.101837 -0.22277,-0.224891 v -0.378709 c -0.53359,-0.133662 -0.68634,-0.450844 -0.68634,-1.101121 0,-0.958972 0.77863,-1.737606 1.73866,-1.737606 0.95898,0 1.73761,0.778634 1.73761,1.737606 0,0.640729 -0.1623,0.956851 -0.68422,1.094756 v 0.382952 c 0,0.125176 -0.10078,0.225953 -0.22489,0.225953 h -0.13048 c -0.12412,0 -0.22489,-0.100777 -0.22489,-0.225953 v -0.30127 c -0.0594,0.0053 -0.11881,0.0064 -0.18246,0.0095 v 0.293845 c 0,0.123054 -0.10078,0.223831 -0.2249,0.223831 h -0.13047 c -0.12412,0 -0.2249,-0.100777 -0.2249,-0.223831 v -0.292784 c -0.0636,-0.0021 -0.12517,-0.0042 -0.18458,-0.0074 v 0.300209 c 0,0.123054 -0.10077,0.224891 -0.22383,0.224891 z m -0.0233,-2.41122 c 0.29597,0.115628 0.53465,0.231256 0.53465,0.517675 0,0.285358 -0.19307,0.34052 -0.53465,0.516614 -0.26096,0.135784 -0.53358,-0.231256 -0.53358,-0.516614 0,-0.286419 0.25883,-0.624817 0.53358,-0.517675 z m 1.43422,0 c 0.2843,-0.08062 0.53359,0.231256 0.53359,0.517675 0,0.285358 -0.28006,0.667249 -0.53359,0.516614 -0.31082,-0.18458 -0.53359,-0.231256 -0.53359,-0.516614 0,-0.286419 0.20792,-0.425385 0.53359,-0.517675 z"
+         fill="#ededed"
+         id="path558"
+         style="display:inline;enable-background:new;stroke-width:1.06081" />
+      <path
+         d="m 326.54014,77.204453 0.52298,0.552682 0.82743,-0.783939 0.66194,0.698013 -0.82743,0.782878 0.52404,0.553742 c 0.17822,0.187764 0.17609,0.479486 -0.004,0.649216 -0.18034,0.17079 -0.471,0.157 -0.64816,-0.03076 l -0.52404,-0.552681 -0.83061,0.784999 -0.66089,-0.696952 0.83062,-0.745749 -0.52404,-0.594054 c -0.17928,-0.187763 -0.1761,-0.478425 0.003,-0.649215 0.18034,-0.170791 0.471,-0.157 0.64922,0.03182 z"
+         fill="#ffffff"
+         id="path560"
+         style="display:inline;enable-background:new;stroke-width:1.06081" />
+      <path
+         d="m 321.00937,158.41 9.59295,-4.58408 v -3.84797 l -9.59295,4.43395 z"
+         fill="#efefef"
+         id="path578"
+         style="display:inline;enable-background:new;stroke-width:0.691832" />
+      <path
+         d="m 321.36636,135.59959 c 0.76932,-1.58153 1.90807,-2.34531 3.30903,-2.53003 l 5.90341,7.00688 0.0235,6.40914 z"
+         fill="#efefef"
+         id="path580"
+         style="display:inline;enable-background:new;stroke-width:0.691832" />
+      <path
+         d="m 330.60232,149.97795 1.38851,-0.19372 -1.38851,-3.29865 -0.0235,-6.40914 4.86635,9.20483 6.99373,-0.57284 v 4.23955 l -11.83656,0.87794 z"
+         fill="#d8d8d8"
+         id="path582"
+         style="display:inline;enable-background:new;stroke-width:0.691832" />
+      <path
+         d="m 342.44259,152.935 8.54015,-6.14124 0.0266,-4.42243 -8.59055,6.34253 z"
+         fill="#efefef"
+         id="path584"
+         style="display:inline;enable-background:new;stroke-width:0.632305" />
+      <path
+         d="m 340.21602,136.3108 c -2.75487,0 -4.98811,2.23323 -4.98811,4.98811 0,0.21032 0.0173,0.41579 0.0429,0.61988 0.42617,3.8964 4.62144,8.38709 4.62144,8.38709 0.0747,0.0837 0.14667,0.1349 0.21585,0.17226 l 0.003,0.002 0.13975,0.0443 0.13975,-0.0443 0.003,-0.002 c 0.0699,-0.0374 0.14182,-0.0913 0.21654,-0.17226 0,0 4.13439,-4.49899 4.55087,-8.39608 0.0249,-0.20133 0.0422,-0.40472 0.0422,-0.61227 -0.001,-2.7535 -2.23324,-4.98673 -4.98812,-4.98673 z m 0,8.19614 c -1.76901,0 -3.20871,-1.43971 -3.20871,-3.20803 0,-1.76902 1.4397,-3.20872 3.20871,-3.20872 1.76902,0 3.20734,1.4397 3.20734,3.20872 0,1.76832 -1.43832,3.20803 -3.20734,3.20803 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path586"
+         style="display:inline;enable-background:new;fill:url(#linearGradient600);stroke-width:0.691832" />
+      <path
+         d="m 334.4157,150.63173 c 0.23661,-0.29818 0.6946,-0.28573 0.91737,-0.0685 0.22346,0.21723 0.21239,0.63994 -0.0284,1.05573 -0.16881,0.31271 -0.58944,0.61919 -0.93813,0.82052 -0.33692,-0.2207 -0.74095,-0.54863 -0.89246,-0.86964 -0.21724,-0.42824 -0.20617,-0.85095 0.0284,-1.05573 0.23523,-0.20548 0.69253,-0.19302 0.91322,0.11761 z m 0.39089,0.2117 c 0.11,0.0187 0.19924,0.0927 0.19717,0.20201 -0.003,0.10793 -0.0962,0.18957 -0.20824,0.19026 -0.13007,6.9e-4 -0.19994,-0.0934 -0.19717,-0.20063 0.003,-0.10931 0.0754,-0.21378 0.20824,-0.19164 z m -0.79769,-0.0201 c 0.12799,-0.018 0.20064,0.0941 0.19718,0.2027 -0.003,0.10724 -0.0477,0.18541 -0.20755,0.19026 -0.11139,0.003 -0.19994,-0.0934 -0.19787,-0.20202 0.003,-0.10862 0.0976,-0.17503 0.20824,-0.19094 z"
+         fill="#cb3434"
+         id="path588"
+         style="display:inline;enable-background:new;stroke-width:0.691832" />
+      <path
+         d="m 325.63496,148.41579 h -0.0858 c -0.0809,0 -0.14529,-0.0664 -0.14529,-0.14667 v -0.24698 c -0.34799,-0.0872 -0.44761,-0.29403 -0.44761,-0.71813 0,-0.62541 0.5078,-1.13322 1.13391,-1.13322 0.62542,0 1.13322,0.50781 1.13322,1.13322 0,0.41787 -0.10585,0.62404 -0.44623,0.71398 v 0.24975 c 0,0.0816 -0.0657,0.14736 -0.14667,0.14736 h -0.0851 c -0.0809,0 -0.14667,-0.0657 -0.14667,-0.14736 v -0.19648 c -0.0387,0.003 -0.0775,0.004 -0.119,0.006 v 0.19164 c 0,0.0803 -0.0657,0.14598 -0.14667,0.14598 h -0.0851 c -0.081,0 -0.14667,-0.0657 -0.14667,-0.14598 v -0.19094 c -0.0415,-10e-4 -0.0816,-0.003 -0.12038,-0.005 v 0.19579 c 0,0.0803 -0.0657,0.14667 -0.14598,0.14667 z m -0.0152,-1.57254 c 0.19303,0.0754 0.34869,0.15082 0.34869,0.33762 0,0.1861 -0.12592,0.22208 -0.34869,0.33692 -0.17019,0.0886 -0.34799,-0.15082 -0.34799,-0.33692 0,-0.1868 0.16881,-0.40749 0.34799,-0.33762 z m 0.93536,0 c 0.18541,-0.0526 0.34799,0.15082 0.34799,0.33762 0,0.1861 -0.18264,0.43516 -0.34799,0.33692 -0.20271,-0.12038 -0.34799,-0.15082 -0.34799,-0.33692 0,-0.1868 0.1356,-0.27743 0.34799,-0.33762 z"
+         fill="#ededed"
+         id="path590"
+         style="display:inline;enable-background:new;stroke-width:0.691832" />
+      <path
+         d="m 324.61313,143.56812 0.34107,0.36044 0.53963,-0.51126 0.4317,0.45523 -0.53962,0.51057 0.34176,0.36113 c 0.11623,0.12246 0.11484,0.31271 -0.003,0.42341 -0.11761,0.11138 -0.30717,0.10239 -0.42271,-0.0201 l -0.34176,-0.36044 -0.54171,0.51195 -0.43101,-0.45453 0.54171,-0.48636 -0.34177,-0.38742 c -0.11692,-0.12246 -0.11484,-0.31202 0.002,-0.42341 0.11761,-0.11138 0.30717,-0.10239 0.4234,0.0208 z"
+         fill="#ffffff"
+         id="path592"
+         style="display:inline;enable-background:new;stroke-width:0.691832" />
+      <path
+         d="m 320.50718,207.981 7.3546,-3.51446 v -2.95012 l -7.3546,3.39937 z"
+         fill="#efefef"
+         id="path610"
+         style="display:inline;enable-background:new;stroke-width:0.530405" />
+      <path
+         d="m 320.78087,190.49302 c 0.58981,-1.21251 1.46286,-1.79807 2.53693,-1.93969 l 4.52594,5.37194 0.018,4.91367 z"
+         fill="#efefef"
+         id="path612"
+         style="display:inline;enable-background:new;stroke-width:0.530405" />
+      <path
+         d="m 327.86178,201.51642 1.06452,-0.14851 -1.06452,-2.52897 -0.018,-4.91367 3.73087,7.05704 5.36186,-0.43918 v 3.25032 l -9.07469,0.67309 z"
+         fill="#d8d8d8"
+         id="path614"
+         style="display:inline;enable-background:new;stroke-width:0.530405" />
+      <path
+         d="m 336.93932,203.7835 6.54745,-4.70829 0.0204,-3.39053 -6.58609,4.86261 z"
+         fill="#efefef"
+         id="path616"
+         style="display:inline;enable-background:new;stroke-width:0.484767" />
+      <path
+         d="m 335.23228,191.03828 c -2.11207,0 -3.82422,1.71214 -3.82422,3.82422 0,0.16124 0.0133,0.31877 0.0329,0.47524 0.32673,2.98724 3.5431,6.4301 3.5431,6.4301 0.0573,0.0642 0.11245,0.10342 0.16549,0.13207 l 0.003,0.002 0.10714,0.0339 0.10715,-0.0339 0.003,-0.002 c 0.0536,-0.0286 0.10873,-0.07 0.16602,-0.13207 0,0 3.16969,-3.44923 3.489,-6.437 0.0191,-0.15435 0.0324,-0.31028 0.0324,-0.46941 -10e-4,-2.11101 -1.71214,-3.82315 -3.82422,-3.82315 z m 0,6.2837 c -1.35624,0 -2.46001,-1.10377 -2.46001,-2.45948 0,-1.35625 1.10377,-2.46002 2.46001,-2.46002 1.35625,0 2.45896,1.10377 2.45896,2.46002 0,1.35571 -1.10271,2.45948 -2.45896,2.45948 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path618"
+         style="display:inline;enable-background:new;fill:url(#linearGradient632);stroke-width:0.530405" />
+      <path
+         d="m 330.78537,202.01766 c 0.1814,-0.22861 0.53253,-0.21906 0.70332,-0.0525 0.17132,0.16654 0.16283,0.49062 -0.0217,0.80939 -0.12942,0.23975 -0.45191,0.47472 -0.71923,0.62906 -0.25831,-0.16919 -0.56806,-0.42061 -0.68422,-0.66671 -0.16655,-0.32832 -0.15806,-0.6524 0.0217,-0.8094 0.18033,-0.15753 0.53093,-0.14799 0.70013,0.0902 z m 0.29968,0.1623 c 0.0843,0.0143 0.15275,0.0711 0.15116,0.15488 -0.003,0.0827 -0.0737,0.14533 -0.15965,0.14586 -0.0997,5.3e-4 -0.15329,-0.0716 -0.15116,-0.15382 0.002,-0.0838 0.0578,-0.16389 0.15965,-0.14692 z m -0.61156,-0.0154 c 0.0981,-0.0138 0.15382,0.0721 0.15117,0.15541 -0.002,0.0822 -0.0366,0.14215 -0.15912,0.14586 -0.0854,0.002 -0.15329,-0.0716 -0.1517,-0.15488 0.003,-0.0833 0.0748,-0.13419 0.15965,-0.14639 z"
+         fill="#cb3434"
+         id="path620"
+         style="display:inline;enable-background:new;stroke-width:0.530405" />
+      <path
+         d="m 324.05347,200.31877 h -0.0658 c -0.0621,0 -0.11138,-0.0509 -0.11138,-0.11245 v -0.18935 c -0.2668,-0.0668 -0.34318,-0.22542 -0.34318,-0.55056 0,-0.47949 0.38932,-0.8688 0.86934,-0.8688 0.47948,0 0.8688,0.38931 0.8688,0.8688 0,0.32036 -0.0811,0.47842 -0.34211,0.54738 v 0.19147 c 0,0.0626 -0.0504,0.11298 -0.11245,0.11298 h -0.0652 c -0.062,0 -0.11244,-0.0504 -0.11244,-0.11298 v -0.15063 c -0.0297,0.003 -0.0594,0.003 -0.0912,0.005 v 0.14692 c 0,0.0615 -0.0504,0.11192 -0.11245,0.11192 h -0.0652 c -0.062,0 -0.11244,-0.0504 -0.11244,-0.11192 v -0.14639 c -0.0318,-0.001 -0.0626,-0.002 -0.0923,-0.004 v 0.1501 c 0,0.0615 -0.0504,0.11245 -0.11192,0.11245 z m -0.0117,-1.20561 c 0.14799,0.0578 0.26733,0.11563 0.26733,0.25884 0,0.14268 -0.0965,0.17026 -0.26733,0.2583 -0.13048,0.0679 -0.26679,-0.11562 -0.26679,-0.2583 0,-0.14321 0.12942,-0.31241 0.26679,-0.25884 z m 0.71711,0 c 0.14215,-0.0403 0.26679,0.11563 0.26679,0.25884 0,0.14268 -0.14002,0.33362 -0.26679,0.2583 -0.15541,-0.0923 -0.26679,-0.11562 -0.26679,-0.2583 0,-0.14321 0.10396,-0.2127 0.26679,-0.25884 z"
+         fill="#ededed"
+         id="path622"
+         style="display:inline;enable-background:new;stroke-width:0.530405" />
+      <path
+         d="m 323.27006,196.60222 0.26149,0.27634 0.41372,-0.39197 0.33097,0.34901 -0.41371,0.39144 0.26202,0.27687 c 0.0891,0.0939 0.088,0.23974 -0.002,0.32461 -0.0902,0.0854 -0.2355,0.0785 -0.32407,-0.0154 l -0.26202,-0.27634 -0.41531,0.3925 -0.33044,-0.34848 0.4153,-0.37287 -0.26202,-0.29703 c -0.0896,-0.0939 -0.088,-0.23921 0.002,-0.32461 0.0902,-0.0854 0.2355,-0.0785 0.3246,0.0159 z"
+         fill="#ffffff"
+         id="path624"
+         style="display:inline;enable-background:new;stroke-width:0.530405" />
+      <path
+         d="m 320.5,249.205 4.79647,-2.29204 v -1.92399 L 320.5,247.20595 Z"
+         fill="#efefef"
+         id="path642"
+         style="display:inline;enable-background:new;stroke-width:0.345916" />
+      <path
+         d="m 320.67849,237.7998 c 0.38466,-0.79077 0.95404,-1.17266 1.65452,-1.26502 l 2.9517,3.50344 0.0118,3.20457 z"
+         fill="#efefef"
+         id="path644"
+         style="display:inline;enable-background:new;stroke-width:0.345916" />
+      <path
+         d="m 325.29647,244.98897 0.69425,-0.0968 -0.69425,-1.64933 -0.0118,-3.20457 2.43317,4.60242 3.49687,-0.28642 v 2.11977 l -5.91828,0.43897 z"
+         fill="#d8d8d8"
+         id="path646"
+         style="display:inline;enable-background:new;stroke-width:0.345916" />
+      <path
+         d="m 331.21661,246.4675 4.27007,-3.07062 0.0133,-2.21122 -4.29528,3.17127 z"
+         fill="#efefef"
+         id="path648"
+         style="display:inline;enable-background:new;stroke-width:0.316153" />
+      <path
+         d="m 330.10332,238.1554 c -1.37744,0 -2.49405,1.11662 -2.49405,2.49405 0,0.10516 0.009,0.2079 0.0214,0.30995 0.21309,1.9482 2.31072,4.19354 2.31072,4.19354 0.0374,0.0419 0.0733,0.0675 0.10793,0.0861 l 0.002,0.001 0.0699,0.0221 0.0699,-0.0221 0.002,-0.001 c 0.0349,-0.0187 0.0709,-0.0457 0.10827,-0.0861 0,0 2.0672,-2.2495 2.27544,-4.19804 0.0125,-0.10066 0.0211,-0.20236 0.0211,-0.30614 -6.9e-4,-1.37674 -1.11662,-2.49336 -2.49406,-2.49336 z m 0,4.09807 c -0.88451,0 -1.60436,-0.71985 -1.60436,-1.60402 0,-0.8845 0.71985,-1.60435 1.60436,-1.60435 0.88451,0 1.60367,0.71985 1.60367,1.60435 0,0.88417 -0.71916,1.60402 -1.60367,1.60402 z"
+         fill="url(#c)"
+         fill-rule="nonzero"
+         id="path650"
+         style="display:inline;enable-background:new;fill:url(#linearGradient664);stroke-width:0.345916" />
+      <path
+         d="m 327.20316,245.31586 c 0.1183,-0.14909 0.3473,-0.14286 0.45869,-0.0342 0.11173,0.10862 0.10619,0.31997 -0.0142,0.52787 -0.0844,0.15635 -0.29472,0.30959 -0.46906,0.41025 -0.16846,-0.11034 -0.37048,-0.27431 -0.44623,-0.43481 -0.10862,-0.21413 -0.10308,-0.42548 0.0142,-0.52787 0.11761,-0.10274 0.34626,-0.0965 0.45661,0.0588 z m 0.19544,0.10585 c 0.055,0.009 0.0996,0.0464 0.0986,0.10101 -0.002,0.054 -0.0481,0.0948 -0.10412,0.0951 -0.065,3.5e-4 -0.1,-0.0467 -0.0986,-0.10032 10e-4,-0.0546 0.0377,-0.10688 0.10412,-0.0958 z m -0.39884,-0.01 c 0.064,-0.009 0.10032,0.0471 0.0986,0.10136 -0.001,0.0536 -0.0239,0.0927 -0.10378,0.0951 -0.0557,0.001 -0.1,-0.0467 -0.0989,-0.101 0.002,-0.0543 0.0488,-0.0875 0.10412,-0.0955 z"
+         fill="#cb3434"
+         id="path652"
+         style="display:inline;enable-background:new;stroke-width:0.345916" />
+      <path
+         d="m 322.81279,244.20789 h -0.0429 c -0.0405,0 -0.0726,-0.0332 -0.0726,-0.0733 v -0.12349 c -0.174,-0.0436 -0.22381,-0.14702 -0.22381,-0.35906 0,-0.31271 0.2539,-0.56661 0.56696,-0.56661 0.3127,0 0.56661,0.2539 0.56661,0.56661 0,0.20893 -0.0529,0.31201 -0.22312,0.35698 v 0.12488 c 0,0.0408 -0.0329,0.0737 -0.0733,0.0737 h -0.0426 c -0.0405,0 -0.0733,-0.0329 -0.0733,-0.0737 v -0.0982 c -0.0194,0.002 -0.0387,0.002 -0.0595,0.003 v 0.0958 c 0,0.0401 -0.0329,0.073 -0.0733,0.073 h -0.0426 c -0.0405,0 -0.0733,-0.0329 -0.0733,-0.073 v -0.0955 c -0.0207,-6.9e-4 -0.0408,-10e-4 -0.0602,-0.002 v 0.0979 c 0,0.0401 -0.0329,0.0733 -0.073,0.0733 z m -0.008,-0.78626 c 0.0965,0.0377 0.17434,0.0754 0.17434,0.1688 0,0.0931 -0.063,0.11104 -0.17434,0.16847 -0.0851,0.0443 -0.17399,-0.0754 -0.17399,-0.16847 0,-0.0934 0.0844,-0.20374 0.17399,-0.1688 z m 0.46768,0 c 0.0927,-0.0263 0.174,0.0754 0.174,0.1688 0,0.0931 -0.0913,0.21759 -0.174,0.16847 -0.10135,-0.0602 -0.17399,-0.0754 -0.17399,-0.16847 0,-0.0934 0.0678,-0.13871 0.17399,-0.1688 z"
+         fill="#ededed"
+         id="path654"
+         style="display:inline;enable-background:new;stroke-width:0.345916" />
+      <path
+         d="m 322.30187,241.78406 0.17054,0.18022 0.26982,-0.25563 0.21585,0.22761 -0.26982,0.25529 0.17089,0.18057 c 0.0581,0.0612 0.0574,0.15635 -10e-4,0.2117 -0.0588,0.0557 -0.15359,0.0512 -0.21135,-0.01 l -0.17089,-0.18023 -0.27085,0.25598 -0.2155,-0.22726 0.27085,-0.24318 -0.17088,-0.19372 c -0.0585,-0.0612 -0.0574,-0.15601 10e-4,-0.2117 0.0588,-0.0557 0.15359,-0.0512 0.2117,0.0104 z"
+         fill="#ffffff"
+         id="path656"
+         style="display:inline;enable-background:new;stroke-width:0.345916" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/mediaplayer-app.svg
+++ b/icons/src/fullcolor/default/apps/mediaplayer-app.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="mediaplayer-app.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -32,17 +32,17 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:zoom="2"
-     inkscape:cx="124.5"
-     inkscape:cy="157.75"
-     inkscape:current-layer="layer8"
+     inkscape:cx="307"
+     inkscape:cy="149.5"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -55,7 +55,7 @@
      inkscape:window-maximized="1"
      inkscape:bbox-paths="true"
      inkscape:snap-bbox-midpoints="true"
-     inkscape:snap-global="false"
+     inkscape:snap-global="true"
      inkscape:object-paths="true"
      inkscape:snap-intersection-paths="true"
      inkscape:snap-smooth-nodes="true"
@@ -92,452 +92,55 @@
   </sodipodi:namedview>
   <defs
      id="defs3">
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4346"
-       x="-0.014454287"
-       width="1.0289086"
-       y="-0.011357288"
-       height="1.0227146">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.120027"
-         id="feGaussianBlur4348" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4380"
-       x="-0.057817147"
-       width="1.1156343"
-       y="-0.045429151"
-       height="1.0908583">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="8.4801079"
-         id="feGaussianBlur4382" />
-    </filter>
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(0,-33.6872,33.6872,0,923.28,40.4502)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#006783"
          offset="0"
-         id="stop923" />
+         id="stop282" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#13bee3"
          offset="1"
-         id="stop925" />
-    </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="66.000679"
-       x2="344"
-       y2="102.00067"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,344,84)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="331.99966"
-       y1="191.00034"
-       x2="331.99966"
-       y2="209.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,331.99966,200)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="238.00043"
-       x2="328"
-       y2="250"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,328,244)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004-8"
-       x1="344"
-       y1="65.144272"
-       x2="344"
-       y2="102.85715"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.04758,0.95458104,0,263.81519,444.36752)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#radialGradient3322"
-       id="linearGradient4878"
-       x1="317.26004"
-       y1="255.44786"
-       x2="338.31595"
-       y2="230.85617"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00001,244)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#radialGradient3322"
-       id="linearGradient4880"
-       x1="319.61288"
-       y1="215.806"
-       x2="344.89194"
-       y2="184.1002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99998,200)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#radialGradient3322"
-       id="linearGradient4882"
-       x1="319.2178"
-       y1="170.97945"
-       x2="355.70792"
-       y2="121.71233"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00001,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#radialGradient3322"
-       id="linearGradient4884"
-       x1="325.00024"
-       y1="107.00019"
-       x2="372.25275"
-       y2="51.776531"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00058,84.00012)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#radialGradient3322"
-       id="linearGradient4886"
-       x1="24.987097"
-       y1="298.46219"
-       x2="292.57532"
-       y2="-5.1179543"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,151.9973,156)" />
-    <radialGradient
-       id="radialGradient3322"
-       gradientUnits="userSpaceOnUse"
-       cy="-2.0645001"
-       cx="26.617001"
-       gradientTransform="matrix(-4.8906e-8,-2.8515,3.7557,0,674.00149,398.26285)"
-       r="23">
-      <stop
-         id="stop2749"
-         style="stop-color:#d280b9;stop-opacity:1"
-         offset="0" />
-      <stop
-         offset="0.52913231"
-         style="stop-color:#b549b5;stop-opacity:1"
-         id="stop4269" />
-      <stop
-         id="stop2755"
-         style="stop-color:#8940a8;stop-opacity:1"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4210">
-      <stop
-         style="stop-color:#d78ec1;stop-opacity:1"
-         offset="0"
-         id="stop4212" />
-      <stop
-         id="stop4218"
-         offset="0.64572346"
-         style="stop-color:#d78ec1;stop-opacity:1" />
-      <stop
-         style="stop-color:#d78ec1;stop-opacity:0"
-         offset="1"
-         id="stop4214" />
+         id="stop284" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4464"
-       id="linearGradient932"
+       xlink:href="#a"
+       id="linearGradient400"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02915937,0,0,0.02915937,321.2354,236.53607)"
-       x1="256"
-       y1="375"
-       x2="256"
-       y2="135.28078" />
+       gradientTransform="matrix(0,-35.758057,35.758057,0,1298.5615,101.46145)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient4464">
-      <stop
-         id="stop4468"
-         offset="0"
-         style="stop-color:#f5f5f5;stop-opacity:1" />
-      <stop
-         id="stop4466"
-         offset="1"
-         style="stop-color:#f1d7e9;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4464"
-       id="linearGradient928"
+       xlink:href="#a"
+       id="linearGradient412"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.0416622,0,0,0.0416622,321.19245,189.33502)"
-       x1="256"
-       y1="375"
-       x2="256"
-       y2="135.28078" />
+       gradientTransform="matrix(0,-23.320473,23.320473,0,958.54015,159.3879)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4464"
-       id="linearGradient923"
+       xlink:href="#a"
+       id="linearGradient424"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.05833333,0,0,0.05833333,321.46839,133.06667)"
-       x1="256"
-       y1="375"
-       x2="256"
-       y2="135.28078" />
+       gradientTransform="matrix(0,-17.879029,17.879029,0,809.28078,208.73072)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4464"
-       id="linearGradient977"
+       xlink:href="#a"
+       id="linearGradient436"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.09166667,0,0,0.09166667,321.02175,60.53333)"
-       x1="256"
-       y1="375"
-       x2="256"
-       y2="135.28078" />
+       gradientTransform="matrix(0,-11.660236,11.660236,0,639.27008,249.69395)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4464"
-       id="linearGradient4470"
-       x1="256"
-       y1="375"
-       x2="256"
-       y2="135.28078"
+       xlink:href="#a"
+       id="linearGradient438"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.5,26.29446,28)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4460"
-       x="-0.012293573"
-       width="1.0245871"
-       y="-0.01133005"
-       height="1.0226601">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1330049"
-         id="feGaussianBlur4462" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4295"
-       id="linearGradient4413"
-       x1="256"
-       y1="137.99998"
-       x2="256"
-       y2="375"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4295">
-      <stop
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0"
-         id="stop4260" />
-      <stop
-         id="stop4262"
-         offset="0.5047667"
-         style="stop-color:#000000;stop-opacity:1" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1"
-         id="stop4264" />
-    </linearGradient>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4415"
-       x="-0.098348581"
-       width="1.1966972"
-       y="-0.090640396"
-       height="1.1812808">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="9.0640396"
-         id="feGaussianBlur4417" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4210"
-       id="linearGradient18209"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.5,12,10)"
-       x1="56"
-       y1="288"
-       x2="56"
-       y2="83.578125"
-       spreadMethod="reflect" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4210"
-       id="linearGradient18213"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.5,12,10)"
-       x1="56"
-       y1="288"
-       x2="56"
-       y2="83.578125"
-       spreadMethod="reflect" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4210"
-       id="linearGradient18215"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.5,12,10)"
-       x1="56"
-       y1="288"
-       x2="56"
-       y2="83.578125"
-       spreadMethod="reflect" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4210"
-       id="linearGradient18217"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.5,12,10)"
-       x1="56"
-       y1="288"
-       x2="56"
-       y2="83.578125"
-       spreadMethod="reflect" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4210"
-       id="linearGradient18219"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.5,12,10)"
-       x1="56"
-       y1="288"
-       x2="56"
-       y2="83.578125"
-       spreadMethod="reflect" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4210"
-       id="linearGradient18221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.5,12,10)"
-       x1="56"
-       y1="288"
-       x2="56"
-       y2="83.578125"
-       spreadMethod="reflect" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4210"
-       id="linearGradient18223"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.5,12,10)"
-       x1="56"
-       y1="288"
-       x2="56"
-       y2="83.578125"
-       spreadMethod="reflect" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4210"
-       id="linearGradient18225"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.5,12,10)"
-       x1="56"
-       y1="288"
-       x2="56"
-       y2="83.578125"
-       spreadMethod="reflect" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4210"
-       id="linearGradient18227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.5,12,10)"
-       x1="56"
-       y1="288"
-       x2="56"
-       y2="83.578125"
-       spreadMethod="reflect" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4210"
-       id="linearGradient18229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.5,12,10)"
-       x1="56"
-       y1="288"
-       x2="56"
-       y2="83.578125"
-       spreadMethod="reflect" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4210"
-       id="linearGradient18231"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.5,12,10)"
-       x1="56"
-       y1="288"
-       x2="56"
-       y2="83.578125"
-       spreadMethod="reflect" />
+       gradientTransform="matrix(0,-174.1262,174.1262,0,4800.2998,241.02965)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -637,7 +240,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">mediaplayer-app</tspan></text>
+           id="tspan924">mediaplayer-app</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -672,346 +275,129 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 343.99961,196.86562 c 0,-1.12014 -0.0241,-2.01524 -0.1543,-2.79101 -0.13022,-0.77577 -0.38763,-1.48014 -0.91601,-2.00977 -0.52838,-0.52962 -1.23687,-0.79079 -2.01367,-0.91992 -0.77681,-0.12912 -1.67169,-0.15002 -2.79493,-0.14453 h -6.12109 -6.125 c -1.12104,-0.005 -2.01529,0.0156 -2.79102,0.14453 -0.77681,0.12912 -1.48529,0.39029 -2.01367,0.91992 -0.52838,0.52964 -0.78579,1.234 -0.91601,2.00977 -0.13022,0.77577 -0.1543,1.67087 -0.1543,2.79101 v 8.26954 c 0,1.12013 0.024,2.01264 0.1543,2.78711 0.13033,0.77446 0.38927,1.48001 0.91797,2.00781 0.52869,0.5278 1.23438,0.78594 2.00976,0.91601 0.77539,0.13007 1.67062,0.1543 2.79297,0.1543 h 6.125 6.125 c 1.12235,0 2.01758,-0.0242 2.79297,-0.1543 0.77538,-0.13007 1.48107,-0.38821 2.00976,-0.91601 0.5287,-0.5278 0.78764,-1.23334 0.91797,-2.00781 0.13033,-0.77448 0.1543,-1.66697 0.1543,-2.78711 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.49972,241.59598 c 0,-0.71904 -0.0139,-1.30185 -0.10352,-1.83593 -0.0897,-0.53409 -0.27628,-1.0683 -0.68359,-1.47657 -0.4073,-0.40826 -0.94323,-0.59657 -1.47851,-0.68554 -0.53529,-0.089 -1.12048,-0.10119 -1.8418,-0.0977 h -2.89258 -3.89844 c -0.71816,-0.003 -1.30235,0.009 -1.83594,0.0977 -0.53528,0.089 -1.07121,0.27727 -1.47851,0.68554 -0.40731,0.40827 -0.59394,0.94248 -0.68359,1.47657 -0.0897,0.53408 -0.10352,1.11689 -0.10352,1.83593 v 5.8086 c 0,0.71904 0.0137,1.30058 0.10352,1.83398 0.0898,0.53341 0.27792,1.06768 0.68554,1.47461 0.40762,0.40693 0.94271,0.59404 1.47656,0.68359 0.53386,0.0896 1.11551,0.10352 1.83594,0.10352 h 3.89844 2.89844 c 0.72043,0 1.30208,-0.014 1.83594,-0.10352 0.53385,-0.0895 1.06894,-0.27666 1.47656,-0.68359 0.40762,-0.40693 0.59578,-0.9412 0.68554,-1.47461 0.0898,-0.5334 0.10352,-1.11494 0.10352,-1.83398 z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 350.99951,143.19385 c 0,-1.42096 -0.0308,-2.54883 -0.19141,-3.50586 -0.16064,-0.95703 -0.4726,-1.79146 -1.09179,-2.41211 -0.61919,-0.62065 -1.45612,-0.93647 -2.41407,-1.0957 -0.95795,-0.15924 -2.08705,-0.18666 -3.51171,-0.17969 h -7.79102 -7.79688 c -1.42131,-0.007 -2.5495,0.0207 -3.50585,0.17969 -0.95796,0.15923 -1.79488,0.47505 -2.41407,1.0957 -0.61919,0.62065 -0.93115,1.45508 -1.09179,2.41211 -0.16065,0.95703 -0.19141,2.0849 -0.19141,3.50586 v 11.61523 c 0,1.42097 0.0307,2.54669 0.19141,3.50196 0.16075,0.95527 0.47425,1.78779 1.09375,2.40625 0.6195,0.61845 1.45363,0.93134 2.41015,1.09179 0.95653,0.16046 2.08403,0.19141 3.50781,0.19141 h 7.79688 7.79688 c 1.42378,0 2.55128,-0.031 3.50781,-0.19141 0.95653,-0.16045 1.79065,-0.47334 2.41015,-1.09179 0.61951,-0.61846 0.933,-1.45098 1.09375,-2.40625 0.16076,-0.95527 0.19141,-2.08099 0.19141,-3.50196 z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 367.49969,76.231427 c 0,-2.22316 -0.0512,-3.97368 -0.29297,-5.41406 -0.24178,-1.44039 -0.69529,-2.61905 -1.55664,-3.48243 -0.86134,-0.86337 -2.03947,-1.31906 -3.48046,-1.55859 -1.441,-0.23953 -3.19535,-0.28629 -5.42383,-0.27539 H 343.99974 331.2476 c -2.22507,-0.0108 -3.97852,0.0361 -5.41797,0.27539 -1.441,0.23953 -2.61913,0.69522 -3.48047,1.55859 -0.86134,0.86338 -1.31486,2.04204 -1.55664,3.48243 -0.24179,1.44039 -0.29297,3.1909 -0.29297,5.41406 v 17.53883 c 0,2.22317 0.0511,3.97276 0.29297,5.41017 0.24189,1.437403 0.69694,2.612463 1.55859,3.472653 0.86165,0.8602 2.03894,1.31319 3.47852,1.55468 1.43957,0.24149 3.19035,0.29297 5.41797,0.29297 h 12.75214 12.75191 c 2.22761,0 3.97839,-0.0515 5.41797,-0.29297 1.43957,-0.24149 2.61686,-0.69449 3.47851,-1.55469 0.86165,-0.86019 1.31671,-2.03525 1.55859,-3.472653 0.24189,-1.4374 0.29297,-3.187 0.29297,-5.41016 z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0,0.5,-0.5,0,300.9973,13.002698)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path4350"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 464,514.75001 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4380);enable-background:accumulate"
-         transform="matrix(0,0.5,-0.5,0,300.9973,13.002698)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.02028775;marker:none;enable-background:accumulate"
-         d="m 266.0025,105.8091 c 0,-36.098811 -3.69016,-39.983003 -39.68984,-39.806081 H 152.0025 77.69234 C 41.69265,65.826097 38.0025,69.710289 38.0025,105.8091 v 100.38732 c 0,36.09881 3.68973,39.80608 39.68984,39.80608 h 74.31016 74.31016 c 36.00011,0 39.68984,-3.70727 39.68984,-39.80608 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4884);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 366.50065,75.231078 c 0,-8.23154 -0.90635,-9.77365 -9.74838,-9.7304 H 344.0007 331.24889 c -8.84203,-0.0433 -9.74838,1.49886 -9.74838,9.7304 v 17.53897 c 0,8.229492 0.90625,9.730392 9.74838,9.730392 h 12.75181 12.75157 c 8.84213,0 9.74838,-1.5009 9.74838,-9.730402 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4886);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 263.9973,205.07568 c 0,35.29673 -3.62542,39.09461 -38.99353,38.92162 H 151.9973 78.99083 C 43.62271,244.17029 39.9973,240.37241 39.9973,205.07568 v -98.15676 c 0,-35.296716 3.625,-38.921616 38.99353,-38.921616 h 73.00647 73.00647 c 35.36853,0 38.99353,3.6249 38.99353,38.921616 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 343.49998,195.636 c 0,-4.65703 -0.47377,-5.15811 -5.09574,-5.13529 h -6.40426 -6.40425 c -4.62197,-0.0229 -5.09574,0.47826 -5.09574,5.13529 v 8.7287 c 0,4.65703 0.47371,5.13529 5.09574,5.13529 h 6.40425 6.40426 c 4.62202,0 5.09574,-0.47827 5.09574,-5.1353 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4880);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4878);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.50001,240.8545 c 0,-3.04166 -0.30899,-3.36894 -3.32331,-3.35403 h -4.17669 -4.17669 c -3.01432,-0.0149 -3.32331,0.31237 -3.32331,3.35403 v 6.29146 c 0,3.04167 0.30895,3.35404 3.32331,3.35404 h 4.17669 4.17669 c 3.01435,0 3.32331,-0.31238 3.32331,-3.35404 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4882);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 350.50001,142.07508 c 0,-5.56175 -0.58409,-6.6037 -6.28227,-6.57447 h -8.21765 -8.21781 c -5.69818,-0.0293 -6.28227,1.01272 -6.28227,6.57447 v 11.85044 c 0,5.56037 0.58403,6.57447 6.28227,6.57447 h 8.21781 8.21765 c 5.69824,0 6.28227,-1.0141 6.28227,-6.57447 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 40,156 v 8 41.00586 C 40,240.37439 43.625165,244 78.921875,244 H 225.07813 C 260.37486,244 264.17299,240.37398 264,205.00586 V 164 156 Z"
-         id="rect4158-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 321.50781,84 v 8.751953 C 321.47611,102.40308 323.33064,102.5 333.3418,102.5 h 21.33008 c 10.00866,0 11.83398,-0.15592 11.83398,-9.748047 V 84 Z"
-         id="path964-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 321.50586,148 v 6.2168 c -0.034,5.69818 1.17532,6.2832 7.62695,6.2832 h 13.7461 c 6.45003,0 7.62695,-0.58496 7.62695,-6.2832 V 148 Z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate"
-         d="m 321.16308,200 v 3.84766 c -0.0253,4.22046 0.52718,4.65428 5.67383,4.65429 l 10.3252,3e-5 c 5.14665,1e-5 5.67578,-0.43378 5.67578,-4.65429 v -3.84767 z"
-         id="path914-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 320.57813,244 v 3.17589 c -0.017,3.01433 0.35794,3.32422 3.83398,3.32422 h 7.18945 c 3.47605,0 3.83203,-0.30985 3.83203,-3.32422 V 244 Z"
-         id="path918-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscc" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer6"
-       inkscape:label="Pictograms"
-       style="display:inline">
-      <path
-         inkscape:connector-curvature="0"
-         id="path934"
-         d="m 331,142.00001 v 14 c 0,0 6.63468,-2.86986 12.43679,-7.00443 0,-9.5e-4 -10e-4,-0.002 -10e-4,-0.004 -4.7e-4,-0.002 -0.002,-0.003 -0.004,-0.005 -10e-4,-0.001 -0.002,-0.003 -0.003,-0.005 -10e-4,-0.002 -10e-4,-0.004 -10e-4,-0.005 -6.11912,-4.26627 -12.42729,-6.97807 -12.42729,-6.97807 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         sodipodi:nodetypes="ccccscccc" />
-      <path
-         sodipodi:nodetypes="ccccscccc"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 328,196.00108 v 9.99893 c 0,0 4.73854,-2.04968 8.88247,-5.00263 0,-6.8e-4 -7.2e-4,-0.001 -7.2e-4,-0.003 -3.3e-4,-0.001 -9.9e-4,-0.002 -0.003,-0.004 -7.2e-4,-7.1e-4 -9.9e-4,-0.002 -0.002,-0.004 -7.2e-4,-0.001 -7.2e-4,-0.003 -7.2e-4,-0.004 -4.37033,-3.04701 -8.87567,-4.9838 -8.87567,-4.9838 z"
-         id="path936"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path938"
-         d="M 326,241.50175 V 248.5 c 0,0 3.3165,-1.43457 6.21684,-3.50134 0,-4.8e-4 -5.1e-4,-7e-4 -5.1e-4,-0.002 -2.3e-4,-7e-4 -7e-4,-0.001 -0.002,-0.003 -5e-4,-5e-4 -7e-4,-0.001 -0.001,-0.003 -5.1e-4,-7e-4 -5.1e-4,-0.002 -5.1e-4,-0.003 -3.05879,-2.1326 -6.21209,-3.48816 -6.21209,-3.48816 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         sodipodi:nodetypes="ccccscccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 336,74 v 22 c 0,0 10.42592,-4.509787 19.5435,-11.006952 0,-0.0015 -0.002,-0.0037 -0.002,-0.0059 -7.5e-4,-0.0029 -0.003,-0.0051 -0.005,-0.0073 -0.002,-0.0022 -0.003,-0.0051 -0.005,-0.0073 -0.002,-0.0029 -0.002,-0.0051 -0.002,-0.0066 C 345.91309,78.2614 336.00024,74 336.00024,74 Z"
-         id="path995-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccscccc" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path4405"
-         d="m 155.41127,137.99999 v 239.99999 c 0,0 121.72498,-49.19762 221.18971,-120.07579 0,-0.0217 -0.0115,-0.0398 -0.0253,-0.0645 -0.0115,-0.0263 -0.0264,-0.0523 -0.0448,-0.0786 -0.0191,-0.026 -0.0374,-0.0533 -0.0504,-0.0786 -0.0147,-0.0262 -0.0253,-0.0526 -0.0253,-0.0758 C 271.53919,184.48813 155.41146,138.00011 155.41146,138.00011 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#linearGradient4413);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;filter:url(#filter4415);enable-background:accumulate"
-         transform="matrix(0.5,0,0,0.5,26.29446,28)"
-         sodipodi:nodetypes="ccccccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path4454"
-         d="m 155.41127,137.99999 v 239.99999 c 0,0 121.72498,-49.19762 221.18971,-120.07579 0,-0.0217 -0.0115,-0.0398 -0.0253,-0.0645 -0.0115,-0.0263 -0.0264,-0.0523 -0.0448,-0.0786 -0.0191,-0.026 -0.0374,-0.0533 -0.0504,-0.0786 -0.0147,-0.0262 -0.0253,-0.0526 -0.0253,-0.0758 C 271.53919,184.48813 155.41146,138.00011 155.41146,138.00011 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;marker:none;filter:url(#filter4460);enable-background:accumulate"
-         transform="matrix(0.5,0,0,0.5,26.29446,28)"
-         sodipodi:nodetypes="ccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4470);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="M 104.00009,95.999995 V 215.99999 c 0,0 60.86248,-24.59881 110.59484,-60.0379 0,-0.0108 -0.006,-0.0199 -0.0127,-0.0322 -0.006,-0.0132 -0.0132,-0.0262 -0.0224,-0.0393 -0.01,-0.013 -0.0187,-0.0266 -0.0252,-0.0393 -0.007,-0.0131 -0.0127,-0.0263 -0.0127,-0.0379 C 162.06394,119.24411 104.00007,96.000095 104.00007,96.000095 Z"
-         id="path4360"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 103.9998,96 v 1 c 0,0 57.66953,23.07928 109.94698,59.41797 0.21558,-0.15303 0.43312,-0.30263 0.64844,-0.45606 0,-0.0108 -0.006,-0.0199 -0.0127,-0.0322 -0.006,-0.0132 -0.0132,-0.0259 -0.0225,-0.0391 -0.01,-0.013 -0.0189,-0.0264 -0.0254,-0.0391 -0.007,-0.0131 -0.0127,-0.0265 -0.0127,-0.0381 C 162.06398,119.2442 103.9998,96 103.9998,96 Z"
-         id="path4472"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path975"
-         d="m 336,73 v 22 c 0,0 10.42592,-4.509787 19.5435,-11.006952 0,-0.0015 -0.002,-0.0037 -0.002,-0.0059 -7.5e-4,-0.0029 -0.003,-0.0051 -0.005,-0.0073 -0.002,-0.0022 -0.003,-0.0051 -0.005,-0.0073 -0.002,-0.0029 -0.002,-0.0051 -0.002,-0.0066 C 345.91309,77.2614 336.00024,73 336.00024,73 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient977);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         sodipodi:nodetypes="ccccscccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 336,73 v 1 c 0,0 9.43255,4.07319 18.8203,10.494141 0.24091,-0.167752 0.48334,-0.331418 0.72266,-0.501953 0,-0.0015 -0.002,-0.0037 -0.002,-0.0059 -7.5e-4,-0.0029 -0.002,-0.0037 -0.004,-0.0059 -0.002,-0.0022 -0.004,-0.0056 -0.006,-0.0078 -0.002,-0.0029 -0.002,-0.0044 -0.002,-0.0059 C 345.91288,77.26225 336,73 336,73 Z"
-         id="path986"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccsccc" />
-      <path
-         sodipodi:nodetypes="ccccscccc"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient923);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 331,141.00001 v 14 c 0,0 6.63468,-2.86986 12.43679,-7.00443 0,-9.5e-4 -10e-4,-0.002 -10e-4,-0.004 -4.7e-4,-0.002 -0.002,-0.003 -0.004,-0.005 -10e-4,-0.001 -0.002,-0.003 -0.003,-0.005 -10e-4,-0.002 -10e-4,-0.004 -10e-4,-0.005 -6.11912,-4.26627 -12.42729,-6.97807 -12.42729,-6.97807 z"
-         id="path919"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path925"
-         d="m 328,195.00108 v 9.99893 c 0,0 4.73854,-2.04968 8.88247,-5.00263 0,-6.8e-4 -7.2e-4,-0.001 -7.2e-4,-0.003 -3.3e-4,-0.001 -9.9e-4,-0.002 -0.003,-0.004 -7.2e-4,-7.1e-4 -9.9e-4,-0.002 -0.002,-0.004 -7.2e-4,-0.001 -7.2e-4,-0.003 -7.2e-4,-0.004 -4.37033,-3.04701 -8.87567,-4.9838 -8.87567,-4.9838 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient928);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         sodipodi:nodetypes="ccccscccc" />
-      <path
-         sodipodi:nodetypes="ccccscccc"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient932);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="M 326,240.50175 V 247.5 c 0,0 3.3165,-1.43457 6.21684,-3.50134 0,-4.8e-4 -5.1e-4,-7e-4 -5.1e-4,-0.002 -2.3e-4,-7e-4 -7e-4,-0.001 -0.002,-0.003 -5e-4,-5e-4 -7e-4,-0.001 -0.001,-0.003 -5.1e-4,-7e-4 -5.1e-4,-0.002 -5.1e-4,-0.003 -3.05879,-2.1326 -6.21209,-3.48816 -6.21209,-3.48816 z"
-         id="path930"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18209);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 44.748047,76 c -2.544931,3.565505 -3.775533,8.683644 -4.330078,16 H 60 V 76 Z"
-         id="path18274" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18209);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 244,76 v 16 h 19.57617 c -0.55454,-7.316356 -1.78515,-12.434495 -4.33008,-16 z"
-         id="path18272" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18209);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 40.416016,220 c 0.551618,7.29656 1.774366,12.42123 4.294922,16 H 60 v -16 z"
-         id="path18270" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18209);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 244,220 v 16 h 15.2832 c 2.52056,-3.57877 3.74331,-8.70344 4.29492,-16 z"
-         id="path13702" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18213);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 40,100 v 16 h 20 v -16 z"
-         id="path13698" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18215);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 244,100 v 16 h 20 v -16 z"
-         id="path13696" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18217);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 40,124 v 16 h 20 v -16 z"
-         id="path13694" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18219);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 244,124 v 16 h 20 v -16 z"
-         id="path13692" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18221);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 40,148 v 16 h 20 v -16 z"
-         id="path13690" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18223);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 244,148 v 16 h 20 v -16 z"
-         id="path13688" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18225);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 40,172 v 16 h 20 v -16 z"
-         id="path13686" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18227);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 244,172 v 16 h 20 v -16 z"
-         id="path13684" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18229);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 40,196 v 16 h 20 v -16 z"
-         id="path13682" />
-      <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient18231);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 244,196 v 16 h 20 v -16 z"
-         id="path13680" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer2"
-       inkscape:label="Highlights"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.990234,67.998047 c -35.36853,0 -38.992187,3.623202 -38.992187,38.919923 v 98.1582 c 0,0.0882 0.0019,0.16224 0.002,0.25 V 108.91602 C 40,73.6193 43.625611,69.994141 78.994141,69.994141 H 152 225.00586 c 35.28016,0 38.97394,3.621035 38.99219,38.671879 v -1.74805 c 0,-35.296721 -3.62561,-38.919923 -38.99414,-38.919923 h -73.00586 z"
-         id="rect4158-78"
-         inkscape:connector-curvature="0" />
+         d="M 264,76.191988 C 264,58.421266 249.57873,43.999999 231.80801,43.999999 H 72.191988 c -17.770722,0 -32.191989,14.421267 -32.191989,32.191989 V 235.80801 C 39.999999,253.57873 54.421266,268 72.191988,268 H 231.80801 C 249.57873,268 264,253.57873 264,235.80801 Z"
+         fill="url(#a)"
+         id="path287"
+         style="fill:url(#linearGradient438);stroke-width:5.16891" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 39.998047,203.07617 v 2 c 0,35.29673 3.624067,39.09487 38.992187,38.92188 h 73.007816 73.00586 c 35.36811,0.17299 38.99414,-3.62515 38.99414,-38.92188 v -2 c 0,35.29673 -3.62603,39.09487 -38.99414,38.92188 H 151.99805 78.990234 c -35.36812,0.17299 -38.992187,-3.62515 -38.992187,-38.92188 z"
-         id="rect4158-6"
-         inkscape:connector-curvature="0" />
+         d="M 231.80801,43.999999 C 249.57873,43.999999 264,58.421266 264,76.191988 v 22.247 H 39.999999 v -22.247 c 0,-17.770722 14.421267,-32.191989 32.191989,-32.191989 z"
+         fill="#393939"
+         id="path289"
+         style="stroke-width:5.16891" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983)"
-         transform="rotate(90,328,244)" />
+         d="m 367,67.610856 c 0,-3.649345 -2.96151,-6.610855 -6.61085,-6.610855 h -32.77829 c -3.64934,0 -6.61085,2.96151 -6.61085,6.610855 v 32.778294 c 0,3.64934 2.96151,6.61085 6.61085,6.61085 h 32.77829 C 364.03849,107 367,104.03849 367,100.38915 Z"
+         fill="url(#a)"
+         id="path390"
+         style="fill:url(#linearGradient400);stroke-width:1.06147" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.51173,240.91355 c 0,-2.89732 -0.30259,-3.44011 -3.25454,-3.42488 h -4.25716 -4.25724 c -2.95195,-0.0152 -3.25453,0.52756 -3.25453,3.42488 v 6.17331 c 0,2.8966 0.30255,3.42488 3.25453,3.42488 h 4.25724 4.25716 c 2.95199,0 3.25454,-0.52828 3.25454,-3.42488 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 360.38915,61.000001 c 3.64934,0 6.61085,2.96151 6.61085,6.610855 v 4.56858 h -45.99999 v -4.56858 c 0,-3.649345 2.96151,-6.610855 6.61085,-6.610855 z"
+         fill="#393939"
+         id="path392"
+         style="stroke-width:1.06147" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 343.51172,195.49156 c 0,-4.23214 -0.46371,-5.02499 -4.98757,-5.00275 h -6.5241 -6.52423 c -4.52386,-0.0222 -4.98757,0.77061 -4.98757,5.00275 v 9.01743 c 0,4.23108 0.46366,5.00275 4.98757,5.00275 h 6.52423 6.5241 c 4.52391,0 4.98757,-0.77167 4.98757,-5.00275 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 351,137.31143 C 351,134.93142 349.06858,133 346.68858,133 H 325.31143 C 322.93142,133 321,134.93142 321,137.31143 v 21.37715 c 0,2.38 1.93142,4.31142 4.31143,4.31142 h 21.37715 c 2.38,0 4.31142,-1.93142 4.31142,-4.31142 z"
+         fill="url(#a)"
+         id="path402"
+         style="fill:url(#linearGradient412);stroke-width:0.692265" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971)"
-         transform="rotate(90,331.99966,200)" />
+         d="m 346.68858,133 c 2.38,0 4.31142,1.93142 4.31142,4.31143 v 2.97951 h -30 v -2.97951 C 321,134.93142 322.93142,133 325.31143,133 Z"
+         fill="#393939"
+         id="path404"
+         style="stroke-width:0.692265" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 350.50001,142.07508 c 0,-5.56175 -0.58409,-6.6037 -6.28227,-6.57447 h -8.21765 -8.21781 c -5.69818,-0.0293 -6.28227,1.01272 -6.28227,6.57447 v 11.85044 c 0,5.56037 0.58403,6.57447 6.28227,6.57447 h 8.21781 8.21765 c 5.69824,0 6.28227,-1.0141 6.28227,-6.57447 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 343.5,191.80543 c 0,-1.82468 -1.48076,-3.30543 -3.30543,-3.30543 h -16.38914 c -1.82468,0 -3.30543,1.48075 -3.30543,3.30543 v 16.38914 c 0,1.82467 1.48075,3.30543 3.30543,3.30543 h 16.38914 c 1.82467,0 3.30543,-1.48076 3.30543,-3.30543 z"
+         fill="url(#a)"
+         id="path414"
+         style="fill:url(#linearGradient424);stroke-width:0.530737" />
       <path
-         transform="matrix(0,0.66664182,-0.63636364,0,389.45455,-81.324786)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004-8);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-1)" />
+         d="m 340.19457,188.5 c 1.82467,0 3.30543,1.48075 3.30543,3.30543 v 2.28429 h -23 v -2.28429 c 0,-1.82468 1.48075,-3.30543 3.30543,-3.30543 z"
+         fill="#393939"
+         id="path416"
+         style="stroke-width:0.530737" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 366.50065,75.231076 c 0,-8.23154 -0.90635,-9.77365 -9.74838,-9.7304 H 344.0007 331.24889 c -8.84203,-0.0433 -9.74838,1.49886 -9.74838,9.7304 v 17.53897 c 0,8.229494 0.90625,9.730394 9.74838,9.730394 h 12.75181 12.75157 c 8.84213,0 9.74838,-1.5009 9.74838,-9.730404 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 335.5,238.65571 c 0,-1.19 -0.96571,-2.15571 -2.15571,-2.15571 h -10.68858 c -1.19,0 -2.15571,0.96571 -2.15571,2.15571 v 10.68858 c 0,1.19 0.96571,2.15571 2.15571,2.15571 h 10.68858 c 1.19,0 2.15571,-0.96571 2.15571,-2.15571 z"
+         fill="url(#a)"
+         id="path426"
+         style="fill:url(#linearGradient436);stroke-width:0.346133" />
       <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994)"
-         transform="rotate(90,344,84)" />
+         d="m 333.34429,236.5 c 1.19,0 2.15571,0.96571 2.15571,2.15571 v 1.48976 h -15 v -1.48976 c 0,-1.19 0.96571,-2.15571 2.15571,-2.15571 z"
+         fill="#393939"
+         id="path428"
+         style="stroke-width:0.346133" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictogram"
+       style="display:inline">
+      <path
+         d="m 166.26103,95.745984 h 34.32158 L 227.40927,72.036182 200.58261,45.809119 h -34.32158 l 24.31457,26.227063 z m -89.37567,0 h 34.32158 L 138.02843,72.036182 111.20694,45.809119 H 76.88536 l 24.31457,26.227063 z"
+         fill="#ffffff"
+         fill-opacity="0.95"
+         id="path291"
+         style="display:inline;enable-background:new;stroke-width:5.16891" />
+      <path
+         d="m 197.05539,166.18749 c 2.97229,1.79012 4.78774,5.00728 4.78774,8.47776 0,3.47048 -1.81545,6.68764 -4.78774,8.47777 -16.93863,10.23411 -45.30199,27.35852 -62.67127,37.84595 -3.06517,1.84923 -6.88185,1.90834 -9.98924,0.15199 -3.11583,-1.75635 -5.04106,-5.05795 -5.04106,-8.62976 v -75.70034 c 0,-3.57181 1.92523,-6.86497 5.04106,-8.62976 3.10739,-1.75635 6.93252,-1.69724 9.98924,0.15199 17.36928,10.48744 45.73264,27.62029 62.67127,37.8544 z"
+         fill="#e0f1fe"
+         id="path293"
+         style="display:inline;enable-background:new;stroke-width:8.44399" />
+      <path
+         d="m 346.92861,71.626408 h 7.04818 l 5.50905,-4.868977 -5.50905,-5.385914 h -7.04818 l 4.99317,5.385914 z m -18.35393,0 h 7.04818 l 5.50798,-4.868977 -5.50798,-5.385914 h -7.04818 l 4.99317,5.385914 z"
+         fill="#ffffff"
+         fill-opacity="0.95"
+         id="path394"
+         style="display:inline;enable-background:new;stroke-width:1.06147" />
+      <path
+         d="m 353.25246,86.092074 c 0.61038,0.367615 0.98319,1.028282 0.98319,1.74097 0,0.712687 -0.37281,1.373354 -0.98319,1.740969 -3.47847,2.101648 -9.30309,5.618267 -12.87,7.771936 -0.62945,0.379753 -1.41323,0.391892 -2.05136,0.03121 -0.63986,-0.360679 -1.03522,-1.038686 -1.03522,-1.772182 V 80.059373 c 0,-0.733496 0.39536,-1.409769 1.03522,-1.772182 0.63813,-0.360679 1.42364,-0.34854 2.05136,0.03121 3.56691,2.153669 9.39153,5.672022 12.87,7.77367 z"
+         fill="#e0f1fe"
+         id="path396"
+         style="display:inline;enable-background:new;stroke-width:1.73403" />
+      <path
+         d="m 337.90996,139.93027 h 4.59664 l 3.59286,-3.17542 -3.59286,-3.51256 h -4.59664 l 3.25642,3.51256 z m -11.96995,0 h 4.59664 l 3.59216,-3.17542 -3.59216,-3.51256 h -4.59664 l 3.25641,3.51256 z"
+         fill="#ffffff"
+         fill-opacity="0.95"
+         id="path406"
+         style="display:inline;enable-background:new;stroke-width:0.692265" />
+      <path
+         d="m 342.03421,149.3644 c 0.39807,0.23975 0.64121,0.67062 0.64121,1.13541 0,0.4648 -0.24314,0.89567 -0.64121,1.13542 -2.26857,1.37064 -6.06723,3.66408 -8.39348,5.06865 -0.41051,0.24767 -0.92167,0.25558 -1.33784,0.0204 -0.4173,-0.23523 -0.67514,-0.67741 -0.67514,-1.15577 v -10.13844 c 0,-0.47837 0.25784,-0.91942 0.67514,-1.15577 0.41617,-0.23523 0.92846,-0.22731 1.33784,0.0204 2.32625,1.40457 6.12491,3.69915 8.39348,5.06979 z"
+         fill="#e0f1fe"
+         id="path408"
+         style="display:inline;enable-background:new;stroke-width:1.13089" />
+      <path
+         d="m 333.4643,193.8132 h 3.52409 l 2.75452,-2.43449 -2.75452,-2.69295 h -3.52409 l 2.49658,2.69295 z m -9.17697,0 h 3.52409 l 2.754,-2.43449 -2.754,-2.69295 h -3.52409 l 2.49659,2.69295 z"
+         fill="#ffffff"
+         fill-opacity="0.95"
+         id="path418"
+         style="display:inline;enable-background:new;stroke-width:0.530737" />
+      <path
+         d="m 336.62622,201.04603 c 0.30519,0.18381 0.4916,0.51414 0.4916,0.87049 0,0.35634 -0.18641,0.68667 -0.4916,0.87048 -1.73923,1.05083 -4.65154,2.80914 -6.43499,3.88597 -0.31473,0.18988 -0.70662,0.19595 -1.02568,0.0156 -0.31993,-0.18034 -0.51761,-0.51935 -0.51761,-0.88609 v -7.77281 c 0,-0.36675 0.19768,-0.70488 0.51761,-0.88609 0.31906,-0.18034 0.71182,-0.17427 1.02568,0.0156 1.78345,1.07683 4.69576,2.83601 6.43499,3.88683 z"
+         fill="#e0f1fe"
+         id="path420"
+         style="display:inline;enable-background:new;stroke-width:0.867017" />
+      <path
+         d="m 328.95498,239.96513 h 2.29832 l 1.79643,-1.58771 -1.79643,-1.75627 h -2.29832 l 1.62821,1.75627 z m -5.98498,0 h 2.29832 l 1.79608,-1.58771 -1.79608,-1.75627 H 322.97 l 1.62821,1.75627 z"
+         fill="#ffffff"
+         fill-opacity="0.95"
+         id="path430"
+         style="display:inline;enable-background:new;stroke-width:0.346133" />
+      <path
+         d="m 331.0171,244.6822 c 0.19904,0.11987 0.32061,0.33531 0.32061,0.56771 0,0.23239 -0.12157,0.44783 -0.32061,0.5677 -1.13428,0.68532 -3.03362,1.83205 -4.19674,2.53433 -0.20525,0.12383 -0.46084,0.12779 -0.66892,0.0102 -0.20865,-0.11761 -0.33757,-0.3387 -0.33757,-0.57789 v -5.06922 c 0,-0.23918 0.12892,-0.4597 0.33757,-0.57788 0.20808,-0.11761 0.46423,-0.11366 0.66892,0.0102 1.16312,0.70228 3.06246,1.84957 4.19674,2.53489 z"
+         fill="#e0f1fe"
+         id="path432"
+         style="display:inline;enable-background:new;stroke-width:0.565446" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/scanner.svg
+++ b/icons/src/fullcolor/default/apps/scanner.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="scanner.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\non-uniform notepad five sizes.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="4"
-     inkscape:cx="223.75"
-     inkscape:cy="208.125"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="237.58788"
+     inkscape:cy="70.003571"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -93,318 +93,203 @@
   <defs
      id="defs3">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1186">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(0.152892,-40.826,40.826,0.152892,124.649,43.9468)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#ff0000;stop-opacity:1;"
+         stop-color="#002956"
          offset="0"
-         id="stop1182" />
+         id="stop386" />
       <stop
-         style="stop-color:#ff0000;stop-opacity:0;"
+         stop-color="#001628"
          offset="1"
-         id="stop1184" />
+         id="stop388" />
     </linearGradient>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4346"
-       x="-0.014454287"
-       width="1.0289086"
-       y="-0.011357288"
-       height="1.0227146">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.120027"
-         id="feGaussianBlur4348" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4380"
-       x="-0.057817147"
-       width="1.1156343"
-       y="-0.045429151"
-       height="1.0908583">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="8.4801079"
-         id="feGaussianBlur4382" />
-    </filter>
     <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="169.65668"
-       x2="4.4137931"
-       y1="386.29544"
-       x1="494.34482"
-       id="linearGradient4226"
-       xlink:href="#linearGradient4245"
-       inkscape:collect="always"
-       gradientTransform="matrix(0,-0.453125,-0.45311204,0,277.957,268)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="b"
+       x2="1"
+       gradientTransform="matrix(-8.26673,-228.293,228.293,-8.26673,-74.0226,276.369)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#f4f4f4"
          offset="0"
-         id="stop923" />
+         id="stop391" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#dbdbdb"
          offset="1"
-         id="stop925" />
+         id="stop393" />
     </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient916"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.05921519,0.05978336,0,313.2699,214.63635)"
-       x1="441.37936"
-       y1="240.30258"
-       x2="52.965523"
-       y2="386.30795" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient920"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.0386186,0.03904659,0,315.4715,253.54546)"
-       x1="441.37933"
-       y1="240.28154"
-       x2="52.9655"
-       y2="401.42957" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="332"
-       y1="189"
-       x2="332"
-       y2="211"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="237"
-       x2="328"
-       y2="251"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient3194"
-       x1="335.23154"
-       y1="61.500046"
-       x2="352.27026"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004-8"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4245"
-       id="linearGradient3257"
-       x1="330.0751"
-       y1="133.5"
-       x2="341.92554"
-       y2="162.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4245"
-       inkscape:collect="always">
+       id="c"
+       x2="1"
+       gradientTransform="matrix(-3.21103,-30.8871,30.8871,-3.21103,234.875,17.0033)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         id="stop4241"
+         stop-color="#dcdcdc"
          offset="0"
-         style="stop-color:#e8e8e8;stop-opacity:1" />
+         id="stop396" />
       <stop
-         id="stop4243"
+         stop-color="#f0f0f0"
          offset="1"
-         style="stop-color:#f5f5f5;stop-opacity:1" />
+         id="stop398" />
+    </linearGradient>
+    <linearGradient
+       id="d"
+       x2="1"
+       gradientTransform="matrix(0,-1.75249,1.75249,0,50.8588,17.9955)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#00a5cc"
+         stop-opacity=".8"
+         offset="0"
+         id="stop401" />
+      <stop
+         stop-color="#0086cc"
+         stop-opacity="0"
+         offset="1"
+         id="stop403" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1186"
-       id="linearGradient1188"
-       x1="40"
-       y1="168"
-       x2="40"
-       y2="136"
+       xlink:href="#a"
+       id="linearGradient586"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.78593751,0,0,1,32.5575,0)" />
+       gradientTransform="matrix(0.15746534,-42.047195,42.047195,0.15746534,447.19613,104.54242)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1186"
-       id="linearGradient1188-6"
-       x1="40"
-       y1="168"
-       x2="40"
-       y2="136"
+       xlink:href="#b"
+       id="linearGradient588"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.78593751,0,0,1,32.5575,-340)" />
+       gradientTransform="matrix(-8.5140061,-235.12175,235.12175,-8.5140061,242.58182,343.91688)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1186"
-       id="linearGradient1188-5"
-       x1="40"
-       y1="168"
-       x2="40"
-       y2="136"
+       xlink:href="#c"
+       id="linearGradient590"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.16071428,0,0,0.18750001,319.57144,55.499998)" />
+       gradientTransform="matrix(-3.307079,-31.811001,31.811001,-3.307079,560.71923,76.792983)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1186"
-       id="linearGradient1188-5-1"
-       x1="40"
-       y1="168"
-       x2="40"
-       y2="136"
+       xlink:href="#d"
+       id="linearGradient592"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.16071428,0,0,0.18750001,319.57144,-119.5)" />
+       gradientTransform="matrix(0,-1.8049108,1.8049108,0,371.1987,77.814862)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1186"
-       id="linearGradient1188-5-1-7"
-       x1="40"
-       y1="168"
-       x2="40"
-       y2="136"
+       xlink:href="#a"
+       id="linearGradient606"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.10714286,0,0,0.125,319.71429,-172)" />
+       gradientTransform="matrix(0.10269479,-27.422085,27.422085,0.10269479,403.30182,161.39723)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1186"
-       id="linearGradient1188-5-0"
-       x1="40"
-       y1="168"
-       x2="40"
-       y2="136"
+       xlink:href="#b"
+       id="linearGradient608"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.10714286,0,0,0.125,319.71429,129)" />
+       gradientTransform="matrix(-5.5526128,-153.34027,153.34027,-5.5526128,269.8577,317.51101)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1186"
-       id="linearGradient1188-5-1-7-5"
-       x1="40"
-       y1="168"
-       x2="40"
-       y2="136"
+       xlink:href="#c"
+       id="linearGradient610"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.08035714,0,0,0.125,319.78572,-223)" />
+       gradientTransform="matrix(-2.1567907,-20.746306,20.746306,-2.1567907,477.33862,143.29977)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1186"
-       id="linearGradient1188-5-0-2"
-       x1="40"
-       y1="168"
-       x2="40"
-       y2="136"
+       xlink:href="#d"
+       id="linearGradient612"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.08035714,0,0,0.125,319.78572,180)" />
+       gradientTransform="matrix(0,-1.1771158,1.1771158,0,353.73827,143.96621)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1186"
-       id="linearGradient1188-5-1-7-5-3"
-       x1="40"
-       y1="168"
-       x2="40"
-       y2="136"
+       xlink:href="#a"
+       id="linearGradient626"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.05357142,0,0,0.125,319.85714,-267)" />
+       gradientTransform="matrix(0.07873267,-21.023599,21.023599,0.07873267,383.60015,210.27172)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1186"
-       id="linearGradient1188-5-0-2-2"
-       x1="40"
-       y1="168"
-       x2="40"
-       y2="136"
+       xlink:href="#b"
+       id="linearGradient628"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.05357142,0,0,0.125,319.85714,226)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-5">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
+       gradientTransform="matrix(-4.2570032,-117.56088,117.56088,-4.2570032,281.29299,329.95896)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient3369"
+       xlink:href="#c"
+       id="linearGradient630"
        gradientUnits="userSpaceOnUse"
-       x1="344"
-       y1="62"
-       x2="344"
-       y2="106" />
+       gradientTransform="matrix(-1.6535396,-15.905501,15.905501,-1.6535396,440.3617,196.397)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d"
+       id="linearGradient632"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.90245545,0.90245545,0,345.60143,196.90794)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient646"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05134739,-13.711043,13.711043,0.05134739,361.69727,250.64589)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient648"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.7763065,-76.670138,76.670138,-2.7763065,294.97521,328.70278)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient650"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0783954,-10.373153,10.373153,-1.0783954,398.71567,241.59715)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d"
+       id="linearGradient652"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.58855791,0.58855791,0,336.9155,241.93038)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient664"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.76678775,-204.75157,204.75157,0.76678775,654.52026,256.03267)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient666"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-41.459509,-1144.9407,1144.9407,-41.459509,-341.86247,1421.6823)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#c"
+       id="linearGradient668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-16.104037,-154.90575,154.90575,-16.104037,1207.3284,120.90496)"
+       x2="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#d"
+       id="linearGradient670"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-8.7891313,8.7891313,0,284.44582,125.88107)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -504,7 +389,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">scanner</tspan></text>
+           id="tspan924">scanner</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -539,451 +424,164 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86523,189 c -1.12014,0 -2.01524,0.0241 -2.79101,0.1543 -0.77577,0.13022 -1.48014,0.38763 -2.00977,0.91601 -0.52962,0.52838 -0.79079,1.23687 -0.91992,2.01367 -0.12912,0.77681 -0.15002,1.67169 -0.14453,2.79493 V 201 v 6.125 c -0.005,1.12104 0.0156,2.01529 0.14453,2.79102 0.12912,0.77681 0.39029,1.48529 0.91992,2.01367 0.52964,0.52838 1.234,0.78579 2.00977,0.91601 0.77577,0.13022 1.67087,0.1543 2.79101,0.1543 h 8.26954 c 1.12013,0 2.01264,-0.024 2.78711,-0.1543 0.77446,-0.13033 1.48001,-0.38927 2.00781,-0.91797 0.5278,-0.52869 0.78594,-1.23438 0.91601,-2.00976 C 341.97577,209.14258 342,208.24735 342,207.125 V 201 194.875 c 0,-1.12235 -0.0242,-2.01758 -0.1543,-2.79297 -0.13007,-0.77538 -0.38821,-1.48107 -0.91601,-2.00976 -0.5278,-0.5287 -1.23334,-0.78764 -2.00781,-0.91797 C 338.1474,189.02397 337.25491,189 336.13477,189 Z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         d="m 237.95569,68.579617 c 0,-5.501702 -2.22676,-12.452803 -6.11857,-16.344618 -3.89182,-3.891814 -9.16783,-6.078452 -14.67455,-6.078452 H 86.711557 c -5.501702,0 -10.782733,2.186638 -14.674548,6.078452 -3.891814,3.891815 -6.038331,10.842916 -6.038331,16.344618 V 243.41035 c 0,5.50171 2.231776,12.46284 6.12359,16.35465 3.891814,3.89182 9.172846,6.07845 14.674548,6.07845 H 238.00083 Z"
+         fill="url(#a)"
+         stroke="url(#b)"
+         stroke-width="4.31309"
+         id="path406"
+         style="fill:url(#linearGradient664);stroke:url(#linearGradient666)" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
+         d="m 361.65162,66.0476 c 0,-1.129814 -0.45728,-2.557272 -1.25649,-3.356484 -0.79922,-0.799212 -1.88268,-1.248253 -3.01353,-1.248253 h -26.78904 c -1.12982,0 -2.21431,0.449041 -3.01353,1.248253 -0.79921,0.799212 -1.24001,2.22667 -1.24001,3.356484 v 35.90274 c 0,1.12981 0.45831,2.55933 1.25752,3.35854 0.79921,0.79921 1.88371,1.24826 3.01352,1.24826 h 31.05083 z"
+         fill="url(#a)"
+         stroke="url(#b)"
+         stroke-width="0.885724"
+         id="path574"
+         style="fill:url(#linearGradient586);stroke:url(#linearGradient588)" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 330.19336,134 c -1.42096,0 -2.54883,0.0308 -3.50586,0.19141 -0.95703,0.16064 -1.79146,0.4726 -2.41211,1.09179 -0.62065,0.61919 -0.93647,1.45612 -1.0957,2.41407 -0.15924,0.95795 -0.18666,2.08705 -0.17969,3.51171 V 149 v 7.79688 c -0.007,1.42131 0.0207,2.5495 0.17969,3.50585 0.15923,0.95796 0.47505,1.79488 1.0957,2.41407 0.62065,0.61919 1.45508,0.93115 2.41211,1.09179 0.95703,0.16065 2.0849,0.19141 3.50586,0.19141 h 11.61523 c 1.42097,0 2.54669,-0.0307 3.50196,-0.19141 0.95527,-0.16075 1.78779,-0.47425 2.40625,-1.09375 0.61845,-0.6195 0.93134,-1.45363 1.09179,-2.41015 C 348.96905,159.34816 349,158.22066 349,156.79688 V 149 141.20312 c 0,-1.42378 -0.031,-2.55128 -0.19141,-3.50781 -0.16045,-0.95653 -0.47334,-1.79065 -1.09179,-2.41015 -0.61846,-0.61951 -1.45098,-0.933 -2.40625,-1.09375 C 344.35528,134.03065 343.22956,134 341.80859,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
+         d="m 347.51192,136.29191 c 0,-0.73684 -0.29823,-1.66779 -0.81945,-2.18901 -0.52123,-0.52123 -1.22784,-0.81408 -1.96534,-0.81408 h -17.47112 c -0.73684,0 -1.44412,0.29285 -1.96534,0.81408 -0.52123,0.52122 -0.80871,1.45217 -0.80871,2.18901 v 23.41483 c 0,0.73684 0.2989,1.66913 0.82012,2.19036 0.52123,0.52122 1.22851,0.81407 1.96535,0.81407 h 20.25053 z"
+         fill="url(#a)"
+         stroke="url(#b)"
+         stroke-width="0.577646"
+         id="path594"
+         style="fill:url(#linearGradient606);stroke:url(#linearGradient608)" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.23093,61.500047 c -2.22316,0 -3.97368,0.05118 -5.41406,0.292969 -1.44039,0.241784 -2.61905,0.695299 -3.48243,1.55664 -0.86337,0.861342 -1.31906,2.039471 -1.55859,3.480469 -0.23953,1.440999 -0.28629,3.195341 -0.27539,5.423828 V 85 97.752143 c -0.0108,2.225063 0.0361,3.978517 0.27539,5.417967 0.23953,1.441 0.69522,2.61913 1.55859,3.48047 0.86338,0.86134 2.04204,1.31486 3.48243,1.55664 1.44039,0.24179 3.1909,0.29297 5.41406,0.29297 h 17.53883 c 2.22317,0 3.97276,-0.0511 5.41017,-0.29297 1.4374,-0.24189 2.61246,-0.69694 3.47265,-1.55859 0.8602,-0.86165 1.31319,-2.03894 1.55468,-3.47852 0.24149,-1.43957 0.29297,-3.190353 0.29297,-5.417967 V 85 72.248094 c 0,-2.227614 -0.0515,-3.978392 -0.29297,-5.417969 -0.24149,-1.439576 -0.69449,-2.616863 -1.55469,-3.478516 -0.86019,-0.861652 -2.03525,-1.316704 -3.47265,-1.558593 -1.4374,-0.24189 -3.187,-0.292969 -5.41016,-0.292969 z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
+         d="m 340.82789,191.02431 c 0,-0.56491 -0.22864,-1.27863 -0.62825,-1.67824 -0.3996,-0.39961 -0.94134,-0.62413 -1.50676,-0.62413 h -13.39452 c -0.56491,0 -1.10716,0.22452 -1.50676,0.62413 -0.39961,0.39961 -0.62001,1.11333 -0.62001,1.67824 v 17.95137 c 0,0.56491 0.22916,1.27967 0.62876,1.67927 0.39961,0.39961 0.94186,0.62413 1.50676,0.62413 h 15.52541 z"
+         fill="url(#a)"
+         stroke="url(#b)"
+         stroke-width="0.442862"
+         id="path614"
+         style="fill:url(#linearGradient626);stroke:url(#linearGradient628)" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path4350"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 464,514.75001 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4380);enable-background:accumulate"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.02028775;marker:none;enable-background:accumulate"
-         d="M 101.8116,42 C 65.712789,42 61.828597,45.690158 62.005519,81.689842 V 156 230.31016 C 61.828597,266.30985 65.712789,270 101.8116,270 h 100.38732 c 36.09881,0 39.80608,-3.68973 39.80608,-39.68984 V 156 81.689842 C 242.005,45.689729 238.29773,42 202.19892,42 Z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 201.07298,44 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 156 229.00647 C 240.16759,264.37459 236.36971,268 201.07298,268 H 102.91622 C 67.619504,268 63.994604,264.375 63.994604,229.00647 V 156 82.99353 C 63.994604,47.624997 67.619504,44 102.91622,44 Z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;opacity:1"
-         d="M 239.99414 216.00586 L 188 268 L 201.07227 268 C 236.369 268 240.16713 264.37398 239.99414 229.00586 L 239.99414 216.00586 z "
-         id="rect4158-6" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188,44 C 67.625152,44 63.82701,47.626029 64,82.994141 v 2 C 63.82701,49.626029 67.625152,46 102.92188,46 h 98.15624 C 236.37485,46 240,49.625608 240,84.994141 v -2 C 240,47.625608 236.37485,44 201.07812,44 Z"
-         id="path931"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 327.636,188.49999 c -4.65703,0 -5.15812,0.47378 -5.1353,5.09575 v 6.40425 6.40426 c -0.0229,4.62196 0.47827,5.09574 5.1353,5.09574 h 8.72869 c 4.65703,0 5.1353,-0.47372 5.1353,-5.09574 v -6.40426 -6.40425 c 0,-4.62202 -0.47828,-5.09575 -5.13531,-5.09575 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.8545,236.50001 c -3.04166,0 -3.36894,0.30899 -3.35403,3.32331 v 4.17669 4.17668 c -0.0149,3.01433 0.31237,3.32332 3.35403,3.32332 h 6.29146 c 3.04167,0 3.35404,-0.30895 3.35404,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.31238,-3.32331 -3.35404,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92728,268 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 C 63.832405,262.37397 67.630549,266 102.92728,266 h 98.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 C 240.0054,264.37439 236.38025,268 201.08352,268 Z"
-         id="path931-8"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3257);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         transform="matrix(0.66664182,0,0,0.63636364,106.67522,94.545454)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004-8);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-1)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:1.85638201;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983)"
-         transform="matrix(1.0833332,0,0,1.0714286,-27.333287,-17.428571)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 152,44 v 224 h 49.07227 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 156 82.994141 C 240.16713,47.626029 236.369,44 201.07227,44 Z"
-         id="rect4158-3"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 336.50849,211.51179 c 4.23214,0 5.02499,-0.46371 5.00275,-4.98757 v -6.5241 -6.52423 c 0.0222,-4.52386 -0.77061,-4.98757 -5.00275,-4.98757 h -9.01743 c -4.23108,0 -5.00275,0.46366 -5.00275,4.98757 v 6.52423 6.5241 c 0,4.52391 0.77167,4.98757 5.00275,4.98757 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.08651,251.51179 c 2.89732,0 3.44011,-0.30259 3.42488,-3.25454 v -4.25716 -4.25724 c 0.0152,-2.95195 -0.52756,-3.25453 -3.42488,-3.25453 h -6.17331 c -2.8966,0 -3.42488,0.30255 -3.42488,3.25453 v 4.25724 4.25716 c 0,2.95199 0.52828,3.25454 3.42488,3.25454 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         transform="translate(2.0229138e-6)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-2"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3369);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-5)" />
+         d="m 333.80232,238.09323 c 0,-0.36842 -0.14911,-0.8339 -0.40973,-1.09451 -0.26061,-0.26061 -0.61391,-0.40704 -0.98267,-0.40704 h -8.73556 c -0.36841,0 -0.72205,0.14643 -0.98267,0.40704 -0.26061,0.26061 -0.40435,0.72609 -0.40435,1.09451 v 11.70741 c 0,0.36842 0.14945,0.83457 0.41006,1.09518 0.26061,0.26061 0.61426,0.40704 0.98267,0.40704 h 10.12527 z"
+         fill="url(#a)"
+         stroke="url(#b)"
+         stroke-width="0.288823"
+         id="path634"
+         style="fill:url(#linearGradient646);stroke:url(#linearGradient648)" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         style="display:inline;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 336,138.5 v 0.5 h 11 v -0.5 z m 0,2 v 0.5 h 11 v -0.5 z m 0,2 v 0.5 h 11 v -0.5 z m 0,2 v 0.5 h 11 v -0.5 z m 0,2 v 0.5 h 11 v -0.5 z m -11,2 v 0.5 h 22 v -0.5 z m 0,2 v 0.5 h 22 v -0.5 z m 0,2 v 0.5 h 22 v -0.5 z m 0,2 v 0.5 h 22 v -0.5 z m 0,2 v 0.5 h 12 v -0.5 z"
-         id="path1062"
-         inkscape:connector-curvature="0" />
+         d="M 86.796816,69.723088 H 217.16257 V 242.26688 H 86.796816 Z"
+         fill="url(#c)"
+         id="path408"
+         style="display:inline;enable-background:new;fill:url(#linearGradient668);stroke-width:5.01522" />
       <path
-         style="display:inline;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 344,69.00001 v 1 h 16 v -1 z m 0,3 v 1 h 16 v -1 z m 0,3 v 1 h 16 v -1 z m 0,3 v 1 h 16 v -1 z m 0,3 v 1 h 16 v -1 z m -16,3 v 1 h 32 v -1 z m 0,3 v 1 h 32 v -1 z m 0,3 v 1 h 32 v -1 z m 0,3 v 1 h 32 v -1 z m 0,3 v 1 h 24 v -1 z"
-         id="rect1105"
-         inkscape:connector-curvature="0" />
+         d="M 209.73001,234.93462 H 92.248365 V 231.2384 H 209.73001 Z m 0,-10.53197 H 92.248365 v -3.82662 H 209.73001 Z m 0,-11.20401 H 92.248365 v -3.69622 H 209.73001 Z m 0,-11.4297 H 92.248365 v -3.69622 H 209.73001 Z M 143.36855,183.8345 H 92.885299 v -3.69622 h 50.483251 z m 25.49239,-11.4297 H 92.885299 v -3.69622 h 75.975641 z m -25.70303,-8.51585 H 93.271471 v -3.70124 h 49.886439 z m 25.51747,-8.29017 H 92.469035 v -3.83163 H 168.67538 Z M 199.188,144.38976 H 92.469035 v -3.69623 H 199.188 Z m 10.76268,-11.42469 H 92.469035 v -3.69622 H 209.95068 Z m 0.41626,-17.45799 H 92.885299 v -3.69623 H 210.36694 Z m 0,-10.53198 H 92.885299 v -3.83163 H 210.36694 Z m 0,-11.209024 H 92.885299 V 90.069855 H 210.36694 Z m 0,-11.424682 H 92.885299 V 78.640158 H 210.36694 Z"
+         fill="#b0b0b0"
+         id="path410"
+         style="display:inline;enable-background:new;stroke-width:5.01522" />
       <path
-         sodipodi:nodetypes="ccccccccccccccccccccc"
-         inkscape:connector-curvature="0"
-         d="M 96.58098,76.07313 76.8475,128.07339 H 72 v 3.99998 h 13.99986 v -3.99998 h -4.48214 l 4.67576,-12.0084 H 109.395 l 4.67022,12.0084 H 108.01 v 3.99998 h 20.0825 v -3.99998 h -5.54 L 102.81348,76.07313 Z m 1.21326,9.0025 10.21576,27.00611 H 87.75022 Z"
-         font-size="13.717"
-         font-weight="400"
-         letter-spacing="0"
-         overflow="visible"
-         style="color:#bebebe;font-weight:400;font-size:13.71700001px;line-height:125%;font-family:'DejaVu Serif';-inkscape-font-specification:'DejaVu Serif';letter-spacing:0;word-spacing:0;display:inline;overflow:visible;fill:#5d5d5d;stroke-width:1.00000012;marker:none;enable-background:new"
-         word-spacing="0"
-         id="path3233" />
+         d="M 68.250514,117.09189 H 235.70887 v 17.52319 H 68.250514 Z"
+         fill="url(#d)"
+         id="path412"
+         style="display:inline;enable-background:new;fill:url(#linearGradient670);stroke-width:5.01522" />
       <path
-         style="display:inline;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 332,193.5 v 0.5 h 8 v -0.5 z m 0,2 v 0.5 h 8 v -0.5 z m 0,2 v 0.5 h 8 v -0.5 z m 0,2 v 0.5 h 8 v -0.5 z m -8,2 v 0.5 h 16 v -0.5 z m 0,2 v 0.5 h 16 v -0.5 z m 0,2 v 0.5 h 12 v -0.5 z"
-         id="path1052"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccc" />
+         d="M 68.250514,124.84041 H 235.70887 v 1.98101 H 68.250514 Z"
+         fill="#ffffff"
+         fill-opacity="0.8"
+         id="path414"
+         style="display:inline;enable-background:new;stroke-width:5.01522" />
       <path
-         style="display:inline;opacity:1;fill:#c8c4b7;fill-opacity:0.99607843;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 328,239.5 v 0.5 h 5 v -0.5 z m 0,2 v 0.5 h 5 v -0.5 z m 1,2 v 0.5 h 4 v -0.5 z m -6,2 v 0.5 h 10 v -0.5 z"
-         id="path1078"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccccccccc" />
+         d="m 330.61006,66.28242 h 26.77154 v 35.4331 h -26.77154 z"
+         fill="url(#c)"
+         id="path576"
+         style="display:inline;enable-background:new;fill:url(#linearGradient590);stroke-width:1.02991" />
       <path
-         sodipodi:nodetypes="ccccccccccccccccccccc"
-         inkscape:connector-curvature="0"
-         d="m 333.70628,69.00001 -4.58097,12.07143 H 328 v 0.92857 h 3.24995 v -0.92857 h -1.04049 l 1.08544,-2.78765 h 5.38604 l 1.08416,2.78765 h -1.40567 v 0.92857 h 4.66198 v -0.92857 h -1.28606 l -4.58226,-12.07143 z m 0.28164,2.08985 2.37151,6.26925 h -4.70314 z"
-         font-size="13.717"
-         font-weight="400"
-         letter-spacing="0"
-         overflow="visible"
-         style="color:#bebebe;font-weight:400;font-size:13.71700001px;line-height:125%;font-family:'DejaVu Serif';-inkscape-font-specification:'DejaVu Serif';letter-spacing:0;word-spacing:0;display:inline;overflow:visible;fill:#5d5d5d;fill-opacity:1;stroke-width:0.92857152;marker:none;enable-background:new"
-         word-spacing="0"
-         id="path3233-3" />
-      <g
-         id="g3767"
-         transform="matrix(0.9,0,0,0.9,-228.4442,26.400018)"
-         style="color:#bebebe;display:inline;fill:#1463a5;enable-background:new">
-        <path
-           id="path3765"
-           word-spacing="0"
-           style="font-weight:400;font-size:13.71700001px;line-height:125%;font-family:'DejaVu Serif';-inkscape-font-specification:'DejaVu Serif';letter-spacing:0;word-spacing:0;overflow:visible;fill:#5d5d5d;fill-opacity:1;marker:none"
-           overflow="visible"
-           letter-spacing="0"
-           font-weight="400"
-           font-size="13.717"
-           d="m 619.375,124 -3.562,9.281 h -0.875 V 134 h 2.812 v -0.719 h -1.094 l 0.844,-2.187 h 4.188 l 0.843,2.187 h -1.093 V 134 h 3.625 v -0.719 h -1 L 620.5,124 Z m 0.219,1.625 1.844,4.75 h -3.657 z"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccccccccccccccccc" />
-      </g>
+         d="m 355.85527,100.20979 h -24.12569 v -0.759047 h 24.12569 z m 0,-2.162818 h -24.12569 v -0.785823 h 24.12569 z m 0,-2.300824 h -24.12569 v -0.759045 h 24.12569 z m 0,-2.34717 h -24.12569 v -0.759045 h 24.12569 z m -13.6278,-3.682966 h -10.36709 v -0.759045 h 10.36709 z m 5.23505,-2.347169 h -15.60214 v -0.759046 h 15.60214 z m -5.2783,-1.748791 h -10.24454 v -0.760076 h 10.24454 z m 5.24019,-1.702445 H 331.7749 v -0.786853 h 15.64951 z m 6.26599,-2.301854 h -21.9155 v -0.759045 h 21.9155 z m 2.21019,-2.34614 H 331.7749 v -0.759045 h 24.12569 z m 0.0855,-3.585124 H 331.8604 v -0.759046 h 24.12569 z m 0,-2.162816 H 331.86038 V 72.73482 h 24.12569 z m 0,-2.301854 H 331.8604 v -0.759045 h 24.12569 z m 0,-2.34614 H 331.8604 v -0.760075 h 24.12569 z"
+         fill="#b0b0b0"
+         id="path578"
+         style="display:inline;enable-background:new;stroke-width:1.02991" />
       <path
-         id="path3780"
-         word-spacing="0"
-         style="color:#bebebe;font-weight:400;font-size:13.71700001px;line-height:125%;font-family:'DejaVu Serif';-inkscape-font-specification:'DejaVu Serif';letter-spacing:0;word-spacing:0;display:inline;overflow:visible;fill:#5d5d5d;fill-opacity:1;stroke-width:1.00000012;marker:none;enable-background:new"
-         overflow="visible"
-         letter-spacing="0"
-         font-weight="400"
-         font-size="13.717"
-         d="m 327.07261,193 -2.46668,6.50002 H 324 V 200 h 1.74997 v -0.49998 h -0.56026 l 0.58447,-1.50106 h 2.90017 l 0.58378,1.50106 h -0.7569 V 200 h 2.5103 v -0.49998 h -0.6925 L 327.85167,193 Z m 0.15165,1.12531 1.27697,3.37576 h -2.53246 z"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccc" />
-      <g
-         id="g3753"
-         transform="matrix(0.38461538,0,0,0.38461538,94.50231,193.23077)"
-         style="color:#bebebe;display:inline;fill:#1463a5;stroke-width:2.5999999;enable-background:new">
-        <path
-           id="path3751"
-           word-spacing="0"
-           style="font-weight:400;font-size:17.83300018px;line-height:125%;font-family:'DejaVu Serif';-inkscape-font-specification:'DejaVu Serif';letter-spacing:0;word-spacing:0;overflow:visible;fill:#5d5d5d;fill-opacity:1;stroke-width:2.5999999;marker:none"
-           overflow="visible"
-           letter-spacing="0"
-           font-weight="400"
-           font-size="17.833"
-           d="m 599.875,119 -4.625,12 h -1.156 v 1 h 3.593 v -1 h -1.343 l 1.093,-3 h 5.469 l 1.063,3 h -1.282 v 1 h 4.594 v -1 H 606 l -4.656,-12 z m 0.281,2.094 2.406,5.906 h -4.781 z"
-           inkscape:connector-curvature="0" />
-      </g>
+         d="m 326.80145,76.009941 h 34.38877 v 3.598513 h -34.38877 z"
+         fill="url(#d)"
+         id="path580"
+         style="display:inline;enable-background:new;fill:url(#linearGradient592);stroke-width:1.02991" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 136,80.074229 v 4 h 96 v -4 z"
-         id="path1328"
-         inkscape:connector-curvature="0" />
+         d="m 326.80145,77.601155 h 34.38877 v 0.406816 h -34.38877 z"
+         fill="#ffffff"
+         fill-opacity="0.8"
+         id="path582"
+         style="display:inline;enable-background:new;stroke-width:1.02991" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 136,96.07423 v 4 h 96 v -4 z"
-         id="path1326"
-         inkscape:connector-curvature="0" />
+         d="m 327.26743,136.44505 h 17.4597 v 23.10855 h -17.4597 z"
+         fill="url(#c)"
+         id="path596"
+         style="display:inline;enable-background:new;fill:url(#linearGradient610);stroke-width:0.671682" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="M 136,112.00001 V 116 h 96 v -3.99999 z"
-         id="path1324"
-         inkscape:connector-curvature="0" />
+         d="m 343.73169,158.5716 h -15.73415 v -0.49503 h 15.73415 z m 0,-1.41053 h -15.73415 v -0.5125 h 15.73415 z m 0,-1.50054 h -15.73415 v -0.49503 h 15.73415 z m 0,-1.53076 h -15.73415 v -0.49503 h 15.73415 z m -8.88769,-2.40194 h -6.76115 v -0.49503 h 6.76115 z m 3.41416,-1.53076 h -10.17531 v -0.49503 h 10.17531 z m -3.44237,-1.14052 h -6.68122 v -0.4957 h 6.68122 z m 3.41751,-1.11029 h -10.2062 v -0.51316 h 10.2062 z m 4.08652,-1.50121 H 328.0271 v -0.49503 h 14.29272 z m 1.44143,-1.53009 H 328.0271 v -0.49503 h 15.73415 z m 0.0557,-2.33812 H 328.0828 v -0.49503 h 15.7342 z m 0,-1.41053 H 328.0828 v -0.51317 h 15.7342 z m 0,-1.50121 H 328.0828 v -0.49503 h 15.7342 z m 0,-1.53009 h -15.7341 V 137.6393 H 343.817 Z"
+         fill="#b0b0b0"
+         id="path598"
+         style="display:inline;enable-background:new;stroke-width:0.671682" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 136,128 v 4 h 96 v -4 z"
-         id="path1322"
-         inkscape:connector-curvature="0" />
+         d="M 324.78355,142.78909 H 347.211 v 2.34686 h -22.42745 z"
+         fill="url(#d)"
+         id="path600"
+         style="display:inline;enable-background:new;fill:url(#linearGradient612);stroke-width:0.671682" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 72,144 v 4 l 160,0.0742 v -4 z"
-         id="path1320"
-         inkscape:connector-curvature="0" />
+         d="M 324.78355,143.82684 H 347.211 v 0.26531 h -22.42745 z"
+         fill="#ffffff"
+         fill-opacity="0.8"
+         id="path602"
+         style="display:inline;enable-background:new;stroke-width:0.671682" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 72,160 v 4 h 160 v -4 z"
-         id="path1318"
-         inkscape:connector-curvature="0" />
+         d="m 325.30711,191.14172 h 13.38577 v 17.71655 h -13.38577 z"
+         fill="url(#c)"
+         id="path616"
+         style="display:inline;enable-background:new;fill:url(#linearGradient630);stroke-width:0.514956" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 72,176 v 4 h 160 v -4 z"
-         id="path1316"
-         inkscape:connector-curvature="0" />
+         d="m 337.92972,208.10541 h -12.06285 v -0.37953 h 12.06285 z m 0,-1.08141 h -12.06285 v -0.39291 h 12.06285 z m 0,-1.15041 h -12.06285 v -0.37953 h 12.06285 z m 0,-1.17359 h -12.06285 v -0.37952 h 12.06285 z m -6.8139,-1.84148 h -5.18355 V 202.479 h 5.18355 z m 2.61752,-1.17359 h -7.80107 v -0.37952 h 7.80107 z m -2.63915,-0.87439 h -5.12227 v -0.38004 h 5.12227 z m 2.6201,-0.85122 h -7.82476 v -0.39343 h 7.82476 z m 3.13299,-1.15093 h -10.95775 v -0.37952 h 10.95775 z m 1.1051,-1.17307 h -12.06285 v -0.37952 h 12.06285 z m 0.0427,-1.79256 h -12.06285 v -0.37953 h 12.06285 z m 0,-1.08141 h -12.06285 v -0.39343 h 12.06285 z m 0,-1.15093 h -12.06285 v -0.37952 h 12.06285 z m 0,-1.17307 h -12.06285 v -0.38004 h 12.06285 z"
+         fill="#b0b0b0"
+         id="path618"
+         style="display:inline;enable-background:new;stroke-width:0.514956" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 72,192 v 4 l 160,0.0742 v -4 z"
-         id="path1314"
-         inkscape:connector-curvature="0" />
+         d="m 323.4028,196.00548 h 17.19439 v 1.79926 H 323.4028 Z"
+         fill="url(#d)"
+         id="path620"
+         style="display:inline;enable-background:new;fill:url(#linearGradient632);stroke-width:0.514956" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 72,208 v 4 h 160 v -4 z"
-         id="path1312"
-         inkscape:connector-curvature="0" />
+         d="m 323.4028,196.80109 h 17.19439 v 0.20341 H 323.4028 Z"
+         fill="#ffffff"
+         fill-opacity="0.8"
+         id="path622"
+         style="display:inline;enable-background:new;stroke-width:0.514956" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#e3dfd5;fill-opacity:0.99607843;fill-rule:nonzero;stroke:none;stroke-width:3.00000024;marker:none;enable-background:accumulate"
-         d="m 72,224 v 4 h 132 v -4 z"
-         id="path1032"
-         inkscape:connector-curvature="0" />
-      <rect
-         style="opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-         id="rect1157"
-         width="176.05"
-         height="4"
-         x="63.994999"
-         y="168" />
-      <rect
-         style="display:inline;opacity:0.4;vector-effect:none;fill:url(#linearGradient1188);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1157-3"
-         width="176.05"
-         height="32"
-         x="63.994999"
-         y="136" />
-      <rect
-         style="display:inline;opacity:0.4;vector-effect:none;fill:url(#linearGradient1188-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1157-3-3"
-         width="176.05"
-         height="32"
-         x="63.994999"
-         y="-204"
-         transform="scale(1,-1)" />
-      <rect
-         style="display:inline;opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:1.99999964;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1330"
-         width="36"
-         height="1"
-         x="326"
-         y="87" />
-      <rect
-         style="display:inline;opacity:0.4;vector-effect:none;fill:url(#linearGradient1188-5);fill-opacity:1;stroke:none;stroke-width:1.99999964;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1157-3-9"
-         width="36"
-         height="6.0000005"
-         x="326"
-         y="81" />
-      <rect
-         style="display:inline;opacity:0.4;vector-effect:none;fill:url(#linearGradient1188-5-1);fill-opacity:1;stroke:none;stroke-width:1.99999964;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1157-3-9-0"
-         width="36"
-         height="6.0000005"
-         x="326"
-         y="-94"
-         transform="scale(1,-1)" />
-      <rect
-         style="display:inline;opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1330-2"
-         width="24"
-         height="1"
-         x="324"
-         y="150" />
-      <rect
-         style="display:inline;opacity:0.4;vector-effect:none;fill:url(#linearGradient1188-5-0);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1157-3-9-3"
-         width="24"
-         height="4"
-         x="324"
-         y="146" />
-      <rect
-         style="display:inline;opacity:0.4;vector-effect:none;fill:url(#linearGradient1188-5-1-7);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1157-3-9-0-7"
-         width="24"
-         height="4"
-         x="324"
-         y="-155"
-         transform="scale(1,-1)" />
-      <rect
-         style="display:inline;opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1330-2-8"
-         width="18"
-         height="1"
-         x="323"
-         y="201" />
-      <rect
-         style="display:inline;opacity:0.4;vector-effect:none;fill:url(#linearGradient1188-5-0-2);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1157-3-9-3-9"
-         width="18"
-         height="4"
-         x="323"
-         y="197" />
-      <rect
-         style="display:inline;opacity:0.4;vector-effect:none;fill:url(#linearGradient1188-5-1-7-5);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1157-3-9-0-7-7"
-         width="18"
-         height="4"
-         x="323"
-         y="-206"
-         transform="scale(1,-1)" />
-      <rect
-         style="display:inline;opacity:1;vector-effect:none;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1330-2-8-9"
-         width="12"
-         height="1"
-         x="322"
-         y="245" />
-      <rect
-         style="display:inline;opacity:0.4;vector-effect:none;fill:url(#linearGradient1188-5-0-2-2);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1157-3-9-3-9-3"
-         width="12"
-         height="4"
-         x="322"
-         y="243" />
-      <rect
-         style="display:inline;opacity:0.4;vector-effect:none;fill:url(#linearGradient1188-5-1-7-5-3);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
-         id="rect1157-3-9-0-7-7-1"
-         width="12"
-         height="4"
-         x="322"
-         y="-250"
-         transform="scale(1,-1)" />
+         d="m 323.68007,238.1698 h 8.72985 v 11.55427 h -8.72985 z"
+         fill="url(#c)"
+         id="path636"
+         style="display:inline;enable-background:new;fill:url(#linearGradient650);stroke-width:0.335841" />
       <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.45;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 63.994141,172 v 57.00586 C 63.994141,264.37439 67.6193,268 102.91602,268 h 98.15625 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 172 Z"
-         id="rect4158-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csssccc" />
+         d="m 331.91221,249.23307 h -7.86708 v -0.24752 h 7.86708 z m 0,-0.70527 h -7.86708 v -0.25624 h 7.86708 z m 0,-0.75027 h -7.86708 v -0.24751 h 7.86708 z m 0,-0.76538 h -7.86708 v -0.24751 h 7.86708 z m -4.44385,-1.20096 h -3.38058 v -0.24752 h 3.38058 z m 1.70708,-0.76539 h -5.08766 v -0.24751 h 5.08766 z m -1.72119,-0.57025 h -3.34061 v -0.24785 h 3.34061 z m 1.70876,-0.55515 h -5.1031 v -0.25658 h 5.1031 z m 2.04326,-0.7506 h -7.14636 v -0.24752 h 7.14636 z m 0.72071,-0.76505 h -7.86707 v -0.24751 h 7.86707 z m 0.0279,-1.16906 h -7.86708 v -0.24752 h 7.86708 z m 0,-0.70527 h -7.86708 v -0.25658 h 7.86708 z m 0,-0.7506 h -7.86708 v -0.24752 h 7.86708 z m 0,-0.76505 h -7.86708 v -0.24785 h 7.86708 z"
+         fill="#b0b0b0"
+         id="path638"
+         style="display:inline;enable-background:new;stroke-width:0.335841" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 325.50195,88 v 8.751953 c -0.0433,8.842027 1.49893,9.748047 9.73047,9.748047 h 17.53906 c 8.22949,0 9.72852,-0.90592 9.72852,-9.748047 V 88 Z"
-         id="path964-70"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscc" />
+         d="m 322.43813,241.34181 h 11.21373 v 1.17343 h -11.21373 z"
+         fill="url(#d)"
+         id="path640"
+         style="display:inline;enable-background:new;fill:url(#linearGradient652);stroke-width:0.335841" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 323.5,151 v 5.2168 c -0.0293,5.69818 1.01247,6.2832 6.57422,6.2832 h 11.85156 c 5.56037,0 6.57422,-0.58496 6.57422,-6.2832 V 151 Z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscc" />
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;opacity:0.45"
-         d="M 322.5 202 L 322.5 206.4043 C 322.4771 211.02626 322.97969 211.5 327.63672 211.5 L 336.36523 211.5 C 341.02226 211.5 341.5 211.02632 341.5 206.4043 L 341.5 202 L 322.5 202 z "
-         id="path914-5" />
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;opacity:0.45"
-         d="M 321.5 246 L 321.5 248.17578 C 321.4851 251.19011 321.81381 251.5 324.85547 251.5 L 331.14648 251.5 C 334.18814 251.5 334.5 251.19015 334.5 248.17578 L 334.5 246 L 321.5 246 z "
-         id="path918-8" />
+         d="m 322.43813,241.86069 h 11.21373 v 0.13266 h -11.21373 z"
+         fill="#ffffff"
+         fill-opacity="0.8"
+         id="path642"
+         style="display:inline;enable-background:new;stroke-width:0.335841" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/screenshot-app.svg
+++ b/icons/src/fullcolor/default/apps/screenshot-app.svg
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="screenshot-app.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="114.5"
-     inkscape:cy="62.097561"
-     inkscape:current-layer="layer6"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="352.84628"
+     inkscape:cy="185.26198"
+     inkscape:current-layer="layer2"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -93,152 +94,202 @@
      id="defs3">
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient927">
+       xlink:href="#linearGradient892"
+       id="linearGradient894"
+       x1="132.29167"
+       y1="101.20831"
+       x2="132.29167"
+       y2="270.54166"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.91662587,0,0,0.91662587,27.827773,7.9343896)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient892">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         style="stop-color:#fdfdfd;stop-opacity:1"
          offset="0"
-         id="stop923" />
+         id="stop888" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="1"
-         id="stop925" />
+         id="stop890" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(3.5512464,0,0,3.5512464,168.16756,-3759.0488)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient868"
+       id="linearGradient862"
+       x1="-6.5454307"
+       y1="1093.0649"
+       x2="-6.5454307"
+       y2="1124.684"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient868">
+      <stop
+         style="stop-color:#b3b3b3;stop-opacity:1"
+         offset="0"
+         id="stop866" />
+      <stop
+         style="stop-color:#cecece;stop-opacity:1"
+         offset="1"
+         id="stop864" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1686"
-       x1="320.99991"
-       y1="92.000153"
-       x2="366.99991"
-       y2="76.000153"
+       xlink:href="#linearGradient1070"
+       id="linearGradient1115"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000121)" />
+       x1="132.29167"
+       y1="48.291649"
+       x2="132.29167"
+       y2="132.95831"
+       gradientTransform="matrix(0.91662587,0,0,0.91662587,27.827745,7.9343896)" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1688"
-       x1="321.00003"
-       y1="153.00002"
-       x2="351.00003"
-       y2="143.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00002,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1690"
-       x1="320.9993"
-       y1="202.99928"
-       x2="342.9993"
-       y2="196.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1692"
-       x1="320.00031"
-       y1="247.00034"
-       x2="336.00031"
-       y2="241.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1694"
-       x1="39.997601"
-       y1="203.99699"
-       x2="263.99759"
-       y2="107.997"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,151.9973,155.9997)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4338-7">
+       id="linearGradient1070"
+       inkscape:collect="always">
       <stop
-         id="stop4342-6"
+         id="stop1066"
          offset="0"
-         style="stop-color:#5884f4;stop-opacity:1" />
+         style="stop-color:#f3f2f3;stop-opacity:1" />
       <stop
-         id="stop4340-2"
+         id="stop1068"
          offset="1"
-         style="stop-color:#80a3fa;stop-opacity:1" />
+         style="stop-color:#dcdadc;stop-opacity:1" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1692-6"
-       x1="321.00031"
-       y1="244.00034"
-       x2="335.00031"
-       y2="244.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1690-9"
-       x1="320.9993"
-       y1="199.99928"
-       x2="342.9993"
-       y2="199.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1688-4"
-       x1="322"
-       y1="148.00002"
-       x2="350"
-       y2="148.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00001,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1686-0"
-       x1="321.99991"
-       y1="84.000153"
-       x2="365.99991"
-       y2="84.000153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000125)" />
     <filter
        inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
-       id="filter58449"
-       x="-0.047999425"
-       width="1.0959988"
-       y="-0.048000575"
-       height="1.0960012">
+       id="filter942"
+       x="-0.025321228"
+       width="1.0506425"
+       y="-0.027357913"
+       height="1.0547158">
       <feGaussianBlur
          inkscape:collect="always"
-         stdDeviation="4.4800539"
-         id="feGaussianBlur58451" />
+         stdDeviation="1.1196871"
+         id="feGaussianBlur944" />
     </filter>
-    <filter
+    <linearGradient
        inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58492"
-       x="-0.011999856"
-       width="1.0239997"
-       y="-0.012000144"
-       height="1.0240003">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1200135"
-         id="feGaussianBlur58494" />
-    </filter>
+       xlink:href="#linearGradient892"
+       id="linearGradient1208"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18823567,0,0,0.18823567,318.50035,53.593669)"
+       x1="132.29167"
+       y1="101.20831"
+       x2="132.29167"
+       y2="270.54166" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient868"
+       id="linearGradient1210"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72927381,0,0,0.72927381,347.32012,-719.98324)"
+       x1="-6.5454307"
+       y1="1093.0649"
+       x2="-6.5454307"
+       y2="1124.684" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1070"
+       id="linearGradient1212"
+       gradientUnits="userSpaceOnUse"
+       x1="132.29167"
+       y1="48.291649"
+       x2="132.29167"
+       y2="132.95831"
+       gradientTransform="matrix(0.18823567,0,0,0.18823567,318.50034,53.593669)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient892"
+       id="linearGradient1230"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12276239,0,0,0.12276239,319.36979,128.16978)"
+       x1="132.29167"
+       y1="101.20831"
+       x2="132.29167"
+       y2="270.54166" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient868"
+       id="linearGradient1232"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.47561334,0,0,0.47561334,338.1653,-376.33688)"
+       x1="-6.5454307"
+       y1="1093.0649"
+       x2="-6.5454307"
+       y2="1124.684" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1070"
+       id="linearGradient1234"
+       gradientUnits="userSpaceOnUse"
+       x1="132.29167"
+       y1="48.291649"
+       x2="132.29167"
+       y2="132.95831"
+       gradientTransform="matrix(0.12276239,0,0,0.12276239,319.36979,128.16978)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient892"
+       id="linearGradient1252"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09411784,0,0,0.09411784,319.25017,184.79683)"
+       x1="132.29167"
+       y1="101.20831"
+       x2="132.29167"
+       y2="270.54166" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient868"
+       id="linearGradient1254"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.36463693,0,0,0.36463693,333.66006,-201.99164)"
+       x1="-6.5454307"
+       y1="1093.0649"
+       x2="-6.5454307"
+       y2="1124.684" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1070"
+       id="linearGradient1256"
+       gradientUnits="userSpaceOnUse"
+       x1="132.29167"
+       y1="48.291649"
+       x2="132.29167"
+       y2="132.95831"
+       gradientTransform="matrix(0.09411784,0,0,0.09411784,319.25017,184.79683)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient892"
+       id="linearGradient1274"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0613812,0,0,0.0613812,319.68489,234.08489)"
+       x1="132.29167"
+       y1="101.20831"
+       x2="132.29167"
+       y2="270.54166" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient868"
+       id="linearGradient1276"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23780669,0,0,0.23780669,329.08265,-18.168462)"
+       x1="-6.5454307"
+       y1="1093.0649"
+       x2="-6.5454307"
+       y2="1124.684" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1070"
+       id="linearGradient1278"
+       gradientUnits="userSpaceOnUse"
+       x1="132.29167"
+       y1="48.291649"
+       x2="132.29167"
+       y2="132.95831"
+       gradientTransform="matrix(0.0613812,0,0,0.0613812,319.68489,234.08489)" />
   </defs>
   <metadata
      id="metadata4">
@@ -250,13 +301,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -338,7 +389,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">screenshot-app</tspan></text>
+           id="tspan924">screenshot-app</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -373,219 +424,249 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         style="display:inline;fill:url(#linearGradient1234);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.55736;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new"
+         d="m 322.78307,134.47171 c -0.77531,0 -1.39947,0.62415 -1.39947,1.39947 v 5.37279 h 29.2328 v -5.37279 c 0,-0.77532 -0.62415,-1.39947 -1.39947,-1.39947 z"
+         id="path1218"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:6.4047;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke;filter:url(#filter942);enable-background:new"
+         id="rect1226"
+         width="232.59531"
+         height="215.27954"
+         x="19.169014"
+         y="53.893547"
+         rx="11.135269"
+         transform="matrix(0.12276239,0,0,0.12276239,319.36979,128.16978)" />
+      <rect
+         rx="1.0729433"
+         y="189.62831"
+         x="320.7941"
+         height="20.743376"
+         width="22.41181"
+         id="rect1236"
+         style="display:inline;fill:url(#linearGradient1252);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.96064;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         style="display:inline;fill:url(#linearGradient1256);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.96064;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new"
+         d="m 321.86702,189.62831 c -0.59441,0 -1.07293,0.47851 -1.07293,1.07293 v 4.11914 h 22.41181 v -4.11914 c 0,-0.59442 -0.47851,-1.07293 -1.07292,-1.07293 z"
+         id="path1240"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:6.4047;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke;filter:url(#filter942);enable-background:new"
+         id="rect1248"
+         width="232.59531"
+         height="215.27954"
+         x="19.169014"
+         y="53.893547"
+         rx="11.135269"
+         transform="matrix(0.09411784,0,0,0.09411784,319.25017,184.79683)" />
+      <rect
+         rx="0.69974566"
+         y="237.23586"
+         x="320.6918"
+         height="13.528289"
+         width="14.616398"
+         id="rect1258"
+         style="display:inline;fill:url(#linearGradient1274);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.27868;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.12858,237.00001 c -3.74357,0 -4.14638,0.30899 -4.12803,3.32331 v 4.17669 4.17668 c -0.0183,3.01433 0.38446,3.32332 4.12803,3.32332 h 7.74335 c 3.7436,0 4.12805,-0.30895 4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 -0.38446,-3.32331 -4.12805,-3.32331 z"
-         id="path918-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         style="display:inline;fill:url(#linearGradient1278);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.27868;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new"
+         d="m 321.39153,237.23585 c -0.38766,0 -0.69973,0.31208 -0.69973,0.69974 v 2.6864 h 14.6164 v -2.6864 c 0,-0.38766 -0.31208,-0.69974 -0.69974,-0.69974 z"
+         id="path1262"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:6.4047;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke;filter:url(#filter942);enable-background:new"
+         id="rect1270"
+         width="232.59531"
+         height="215.27954"
+         x="19.169014"
+         y="53.893547"
+         rx="11.135269"
+         transform="matrix(0.0613812,0,0,0.0613812,319.68489,234.08489)" />
+      <rect
+         rx="2.1458867"
+         y="63.256626"
+         x="321.5882"
+         height="41.486752"
+         width="44.82362"
+         id="rect1192"
+         style="display:inline;fill:url(#linearGradient1208);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.92129;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 326.45275,189.00048 c -1.2321,0 -2.21668,0.0221 -3.06999,0.14144 -0.85332,0.11937 -1.62809,0.35533 -2.21066,0.83967 -0.58256,0.48436 -0.86983,1.13381 -1.01188,1.84587 -0.14202,0.71207 -0.16501,1.53239 -0.15897,2.56202 v 7.61066 4.6143 c -0.006,1.02762 0.0171,1.84735 0.15897,2.55843 0.14203,0.71208 0.42931,1.36152 1.01188,1.84587 0.58258,0.48434 1.35734,0.7203 2.21066,0.83967 0.85331,0.11936 1.83789,0.14144 3.06999,0.14144 h 11.09542 c 1.2321,0 2.21381,-0.022 3.0657,-0.14144 0.85187,-0.11947 1.62795,-0.35683 2.2085,-0.84146 0.58057,-0.48464 0.86451,-1.13152 1.00758,-1.84228 0.14307,-0.71077 0.16972,-1.5314 0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 -0.0266,-1.84946 -0.16972,-2.56023 -0.14307,-0.71076 -0.42701,-1.35765 -1.00758,-1.84228 -0.58055,-0.48464 -1.35661,-0.722 -2.2085,-0.84147 -0.8519,-0.11947 -1.83359,-0.14144 -3.0657,-0.14144 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         style="display:inline;fill:url(#linearGradient1212);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.92129;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new"
+         d="m 323.73404,63.256626 c -1.18882,0 -2.14585,0.957032 -2.14585,2.145853 v 8.238285 h 44.82362 v -8.238285 c 0,-1.188821 -0.95703,-2.145853 -2.14586,-2.145853 z"
+         id="path1196"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:6.4047;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke;filter:url(#filter942);enable-background:new"
+         id="rect1204"
+         width="232.59531"
+         height="215.27954"
+         x="19.169014"
+         y="53.893547"
+         rx="11.135269"
+         transform="matrix(0.18823567,0,0,0.18823567,318.50034,53.593669)" />
+      <rect
+         rx="1.3994912"
+         y="134.47171"
+         x="321.38361"
+         height="27.056576"
+         width="29.232794"
+         id="rect1214"
+         style="display:inline;fill:url(#linearGradient1230);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.55736;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
+      <rect
+         rx="10.449534"
+         y="54.988789"
+         x="42.864227"
+         height="202.02243"
+         width="218.27153"
+         id="rect1383"
+         style="display:inline;fill:url(#linearGradient894);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:19.095;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 329.30094,134 c -1.63949,0 -2.94082,0.0308 -4.04505,0.19141 -1.10422,0.16064 -2.06697,0.4726 -2.78308,1.09179 -0.71611,0.61919 -1.0805,1.45612 -1.26421,2.41407 -0.18374,0.95795 -0.21537,2.08705 -0.20733,3.51171 V 149 v 7.79688 c -0.009,1.42131 0.0239,2.5495 0.20733,3.50585 0.18371,0.95796 0.5481,1.79488 1.26421,2.41407 0.71611,0.61919 1.67886,0.93115 2.78308,1.09179 1.10423,0.16065 2.40556,0.19141 4.04505,0.19141 h 13.40164 c 1.63949,0 2.93835,-0.0307 4.04054,-0.19141 1.10219,-0.16075 2.06274,-0.47425 2.77633,-1.09375 0.71357,-0.6195 1.07457,-1.45363 1.25969,-2.41015 C 350.96429,159.34816 351,158.22066 351,156.79688 V 149 141.20312 c 0,-1.42378 -0.0358,-2.55128 -0.22086,-3.50781 -0.18512,-0.95653 -0.54612,-1.79065 -1.25969,-2.41015 -0.71359,-0.61951 -1.67414,-0.933 -2.77633,-1.09375 C 345.64093,134.03065 344.34207,134 342.70258,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 333.65776,62 c -2.6221,0 -4.68675,0.05009 -6.38561,0.286735 -1.69887,0.236639 -3.08904,0.680503 -4.10735,1.523515 -1.0183,0.843013 -1.55577,1.996072 -1.83828,3.406406 -0.28252,1.410336 -0.33767,3.127346 -0.32482,5.308412 v 12.474816 12.480783 c -0.0127,2.177715 0.0426,3.893853 0.32482,5.302673 0.28251,1.41034 0.81998,2.5634 1.83828,3.40641 1.01831,0.84301 2.40848,1.28688 4.10735,1.52351 1.69888,0.23665 3.76351,0.28674 6.38561,0.28674 h 20.68618 c 2.62213,0 4.68568,-0.05 6.38104,-0.28674 1.69534,-0.23674 3.08126,-0.6821 4.09581,-1.52542 1.01457,-0.84331 1.54885,-1.99555 1.83367,-3.4045 C 366.93929,101.37441 367,99.660878 367,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0608,-3.893733 -0.34554,-5.302677 -0.28482,-1.408942 -0.81911,-2.561177 -1.83368,-3.404494 -1.01455,-0.843317 -2.40047,-1.288685 -4.09582,-1.525427 C 359.02962,62.049992 356.96605,62 354.34394,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500049 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 v 12.75157 12.75181 c -0.0527,8.842031 1.82291,9.748381 11.83407,9.748381 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.748381 v -12.75181 -12.75157 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1694);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 225.07297,43.999694 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.006466 73.00648 c 0.17299,35.36812 -3.62489,38.99353 -38.92162,38.99353 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 155.99969 82.993224 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 326.17688,188.49945 c -5.14666,0 -5.70043,0.43262 -5.67521,4.65309 v 5.84793 7.84761 c -0.0253,4.22046 0.52855,4.65307 5.67521,4.65307 h 11.64568 c 5.14665,0 5.67521,-0.43255 5.67521,-4.65307 v -7.84761 -5.84793 c 0,-4.22051 -0.52857,-4.65309 -5.67522,-4.65309 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.4056,236.50001 c -3.47604,0 -3.85006,0.30899 -3.83302,3.32331 v 4.17669 4.17668 c -0.017,3.01433 0.35698,3.32332 3.83302,3.32332 h 7.18996 c 3.47605,0 3.83303,-0.30895 3.83303,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.35699,-3.32331 -3.83303,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         style="display:inline;fill:url(#linearGradient1115);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:19.095;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0;paint-order:stroke markers fill;enable-background:new"
+         d="m 53.3136,54.98879 c -5.789043,0 -10.449372,4.660328 -10.449372,10.449371 V 105.55503 H 261.13576 V 65.438161 c 0,-5.789043 -4.66033,-10.449371 -10.44937,-10.449371 z"
+         id="rect1113"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;opacity:0.2;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:6.4047;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke;filter:url(#filter942);enable-background:new"
+         id="rect932"
+         width="232.59531"
+         height="215.27954"
+         x="19.169014"
+         y="53.893547"
+         rx="11.135269"
+         transform="matrix(0.91662587,0,0,0.91662587,27.827745,7.9343896)" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms and folds"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 39.994,156 v 8 65.00586 C 39.994,264.37439 43.61917,268 78.91587,268 h 146.15626 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 164 156 Z"
-         id="rect4158-5"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscccc" />
-      <rect
-         style="display:inline;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         id="rect934"
-         width="144"
-         height="120"
-         x="75.999863"
-         y="88" />
+         style="display:inline;enable-background:new;opacity:0.7;fill:url(#linearGradient862);fill-opacity:1;stroke-width:3.77434"
+         d="m 201.06641,138.73516 h -18.87172 l -5.2841,-7.9264 c -1.50974,-2.26463 -3.77429,-3.39678 -6.41636,-3.39678 H 133.1283 c -2.64209,0 -4.90668,1.13215 -6.41643,3.39678 l -4.90663,7.9264 h -18.87173 c -8.303506,0 -15.097327,6.79315 -15.097327,15.09738 v 64.16287 c 0,8.30423 6.793828,15.09745 15.097327,15.09745 h 98.1329 c 8.30357,0 15.0974,-6.79322 15.0974,-15.09745 v -64.16287 c 0,-8.30423 -6.79383,-15.09738 -15.0974,-15.09738 z m -94.35856,26.42017 c -4.15175,0 -7.548623,-3.39748 -7.548623,-7.5485 0,-4.15212 3.396873,-7.54888 7.548623,-7.54888 4.15181,0 7.5487,3.39676 7.5487,7.54888 0,4.15102 -3.39689,7.5485 -7.5487,7.5485 z m 45.29211,49.06586 c -16.60706,0 -30.19472,-13.58748 -30.19472,-30.19484 0,-16.60635 13.58766,-30.19381 30.19472,-30.19381 16.60714,0 30.19473,13.58746 30.19473,30.19381 0,16.60736 -13.58759,30.19484 -30.19473,30.19484 z"
+         id="path4" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.687469;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="path1086"
+         cx="74.948997"
+         cy="80.404152"
+         r="13.167902" />
+      <circle
+         r="13.167902"
+         cy="80.404152"
+         cx="113.75282"
+         id="circle1088"
+         style="display:inline;enable-background:new;fill:#ffbe2f;fill-opacity:1;fill-rule:evenodd;stroke:#dfa22a;stroke-width:0.687469;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <circle
+         style="display:inline;enable-background:new;fill:#28ca40;fill-opacity:1;fill-rule:evenodd;stroke:#1bac2c;stroke-width:0.687469;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1090"
+         cx="152.55663"
+         cy="80.404152"
+         r="13.167902" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:8, 16;stroke-dashoffset:4;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 71.99986,84 v 8 h 8 v -8 z m 24,0 v 8 h 8 v -8 z m 24,0 v 8 h 8 v -8 z m 24,0 v 8 h 8 v -8 z m 24,0 v 8 h 8 v -8 z m 24,0 v 8 h 8 v -8 z m 24,0 v 8 h 8 v -8 z m -144,24 v 8 h 8 v -8 z m 144,0 v 8 h 8 v -8 z m -144,24 v 8 h 8 v -8 z m 144,0 v 8 h 8 v -8 z m -144,24 v 8 h 8 v -8 z m 144,0 v 8 h 8 v -8 z m -144,24 v 8 h 8 v -8 z m 144,0 v 24 h -24 v 8 h 24 v 24 h 8 v -24 h 24 v -8 h -24 v -24 z m -144,24 v 8 h 8 v -8 z m 24,0 v 8 h 8 v -8 z m 24,0 v 8 h 8 v -8 z m 24,0 v 8 h 8 v -8 z m 24,0 v 8 h 8 v -8 z"
-         id="rect917"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:1, 2;stroke-dashoffset:4;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.99986,139 v 1 h 1 v -1 z m 3,0 v 1 h 1 v -1 z m 3,0 v 1 h 1 v -1 z m 3,0 v 1 h 1 v -1 z m 3,0 v 1 h 1 v -1 z m 3,0 v 1 h 1 v -1 z m 3,0 v 1 h 1 v -1 z m -18,3 v 1 h 1 v -1 z m 18,0 v 1 h 1 v -1 z m -18,3 v 1 h 1 v -1 z m 18,0 v 1 h 1 v -1 z m -18,3 v 1 h 1 v -1 z m 18,0 v 1 h 1 v -1 z m -18,3 v 1 h 1 v -1 z m 18,0 v 3 h -3 v 1 h 3 v 3 h 1 v -3 h 3 v -1 h -3 v -3 z m -18,3 v 1 h 1 v -1 z m 3,0 v 1 h 1 v -1 z m 3,0 v 1 h 1 v -1 z m 3,0 v 1 h 1 v -1 z m 3,0 v 1 h 1 v -1 z"
-         id="path938"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.00000002, 1.00000002;stroke-dashoffset:0.5;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 323.99986,193 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z m -14,2 v 1 h 1 v -1 z m 14,0 v 1 h 1 v -1 z m -14,2 v 1 h 1 v -1 z m 14,0 v 1 h 1 v -1 z m -14,2 v 1 h 1 v -1 z m 14,0 v 1 h 1 v -1 z m -14,2 v 1 h 1 v -1 z m 14,0 v 1 h 1 v -1 z m -14,2 v 1 h 1 v -1 z m 14,0 v 2 h -2 v 1 h 2 v 2 h 1 v -2 h 2 v -1 h -2 v -2 z m -14,2 v 0.5 0.5 h 0.5 0.5 v -0.5 -0.5 h -0.5 z m 2,0 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z m 2,0 v 1 h 1 v -1 z"
-         id="rect942"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.00000002, 2.00000002;stroke-dashoffset:1;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.99986,70 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m -28,4 v 2 h 2 v -2 z m 28,0 v 2 h 2 v -2 z m -28,4 v 2 h 2 v -2 z m 28,0 v 2 h 2 v -2 z m -28,4 v 2 h 2 v -2 z m 28,0 v 2 h 2 v -2 z m -28,4 v 2 h 2 v -2 z m 28,0 v 2 h 2 v -2 z m -28,4 v 2 h 2 v -2 z m 28,0 v 4 h -4 v 2 h 4 v 4 h 2 v -4 h 4 v -2 h -4 v -4 z m -28,4 v 1 1 h 1 1 v -1 -1 h -1 z m 4,0 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z"
-         id="rect949"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
          inkscape:connector-curvature="0"
-         id="path890"
-         d="m 333.99986,245 h -5 v 1 h 5 z m -6,0 h -1 v 1 h 1 z m -2,0 h -1 v 1 h 1 z m -2,0.5 V 245 h -0.5 -0.5 v 0.5 0.5 h 0.5 0.5 z m 8,-2.5 h -1 v 5 h 1 z m -8,0 h -1 v 1 h 1 z m 8,-2 h -1 v 1 h 1 z m -8,0 h -1 v 1 h 1 z m 8,-2 h -1 v 1 h 1 z m -8,0 h -1 v 1 h 1 z m 6,0 h -1 v 1 h 1 z m -2,0 h -1 v 1 h 1 z m -2,0 h -1 v 1 h 1 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.00000002, 1.00000002;stroke-dashoffset:0.5;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-      <rect
-         style="display:inline;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         id="rect904"
-         width="28"
-         height="24"
-         x="328.99985"
-         y="71" />
-      <rect
-         style="display:inline;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         id="rect906"
-         width="17"
-         height="14"
-         x="326.99985"
-         y="140" />
-      <rect
-         style="display:inline;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:1;stroke-opacity:1;enable-background:new"
-         id="rect908"
-         width="13"
-         height="11"
-         x="324.99985"
-         y="194" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer4"
-       inkscape:label="Borders"
-       style="display:inline;opacity:1">
+         style="display:inline;enable-background:new;opacity:0.7;fill:url(#linearGradient1210);fill-opacity:1;stroke-width:0.775089"
+         d="m 354.07614,80.454541 h -3.87544 l -1.08513,-1.627743 c -0.31004,-0.465057 -0.77508,-0.697552 -1.31765,-0.697552 h -7.67336 c -0.54257,0 -1.00762,0.232495 -1.31766,0.697552 l -1.00761,1.627743 h -3.87545 c -1.70518,0 -3.10034,1.395023 -3.10034,3.100355 v 13.176305 c 0,1.705332 1.39516,3.100367 3.10034,3.100367 h 20.1523 c 1.70519,0 3.10036,-1.395035 3.10036,-3.100367 V 83.554896 c 0,-1.705332 -1.39517,-3.100355 -3.10036,-3.100355 z m -19.37721,5.425572 c -0.85259,0 -1.55016,-0.697698 -1.55016,-1.55014 0,-0.852666 0.69757,-1.550215 1.55016,-1.550215 0.85261,0 1.55018,0.697549 1.55018,1.550215 0,0.852442 -0.69757,1.55014 -1.55018,1.55014 z m 9.30106,10.076024 c -3.41038,0 -6.2007,-2.790285 -6.2007,-6.200726 0,-3.410232 2.79032,-6.200515 6.2007,-6.200515 3.4104,0 6.20071,2.790283 6.20071,6.200515 0,3.410441 -2.79031,6.200726 -6.20071,6.200726 z"
+         id="path1194" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.141177;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1198"
+         cx="328.17703"
+         cy="68.475853"
+         r="2.7041228" />
+      <circle
+         r="2.7041228"
+         cy="68.475853"
+         cx="336.14566"
+         id="circle1200"
+         style="display:inline;enable-background:new;fill:#ffbe2f;fill-opacity:1;fill-rule:evenodd;stroke:#dfa22a;stroke-width:0.141177;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <circle
+         style="display:inline;enable-background:new;fill:#28ca40;fill-opacity:1;fill-rule:evenodd;stroke:#1bac2c;stroke-width:0.141177;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1202"
+         cx="344.11432"
+         cy="68.475853"
+         r="2.7041228" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92188,43.999698 c -35.296728,0 -39.09487,3.62603 -38.92188,38.99414 v 2 c -0.17299,-35.36811 3.625152,-38.99414 38.92188,-38.99414 h 146.15624 c 35.29673,0 38.92188,3.62561 38.92188,38.99414 v -2 c 0,-35.36853 -3.62515,-38.99414 -38.92188,-38.99414 z"
-         id="path931"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
+         style="display:inline;enable-background:new;opacity:0.7;fill:url(#linearGradient1232);fill-opacity:1;stroke-width:0.505493"
+         d="m 342.5714,145.68774 h -2.52747 l -0.70769,-1.06157 c -0.2022,-0.3033 -0.50548,-0.45493 -0.85933,-0.45493 h -5.00437 c -0.35385,0 -0.65714,0.15163 -0.85934,0.45493 l -0.65714,1.06157 h -2.52746 c -1.11208,0 -2.02197,0.9098 -2.02197,2.02197 v 8.59324 c 0,1.11218 0.90989,2.02198 2.02197,2.02198 h 13.1428 c 1.11208,0 2.02197,-0.9098 2.02197,-2.02198 v -8.59324 c 0,-1.11217 -0.90989,-2.02197 -2.02197,-2.02197 z m -12.63731,3.53842 c -0.55604,0 -1.01098,-0.45502 -1.01098,-1.01096 0,-0.55609 0.45494,-1.01101 1.01098,-1.01101 0.55605,0 1.01099,0.45492 1.01099,1.01101 0,0.55594 -0.45494,1.01096 -1.01099,1.01096 z M 336,155.79748 c -2.22416,0 -4.04394,-1.81976 -4.04394,-4.04396 0,-2.22406 1.81978,-4.04381 4.04394,-4.04381 2.22417,0 4.04393,1.81975 4.04393,4.04381 0,2.2242 -1.81976,4.04396 -4.04393,4.04396 z"
+         id="path1216" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.0920718;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1220"
+         cx="325.68066"
+         cy="137.87555"
+         r="1.7635583" />
+      <circle
+         r="1.7635583"
+         cy="137.87555"
+         cx="330.87762"
+         id="circle1222"
+         style="display:inline;enable-background:new;fill:#ffbe2f;fill-opacity:1;fill-rule:evenodd;stroke:#dfa22a;stroke-width:0.0920718;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <circle
+         style="display:inline;enable-background:new;fill:#28ca40;fill-opacity:1;fill-rule:evenodd;stroke:#1bac2c;stroke-width:0.0920718;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1224"
+         cx="336.07455"
+         cy="137.87555"
+         r="1.7635583" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92728,267.9997 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 c -0.17299,35.36811 3.625154,38.99414 38.921885,38.99414 h 146.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 c 0,35.36853 -3.62515,38.99414 -38.92188,38.99414 z"
-         id="path931-8"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
+         style="display:inline;enable-background:new;opacity:0.7;fill:url(#linearGradient1254);fill-opacity:1;stroke-width:0.387544"
+         d="m 337.03807,198.22727 h -1.93772 l -0.54257,-0.81387 c -0.15501,-0.23253 -0.38753,-0.34878 -0.65882,-0.34878 h -3.83668 c -0.27128,0 -0.50381,0.11625 -0.65883,0.34878 l -0.5038,0.81387 h -1.93773 c -0.85259,0 -1.55017,0.69751 -1.55017,1.55017 v 6.58816 c 0,0.85266 0.69758,1.55018 1.55017,1.55018 h 10.07615 c 0.8526,0 1.55018,-0.69752 1.55018,-1.55018 v -6.58816 c 0,-0.85266 -0.69758,-1.55017 -1.55018,-1.55017 z m -9.6886,2.71278 c -0.4263,0 -0.77508,-0.34885 -0.77508,-0.77507 0,-0.42633 0.34878,-0.7751 0.77508,-0.7751 0.4263,0 0.77509,0.34877 0.77509,0.7751 0,0.42622 -0.34879,0.77507 -0.77509,0.77507 z M 332,205.97806 c -1.70519,0 -3.10035,-1.39514 -3.10035,-3.10036 0,-1.70511 1.39516,-3.10026 3.10035,-3.10026 1.70519,0 3.10035,1.39515 3.10035,3.10026 0,1.70522 -1.39516,3.10036 -3.10035,3.10036 z"
+         id="path1238" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.0705884;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1242"
+         cx="324.0885"
+         cy="192.23792"
+         r="1.3520615" />
+      <circle
+         r="1.3520615"
+         cy="192.23792"
+         cx="328.07285"
+         id="circle1244"
+         style="display:inline;enable-background:new;fill:#ffbe2f;fill-opacity:1;fill-rule:evenodd;stroke:#dfa22a;stroke-width:0.0705884;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <circle
+         style="display:inline;enable-background:new;fill:#28ca40;fill-opacity:1;fill-rule:evenodd;stroke:#1bac2c;stroke-width:0.0705884;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1246"
+         cx="332.05716"
+         cy="192.23792"
+         r="1.3520615" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500047 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 V 84 96.75181 c -0.0527,8.84203 1.82291,9.74838 11.83407,9.74838 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path958"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 337.97659,211.50015 c 4.67187,0 5.5471,-0.42296 5.52255,-4.54923 v -7.95037 -5.95084 c 0.0245,-4.12627 -0.85068,-4.54923 -5.52255,-4.54923 h -11.95364 c -4.67071,0 -5.52256,0.42291 -5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 0.85185,4.54923 5.52256,4.54923 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.55494,251.5 c 3.33705,0 3.96221,-0.30212 3.94468,-3.24946 v -4.2505 -4.25059 c 0.0175,-2.94734 -0.60763,-3.24945 -3.94468,-3.24945 h -7.11025 c -3.33622,0 -3.94469,0.30208 -3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 0.60847,3.24946 3.94469,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline;opacity:0.7">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.44531,237 c -1.65302,0 -2.54604,0.12548 -2.91601,0.41406 -0.18499,0.14429 -0.30479,0.33122 -0.39649,0.70313 C 321.0411,238.4891 321,239.03036 321,239.75 v 4.25 4.25 c 0,0.71964 0.0411,1.26082 0.13281,1.63281 0.0917,0.37191 0.2115,0.55884 0.39649,0.70313 0.36997,0.28858 1.26299,0.41406 2.91601,0.41406 h 7.10938 c 1.65343,0 2.55203,-0.12511 2.92383,-0.41406 0.18589,-0.14448 0.30578,-0.33208 0.39648,-0.70313 0.0907,-0.37105 0.129,-0.90979 0.125,-1.6289 v -0.002 V 244 v -4.25195 -0.002 c 0.004,-0.71911 -0.0343,-1.25785 -0.125,-1.6289 -0.0907,-0.37105 -0.21059,-0.55865 -0.39648,-0.70313 C 334.10673,237.12512 333.20812,237 331.55469,237 Z m 5.32813,1.04688 c 1.10767,-3.4e-4 2.21363,0.008 3.32031,0.0449 0.26616,0.0599 0.75737,-0.0208 0.79297,0.3457 0.13405,1.84438 0.0662,3.68774 0.10156,5.53906 -0.0126,1.86745 0.0543,3.67031 -0.10351,5.49805 0.0642,0.42314 -0.43946,0.35577 -0.70313,0.42187 -3.43277,0.0703 -6.87577,0.0589 -10.29883,0.002 -0.22288,-0.0398 -0.55622,-3.2e-4 -0.71093,-0.1875 -0.19863,-1.12995 -0.12696,-2.26946 -0.16016,-3.41992 0.0138,-2.55648 -0.029,-5.10728 0.0898,-7.65625 -0.03,-0.2727 0.10944,-0.49629 0.40039,-0.48829 1.30659,-0.161 2.63265,-0.0636 3.94727,-0.0976 1.10718,0.006 2.21655,-0.002 3.32422,-0.002 z"
-         id="path918-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate"
-         d="m 326.02383,189.00048 c -2.32027,0 -3.60941,0.15494 -4.20703,0.62109 -0.29882,0.23308 -0.48964,0.54668 -0.625,1.09571 -0.13541,0.54902 -0.19141,1.31765 -0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 0.056,1.783 0.19141,2.33203 0.13536,0.54903 0.32618,0.86263 0.625,1.09571 0.59762,0.46615 1.88676,0.62109 4.20703,0.62109 h 11.9524 c 2.32085,0 3.61652,-0.15457 4.2168,-0.62109 0.30014,-0.23327 0.49095,-0.54754 0.625,-1.09571 0.13404,-0.54816 0.18764,-1.31623 0.18164,-2.33008 v -7.95279 -5.95312 c 0.006,-1.01386 -0.0476,-1.78191 -0.18164,-2.33008 -0.13406,-0.54817 -0.32486,-0.86244 -0.625,-1.09571 -0.60028,-0.46652 -1.89595,-0.62109 -4.2168,-0.62109 z m 4.95859,1.00977 c 1.5798,-0.002 4.16014,-3.9e-4 5.73991,0.0117 1.50021,0.0511 3.02236,-0.0712 4.5,0.28321 0.55111,0.0919 0.61303,0.71807 0.67773,1.16601 0.1117,4.30832 0.075,10.62608 0.0508,14.94108 -0.0716,0.99089 0.13687,2.07606 -0.30078,3.01366 -0.34356,0.40964 -0.9694,0.35958 -1.45117,0.45509 -3.95407,0.0823 -9.92936,0.0499 -13.89381,0.0371 -1.16908,-0.0622 -2.37292,0.11291 -3.51758,-0.22266 -0.57935,-0.098 -0.6137,-0.75914 -0.6875,-1.2207 -0.1146,-4.11835 -0.0751,-10.24472 -0.0547,-14.36881 0.0572,-1.06305 -0.0797,-2.16734 0.18164,-3.21485 0.10495,-0.6386 0.8614,-0.66043 1.36719,-0.74023 2.1305,-0.19658 5.24071,-0.10662 7.38828,-0.14062 z"
-         id="path914-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12695,134 c -3.21072,0 -5.03255,0.19514 -5.9375,0.89844 -0.45247,0.35165 -0.74178,0.83286 -0.93359,1.61718 -0.19176,0.78433 -0.26386,1.85686 -0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c -0.008,1.40682 0.0641,2.47935 0.25586,3.26368 0.1918,0.78431 0.48112,1.26553 0.93359,1.61718 0.90496,0.7033 2.72678,0.89844 5.9375,0.89844 h 13.7461 c 3.20992,0 5.02461,-0.19551 5.92578,-0.89844 0.45058,-0.35146 0.73805,-0.83201 0.93164,-1.61718 C 349.9241,158.69918 350,157.62415 350,156.2168 V 148 139.7832 c 0,-1.40735 -0.0759,-2.48237 -0.26953,-3.26758 -0.19359,-0.78517 -0.48106,-1.26572 -0.93164,-1.61718 C 347.89766,134.19551 346.08297,134 342.87305,134 Z m 6.49805,1.04688 c 3.45647,0.0171 6.9142,-0.0268 10.36133,0.0918 0.8211,0.13276 1.80664,0.14835 2.39062,0.82617 0.67884,1.16473 0.51296,2.58781 0.56446,3.87305 0.0431,6.02893 0.0678,12.06719 -0.0332,18.08789 -0.0775,0.77792 -0.12055,1.67263 -0.67968,2.27539 -0.70249,0.51038 -1.61833,0.59683 -2.45899,0.67383 -4.04742,0.0864 -8.16222,0.0456 -12.24023,0.0606 -2.45188,-0.0199 -4.91402,0.0317 -7.35352,-0.0606 -0.87784,-0.12055 -1.915,-0.14021 -2.56055,-0.83398 -0.64775,-1.02591 -0.50264,-2.30525 -0.56054,-3.46485 -0.035,-5.65575 -0.0351,-11.35518 0,-17.00976 0.0632,-1.22153 -0.10864,-2.57724 0.59179,-3.65235 0.6025,-0.62665 1.55621,-0.63986 2.35938,-0.77344 2.73743,-0.10739 5.48083,-0.0704 8.22656,-0.0918 0.46403,-2.9e-4 0.92855,-0.002 1.39258,-0.002 z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33594,62 c -4.99049,0 -7.87051,0.276282 -9.38477,1.453125 -0.75713,0.588421 -1.23761,1.403518 -1.54492,2.660156 -0.3073,1.256638 -0.4173,2.940031 -0.4043,5.132813 V 84 96.753906 c -0.0131,2.19278 0.097,3.876174 0.4043,5.132814 0.30731,1.25663 0.78779,2.07172 1.54492,2.66016 1.51427,1.17683 4.39428,1.45312 9.38477,1.45312 h 21.33008 c 4.98923,0 7.85502,-0.27668 9.36328,-1.45312 0.75412,-0.58824 1.23293,-1.40461 1.54297,-2.66211 C 365.8823,100.62727 366,98.945281 366,96.751953 V 84 71.248047 c 0,-2.193329 -0.1177,-3.875313 -0.42773,-5.132813 -0.31004,-1.257499 -0.78884,-2.073874 -1.54297,-2.662109 C 362.52104,62.276656 359.65526,62 354.66602,62 Z m 2.40234,1.097656 c 6.94737,8.3e-4 13.91063,0.0034 20.84961,0.05469 2.14296,0.08293 4.46431,-0.147701 6.42383,0.93164 1.29609,0.695228 1.54862,2.250325 1.76953,3.564454 0.17551,2.202888 0.0915,4.442228 0.13867,6.669921 0.0227,8.479532 0.077,16.968993 -0.0801,25.447266 -0.16151,1.483233 -0.38135,3.305793 -1.79882,4.142573 -1.6055,0.82871 -3.47551,0.90643 -5.24805,0.95313 -9.49974,0.0678 -19.0243,0.0843 -28.52344,-0.0176 -1.57816,-0.11413 -3.27053,-0.24014 -4.63281,-1.12109 -1.22952,-0.99538 -1.36082,-2.72739 -1.50391,-4.193361 -0.1272,-8.998585 -0.0836,-18.004484 -0.0527,-27.007813 0.0997,-2.381275 -0.24538,-4.900002 0.70508,-7.160156 0.67165,-1.50972 2.46573,-1.859954 3.93945,-2.05664 2.66168,-0.316582 5.34184,-0.147022 8.01367,-0.207032 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
+         style="display:inline;enable-background:new;opacity:0.7;fill:url(#linearGradient1276);fill-opacity:1;stroke-width:0.252746"
+         d="m 331.28569,242.84387 h -1.26373 l -0.35384,-0.53079 c -0.1011,-0.15164 -0.25275,-0.22746 -0.42967,-0.22746 h -2.50218 c -0.17693,0 -0.32858,0.0758 -0.42967,0.22746 l -0.32857,0.53079 h -1.26374 c -0.55603,0 -1.01098,0.4549 -1.01098,1.01099 v 4.29662 c 0,0.55608 0.45495,1.01099 1.01098,1.01099 h 6.5714 c 0.55605,0 1.01099,-0.45491 1.01099,-1.01099 v -4.29662 c 0,-0.55609 -0.45494,-1.01099 -1.01099,-1.01099 z m -6.31865,1.76921 c -0.27802,0 -0.50549,-0.22751 -0.50549,-0.50548 0,-0.27804 0.22747,-0.50551 0.50549,-0.50551 0.27802,0 0.50549,0.22747 0.50549,0.50551 0,0.27797 -0.22747,0.50548 -0.50549,0.50548 z m 3.03295,3.28566 c -1.11208,0 -2.02196,-0.90988 -2.02196,-2.02198 0,-1.11203 0.90988,-2.0219 2.02196,-2.0219 1.11209,0 2.02197,0.90987 2.02197,2.0219 0,1.1121 -0.90988,2.02198 -2.02197,2.02198 z"
+         id="path1260" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.0460359;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1264"
+         cx="322.84033"
+         cy="238.93777"
+         r="0.88177919" />
+      <circle
+         r="0.88177919"
+         cy="238.93777"
+         cx="325.43881"
+         id="circle1266"
+         style="display:inline;enable-background:new;fill:#ffbe2f;fill-opacity:1;fill-rule:evenodd;stroke:#dfa22a;stroke-width:0.0460359;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke" />
+      <circle
+         style="display:inline;enable-background:new;fill:#28ca40;fill-opacity:1;fill-rule:evenodd;stroke:#1bac2c;stroke-width:0.0460359;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1268"
+         cx="328.03726"
+         cy="238.93777"
+         r="0.88177919" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/session-properties.svg
+++ b/icons/src/fullcolor/default/apps/session-properties.svg
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="session-properties.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,18 +30,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="345.24377"
-     inkscape:cy="240.3826"
-     inkscape:current-layer="layer6"
+     inkscape:zoom="2"
+     inkscape:cx="305"
+     inkscape:cy="155.5"
+     inkscape:current-layer="layer3"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1294"
-     inkscape:window-height="704"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +60,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -90,182 +90,7 @@
        originy="0" />
   </sodipodi:namedview>
   <defs
-     id="defs3">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1686"
-       x1="320.99991"
-       y1="92.000153"
-       x2="366.99991"
-       y2="76.000153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000121)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1688"
-       x1="321.00003"
-       y1="153.00002"
-       x2="351.00003"
-       y2="143.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00002,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1690"
-       x1="320.9993"
-       y1="202.99928"
-       x2="342.9993"
-       y2="196.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1692"
-       x1="320.00031"
-       y1="247.00034"
-       x2="336.00031"
-       y2="241.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1694"
-       x1="39.997601"
-       y1="203.99699"
-       x2="263.99759"
-       y2="107.997"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,151.9973,155.9997)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4338-7">
-      <stop
-         id="stop4342-6"
-         offset="0"
-         style="stop-color:#5884f4;stop-opacity:1" />
-      <stop
-         id="stop4340-2"
-         offset="1"
-         style="stop-color:#80a3fa;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1692-6"
-       x1="321.00031"
-       y1="244.00034"
-       x2="335.00031"
-       y2="244.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1690-9"
-       x1="320.9993"
-       y1="199.99928"
-       x2="342.9993"
-       y2="199.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1688-4"
-       x1="322"
-       y1="148.00002"
-       x2="350"
-       y2="148.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00001,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1686-0"
-       x1="321.99991"
-       y1="84.000153"
-       x2="365.99991"
-       y2="84.000153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000125)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58449"
-       x="-0.047999425"
-       width="1.0959988"
-       y="-0.048000575"
-       height="1.0960012">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.4800539"
-         id="feGaussianBlur58451" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58492"
-       x="-0.011999856"
-       width="1.0239997"
-       y="-0.012000144"
-       height="1.0240003">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1200135"
-         id="feGaussianBlur58494" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter927"
-       x="-0.055713851"
-       width="1.1114277"
-       y="-0.065000594"
-       height="1.1300012">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.6000235"
-         id="feGaussianBlur929" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter941"
-       x="-0.02228554"
-       width="1.044571"
-       y="-0.026000237"
-       height="1.0520005">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.0400093"
-         id="feGaussianBlur943" />
-    </filter>
-  </defs>
+     id="defs3" />
   <metadata
      id="metadata4">
     <rdf:RDF>
@@ -276,13 +101,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -364,7 +189,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">session-properties</tspan></text>
+           id="tspan924">session-properties</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -399,363 +224,525 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
+      <rect
+         x="42.545704"
+         y="59.272949"
+         width="218.9086"
+         height="193.4541"
+         rx="7.6363463"
+         ry="7.6363463"
+         color="#000000"
+         fill="#9677e2"
+         overflow="visible"
+         id="rect282"
+         style="fill:#12a327;fill-opacity:1;stroke-width:5.0909" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 50.182051,59.272949 c -4.230536,0 -7.636346,3.40581 -7.636346,7.636346 v 20.36359 H 261.4543 v -20.36359 c 0,-4.230536 -3.40581,-7.636346 -7.63635,-7.636346 z"
+         opacity="0.35"
+         id="path284"
+         style="stroke-width:5.0909" />
+      <rect
+         x="321.52274"
+         y="64.136368"
+         width="44.954544"
+         height="39.727272"
+         rx="1.5681818"
+         ry="1.5681818"
+         color="#000000"
+         fill="#9677e2"
+         overflow="visible"
+         id="rect1526"
+         style="fill:#12a327;fill-opacity:1;stroke-width:1.04545" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 323.09091,64.136365 c -0.86877,0 -1.56818,0.699409 -1.56818,1.568182 v 4.181818 h 44.95454 v -4.181818 c 0,-0.868773 -0.69941,-1.568182 -1.56818,-1.568182 z"
+         opacity="0.35"
+         id="path1528"
+         style="stroke-width:1.04545" />
+      <rect
+         x="321.34091"
+         y="135.04546"
+         width="29.318182"
+         height="25.90909"
+         rx="1.0227273"
+         ry="1.0227273"
+         color="#000000"
+         fill="#9677e2"
+         overflow="visible"
+         id="rect1550"
+         style="fill:#12a327;fill-opacity:1;stroke-width:0.681818" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.12858,237.00001 c -3.74357,0 -4.14638,0.30899 -4.12803,3.32331 v 4.17669 4.17668 c -0.0183,3.01433 0.38446,3.32332 4.12803,3.32332 h 7.74335 c 3.7436,0 4.12805,-0.30895 4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 -0.38446,-3.32331 -4.12805,-3.32331 z"
-         id="path918-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 322.36363,135.04546 c -0.56659,0 -1.02272,0.45613 -1.02272,1.02273 v 2.72727 h 29.31818 v -2.72727 c 0,-0.5666 -0.45614,-1.02273 -1.02273,-1.02273 z"
+         opacity="0.35"
+         id="path1552"
+         style="stroke-width:0.681818" />
+      <rect
+         x="320.76138"
+         y="190.06819"
+         width="22.477272"
+         height="19.863636"
+         rx="0.78409088"
+         ry="0.78409088"
+         color="#000000"
+         fill="#9677e2"
+         overflow="visible"
+         id="rect1574"
+         style="fill:#12a327;fill-opacity:1;stroke-width:0.522727" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 326.45275,189.00048 c -1.2321,0 -2.21668,0.0221 -3.06999,0.14144 -0.85332,0.11937 -1.62809,0.35533 -2.21066,0.83967 -0.58256,0.48436 -0.86983,1.13381 -1.01188,1.84587 -0.14202,0.71207 -0.16501,1.53239 -0.15897,2.56202 v 7.61066 4.6143 c -0.006,1.02762 0.0171,1.84735 0.15897,2.55843 0.14203,0.71208 0.42931,1.36152 1.01188,1.84587 0.58258,0.48434 1.35734,0.7203 2.21066,0.83967 0.85331,0.11936 1.83789,0.14144 3.06999,0.14144 h 11.09542 c 1.2321,0 2.21381,-0.022 3.0657,-0.14144 0.85187,-0.11947 1.62795,-0.35683 2.2085,-0.84146 0.58057,-0.48464 0.86451,-1.13152 1.00758,-1.84228 0.14307,-0.71077 0.16972,-1.5314 0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 -0.0266,-1.84946 -0.16972,-2.56023 -0.14307,-0.71076 -0.42701,-1.35765 -1.00758,-1.84228 -0.58055,-0.48464 -1.35661,-0.722 -2.2085,-0.84147 -0.8519,-0.11947 -1.83359,-0.14144 -3.0657,-0.14144 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         d="m 321.54546,190.06819 c -0.43439,0 -0.78409,0.3497 -0.78409,0.78409 v 2.09091 h 22.47727 v -2.09091 c 0,-0.43439 -0.3497,-0.78409 -0.78409,-0.78409 z"
+         opacity="0.35"
+         id="path1576"
+         style="stroke-width:0.522727" />
+      <rect
+         x="320.67072"
+         y="237.52295"
+         width="14.658589"
+         height="12.954103"
+         rx="0.51134616"
+         ry="0.51134616"
+         color="#000000"
+         fill="#9677e2"
+         overflow="visible"
+         id="rect1598"
+         style="fill:#12a327;fill-opacity:1;stroke-width:0.340897" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 329.30094,134 c -1.63949,0 -2.94082,0.0308 -4.04505,0.19141 -1.10422,0.16064 -2.06697,0.4726 -2.78308,1.09179 -0.71611,0.61919 -1.0805,1.45612 -1.26421,2.41407 -0.18374,0.95795 -0.21537,2.08705 -0.20733,3.51171 V 149 v 7.79688 c -0.009,1.42131 0.0239,2.5495 0.20733,3.50585 0.18371,0.95796 0.5481,1.79488 1.26421,2.41407 0.71611,0.61919 1.67886,0.93115 2.78308,1.09179 1.10423,0.16065 2.40556,0.19141 4.04505,0.19141 h 13.40164 c 1.63949,0 2.93835,-0.0307 4.04054,-0.19141 1.10219,-0.16075 2.06274,-0.47425 2.77633,-1.09375 0.71357,-0.6195 1.07457,-1.45363 1.25969,-2.41015 C 350.96429,159.34816 351,158.22066 351,156.79688 V 149 141.20312 c 0,-1.42378 -0.0358,-2.55128 -0.22086,-3.50781 -0.18512,-0.95653 -0.54612,-1.79065 -1.25969,-2.41015 -0.71359,-0.61951 -1.67414,-0.933 -2.77633,-1.09375 C 345.64093,134.03065 344.34207,134 342.70258,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 333.65776,62 c -2.6221,0 -4.68675,0.05009 -6.38561,0.286735 -1.69887,0.236639 -3.08904,0.680503 -4.10735,1.523515 -1.0183,0.843013 -1.55577,1.996072 -1.83828,3.406406 -0.28252,1.410336 -0.33767,3.127346 -0.32482,5.308412 v 12.474816 12.480783 c -0.0127,2.177715 0.0426,3.893853 0.32482,5.302673 0.28251,1.41034 0.81998,2.5634 1.83828,3.40641 1.01831,0.84301 2.40848,1.28688 4.10735,1.52351 1.69888,0.23665 3.76351,0.28674 6.38561,0.28674 h 20.68618 c 2.62213,0 4.68568,-0.05 6.38104,-0.28674 1.69534,-0.23674 3.08126,-0.6821 4.09581,-1.52542 1.01457,-0.84331 1.54885,-1.99555 1.83367,-3.4045 C 366.93929,101.37441 367,99.660878 367,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0608,-3.893733 -0.34554,-5.302677 -0.28482,-1.408942 -0.81911,-2.561177 -1.83368,-3.404494 -1.01455,-0.843317 -2.40047,-1.288685 -4.09582,-1.525427 C 359.02962,62.049992 356.96605,62 354.34394,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500049 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 v 12.75157 12.75181 c -0.0527,8.842031 1.82291,9.748381 11.83407,9.748381 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.748381 v -12.75181 -12.75157 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1694);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 225.07297,43.999694 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.006466 73.00648 c 0.17299,35.36812 -3.62489,38.99353 -38.92162,38.99353 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 155.99969 82.993224 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 326.17688,188.49945 c -5.14666,0 -5.70043,0.43262 -5.67521,4.65309 v 5.84793 7.84761 c -0.0253,4.22046 0.52855,4.65307 5.67521,4.65307 h 11.64568 c 5.14665,0 5.67521,-0.43255 5.67521,-4.65307 v -7.84761 -5.84793 c 0,-4.22051 -0.52857,-4.65309 -5.67522,-4.65309 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.4056,236.50001 c -3.47604,0 -3.85006,0.30899 -3.83302,3.32331 v 4.17669 4.17668 c -0.017,3.01433 0.35698,3.32332 3.83302,3.32332 h 7.18996 c 3.47605,0 3.83303,-0.30895 3.83303,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.35699,-3.32331 -3.83303,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 321.18205,237.52294 c -0.28329,0 -0.51135,0.22806 -0.51135,0.51135 v 1.36359 h 14.65859 v -1.36359 c 0,-0.28329 -0.22806,-0.51135 -0.51134,-0.51135 z"
+         opacity="0.35"
+         id="path1600"
+         style="stroke-width:0.340897" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms and folds"
+       inkscape:label="Pictogram"
        style="display:inline">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 39.994,156 v 8 65.00586 C 39.994,264.37439 43.619165,268 78.915875,268 H 225.07213 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 164 156 Z"
-         id="rect4158-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscccc" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.99999988;filter:url(#filter941);enable-background:new"
-         d="m 221.14973,134.00213 c 4.23134,-0.0532 7.07155,0.89696 8.53084,2.64832 1.53216,1.82431 2.32023,4.81666 2.32023,8.97616 v 72.74891 c 0,4.15961 -0.78807,7.15179 -2.32023,8.97615 C 228.22128,229.10311 225.38141,230 221.14973,230 h -90.2997 c -4.23168,0 -7.07943,-0.89689 -8.53872,-2.64833 -1.53216,-1.82437 -2.31239,-4.81655 -2.31239,-8.97616 v -72.7489 c 0,-4.1595 0.78023,-7.15185 2.31239,-8.97616 1.4592,-1.75136 4.30704,-2.64832 8.53872,-2.64832 z"
-         id="path931-3"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccsscsscsscsc" />
-      <path
-         sodipodi:nodetypes="ccsscsscsscsc"
-         inkscape:connector-curvature="0"
-         id="path919"
-         d="m 221.14973,132.00213 c 4.23134,-0.0532 7.07155,0.89696 8.53084,2.64832 1.53216,1.82431 2.32023,4.81666 2.32023,8.97616 v 72.74891 c 0,4.15961 -0.78807,7.15179 -2.32023,8.97615 C 228.22128,227.10311 225.38141,228 221.14973,228 h -90.2997 c -4.23168,0 -7.07943,-0.89689 -8.53872,-2.64833 -1.53216,-1.82437 -2.31239,-4.81655 -2.31239,-8.97616 v -72.7489 c 0,-4.1595 0.78023,-7.15185 2.31239,-8.97616 1.4592,-1.75136 4.30704,-2.64832 8.53872,-2.64832 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#a2bcfe;fill-opacity:1;stroke:none;stroke-width:1.99999988;enable-background:new" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#a2bcfe;fill-opacity:1;stroke:none;stroke-width:1.99999988;enable-background:new"
-         d="m 357.28662,80.000533 c 1.05783,-0.0133 1.76788,0.22424 2.13271,0.66208 0.38304,0.456078 0.58005,1.204166 0.58005,2.244041 v 12.187227 c 0,1.039902 -0.19701,1.787947 -0.58005,2.244038 -0.36483,0.43786 -1.07479,0.662082 -2.13271,0.662082 h -16.57493 c -1.05792,0 -1.76986,-0.224222 -2.13468,-0.662082 -0.38304,-0.456093 -0.5781,-1.204138 -0.5781,-2.24404 V 82.906654 c 0,-1.039875 0.19506,-1.787963 0.5781,-2.24404 0.3648,-0.437841 1.07676,-0.66208 2.13468,-0.66208 z"
-         id="path945"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccsscsscsscsc" />
-      <path
-         sodipodi:nodetypes="ccsscsscsscsc"
-         inkscape:connector-curvature="0"
-         id="path956"
-         d="m 338.64276,198.00027 c 0.52892,-0.007 0.88394,0.11212 1.06636,0.33104 0.19152,0.22803 0.29002,0.60208 0.29002,1.12202 v 6.09361 c 0,0.51995 -0.0985,0.89397 -0.29002,1.12202 C 339.5267,206.88789 339.17172,207 338.64276,207 h -8.28746 c -0.52896,0 -0.88493,-0.11211 -1.06734,-0.33104 -0.19152,-0.22805 -0.28905,-0.60207 -0.28905,-1.12202 v -6.09361 c 0,-0.51994 0.0975,-0.89399 0.28905,-1.12202 0.1824,-0.21892 0.53838,-0.33104 1.06734,-0.33104 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#a2bcfe;fill-opacity:1;stroke:none;stroke-width:1.99999988;enable-background:new" />
-      <path
-         sodipodi:nodetypes="ccsscsscsscsc"
-         inkscape:connector-curvature="0"
-         id="path968"
-         d="m 332.01342,242.00376 c 0.38466,-0.005 0.64285,0.0815 0.77552,0.24075 0.13929,0.16584 0.21092,0.43787 0.21092,0.816 v 3.88274 c 0,0.37814 -0.0716,0.65015 -0.21092,0.816 C 332.65627,247.91847 332.39811,248 332.01342,248 h -5.02712 c -0.38469,0 -0.64357,-0.0815 -0.77623,-0.24075 -0.13928,-0.16585 -0.21021,-0.43786 -0.21021,-0.816 v -3.88274 c 0,-0.37813 0.0709,-0.65016 0.21021,-0.816 0.13265,-0.15921 0.39154,-0.24076 0.77623,-0.24076 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#a2bcfe;fill-opacity:1;stroke:none;stroke-width:1.99999976;enable-background:new" />
-      <path
-         id="rect15711-6"
-         style="display:inline;opacity:0.1;fill:#000000;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
-         d="m 130.85003,132.00213 c -4.23167,0 -7.07987,0.89708 -8.53906,2.64844 -1.53217,1.82432 -2.3125,4.81706 -2.3125,8.97656 v 4.37305 h 112.00195 v -4.37305 c 0,-4.1595 -0.78815,-7.15224 -2.32031,-8.97656 -1.45929,-1.75136 -4.29796,-2.70168 -8.5293,-2.64844 z" />
-      <path
-         sodipodi:nodetypes="ccsscsscsscsc"
-         inkscape:connector-curvature="0"
-         id="path921"
-         d="m 173.14973,86.002126 c 4.23134,-0.05324 7.07155,0.896961 8.53084,2.648322 1.53216,1.824317 2.32023,4.816665 2.32023,8.976166 v 72.748906 c 0,4.15961 -0.78807,7.15179 -2.32023,8.97615 C 180.22128,181.10311 177.38141,182 173.14973,182 H 82.850025 c -4.23167,0 -7.07942,-0.89689 -8.53871,-2.64833 -1.53217,-1.82437 -2.3124,-4.81655 -2.3124,-8.97616 V 97.626614 c 0,-4.159501 0.78023,-7.151849 2.3124,-8.976166 1.45919,-1.751361 4.30704,-2.648322 8.53871,-2.648322 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.99999988;filter:url(#filter927);enable-background:new" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.99999988;enable-background:new"
-         d="m 173.14973,84.002126 c 4.23134,-0.05324 7.07155,0.896961 8.53084,2.648322 1.53216,1.824317 2.32023,4.816665 2.32023,8.976166 v 72.748906 c 0,4.15961 -0.78807,7.15179 -2.32023,8.97615 C 180.22128,179.10311 177.38141,180 173.14973,180 H 82.850025 c -4.23167,0 -7.07942,-0.89689 -8.53871,-2.64833 -1.53217,-1.82437 -2.3124,-4.81655 -2.3124,-8.97616 V 95.626614 c 0,-4.159501 0.78023,-7.151849 2.3124,-8.976166 1.45919,-1.751361 4.30704,-2.648322 8.53871,-2.648322 z"
-         id="path1442"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccsscsscsscsc" />
-      <path
-         id="rect15711"
-         style="fill:#000000;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;opacity:0.1"
-         d="M 82.849609 84.001953 C 78.617939 84.001953 75.769737 84.89903 74.310547 86.650391 C 72.778377 88.474708 71.998047 91.467452 71.998047 95.626953 L 71.998047 100 L 184 100 L 184 95.626953 C 184 91.467452 183.21185 88.474708 181.67969 86.650391 C 180.2204 84.89903 177.38173 83.948713 173.15039 84.001953 L 82.849609 84.001953 z " />
       <rect
-         ry="4"
-         rx="4"
-         y="-176"
-         x="-96"
-         height="8"
-         width="8"
-         id="rect4414"
-         style="display:inline;fill:#e95420;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:0.25098;enable-background:new"
-         transform="matrix(0,-1,-1,0,0,0)" />
-      <rect
-         ry="4"
-         rx="4"
-         y="-224"
-         x="-144"
-         height="8"
-         width="8"
-         id="rect4414-7"
-         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:0.25098;enable-background:new;opacity:0.2"
-         transform="matrix(0,-1,-1,0,0,0)" />
+         x="80.72744"
+         y="153.45456"
+         width="91.636162"
+         height="61.090775"
+         rx="5.0908976"
+         ry="5.0908976"
+         fill="#ffffff"
+         opacity="0.75"
+         stroke="#000000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         stroke-opacity="0.196"
+         style="display:inline;enable-background:new;stroke-width:5.09088;paint-order:fill markers stroke"
+         id="rect292" />
       <path
-         id="rect17405-3"
-         style="display:inline;opacity:0.1;fill:#000000;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
-         d="m 340.71169,80.000534 c -1.05792,0 -1.76997,0.224269 -2.13477,0.662109 -0.38304,0.456079 -0.57812,1.204266 -0.57812,2.244141 v 1.09375 h 22.00195 v -1.09375 c 0,-1.039875 -0.19704,-1.788062 -0.58008,-2.244141 -0.36483,-0.43784 -1.07498,-0.675419 -2.13281,-0.662109 z" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.99999988;enable-background:new"
-         d="m 347.28662,71.000531 c 1.05783,-0.01331 1.76788,0.224241 2.13271,0.662081 0.38304,0.456079 0.58005,1.204166 0.58005,2.244041 v 12.187228 c 0,1.039902 -0.19701,1.787947 -0.58005,2.244038 -0.36483,0.43786 -1.07479,0.662082 -2.13271,0.662082 h -16.57493 c -1.05792,0 -1.76985,-0.224222 -2.13468,-0.662082 -0.38304,-0.456093 -0.5781,-1.204138 -0.5781,-2.24404 V 73.906653 c 0,-1.039875 0.19506,-1.787962 0.5781,-2.244041 0.3648,-0.43784 1.07676,-0.662081 2.13468,-0.662081 z"
-         id="path973-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccsscsscsscsc" />
-      <path
-         sodipodi:nodetypes="ccsscsscsscsc"
-         inkscape:connector-curvature="0"
-         id="path947"
-         d="m 347.28662,70.000531 c 1.05783,-0.01331 1.76788,0.224241 2.13271,0.662081 0.38304,0.456079 0.58005,1.204166 0.58005,2.244041 v 12.187228 c 0,1.039902 -0.19701,1.787947 -0.58005,2.244038 -0.36483,0.43786 -1.07479,0.662082 -2.13271,0.662082 h -16.57493 c -1.05792,0 -1.76985,-0.224222 -2.13468,-0.662082 -0.38304,-0.456093 -0.5781,-1.204138 -0.5781,-2.24404 V 72.906653 c 0,-1.039875 0.19506,-1.787962 0.5781,-2.244041 0.3648,-0.43784 1.07676,-0.662081 2.13468,-0.662081 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.99999988;enable-background:new" />
-      <path
-         id="rect17405"
-         style="opacity:0.1;fill:#000000;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-         d="M 330.71094 70 C 329.65302 70 328.94097 70.224269 328.57617 70.662109 C 328.19313 71.118188 327.99805 71.866375 327.99805 72.90625 L 327.99805 74 L 350 74 L 350 72.90625 C 350 71.866375 349.80296 71.118188 349.41992 70.662109 C 349.05509 70.224269 348.34494 69.98669 347.28711 70 L 330.71094 70 z " />
-      <path
-         sodipodi:nodetypes="ccsscsscsscsc"
-         inkscape:connector-curvature="0"
-         id="path964-5-2"
-         d="m 345.02797,144.00043 c 0.76932,-0.0102 1.28571,0.16308 1.55104,0.4815 0.27857,0.33168 0.42184,0.87574 0.42184,1.632 v 8.86324 c 0,0.75628 -0.14327,1.3003 -0.42184,1.632 -0.26533,0.31844 -0.78166,0.4815 -1.55104,0.4815 h -12.05423 c -0.76938,0 -1.28715,-0.16306 -1.55246,-0.4815 -0.27857,-0.3317 -0.42043,-0.87572 -0.42043,-1.632 v -8.86324 c 0,-0.75626 0.14181,-1.30032 0.42043,-1.632 0.2653,-0.31842 0.78308,-0.48151 1.55246,-0.48151 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#a2bcfe;fill-opacity:1;stroke:none;stroke-width:2;enable-background:new" />
-      <path
-         id="rect17448-9"
-         style="display:inline;opacity:0.1;fill:#000000;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
-         d="m 332.97461,144.00084 c -0.76938,0 -1.28744,0.16204 -1.55274,0.48046 C 331.14325,144.81299 331,145.35786 331,146.11412 v 0.97656 h 16 v -0.97656 c 0,-0.75626 -0.14331,-1.30113 -0.42188,-1.63282 -0.26533,-0.31842 -0.78146,-0.49066 -1.55078,-0.48046 z" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.99999976;enable-background:new"
-         d="m 339.02602,139.90975 c 0.76932,-0.0102 1.28571,0.16308 1.55104,0.4815 0.27857,0.33168 0.42184,0.87574 0.42184,1.632 v 8.86324 c 0,0.75628 -0.14327,1.3003 -0.42184,1.632 -0.26533,0.31844 -0.78166,0.4815 -1.55104,0.4815 h -12.05423 c -0.76938,0 -1.28715,-0.16306 -1.55246,-0.4815 -0.27857,-0.3317 -0.42043,-0.87572 -0.42043,-1.632 v -8.86324 c 0,-0.75626 0.14181,-1.30032 0.42043,-1.632 0.2653,-0.31842 0.78308,-0.48151 1.55246,-0.48151 z"
-         id="path975"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccsscsscsscsc" />
-      <path
-         sodipodi:nodetypes="ccsscsscsscsc"
-         inkscape:connector-curvature="0"
-         id="path964-5"
-         d="m 339.02602,138.90975 c 0.76932,-0.0102 1.28571,0.16308 1.55104,0.4815 0.27857,0.33168 0.42184,0.87574 0.42184,1.632 v 8.86324 c 0,0.75628 -0.14327,1.3003 -0.42184,1.632 -0.26533,0.31844 -0.78166,0.4815 -1.55104,0.4815 h -12.05423 c -0.76938,0 -1.28715,-0.16306 -1.55246,-0.4815 -0.27857,-0.3317 -0.42043,-0.87572 -0.42043,-1.632 v -8.86324 c 0,-0.75626 0.14181,-1.30032 0.42043,-1.632 0.2653,-0.31842 0.78308,-0.48151 1.55246,-0.48151 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.99999976;enable-background:new" />
-      <path
-         id="rect17448"
-         style="opacity:0.1;fill:#000000;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-         d="M 326.97266 138.91016 C 326.20328 138.91016 325.68522 139.0722 325.41992 139.39062 C 325.1413 139.72231 324.99805 140.26718 324.99805 141.02344 L 324.99805 142 L 340.99805 142 L 340.99805 141.02344 C 340.99805 140.26718 340.85474 139.72231 340.57617 139.39062 C 340.31084 139.0722 339.79471 138.89996 339.02539 138.91016 L 326.97266 138.91016 z " />
-      <path
-         id="rect17515-2"
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
-         d="m 330.35547,198 c -0.52896,0 -0.88596,0.11311 -1.06836,0.33203 -0.19155,0.22803 -0.28906,0.60116 -0.28906,1.12109 V 200 H 340 v -0.54688 c 0,-0.51993 -0.0995,-0.89306 -0.29102,-1.12109 -0.18242,-0.21892 -0.53748,-0.33903 -1.0664,-0.33203 z" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.99999988;enable-background:new"
-         d="m 333.64276,193.00027 c 0.52892,-0.007 0.88394,0.11212 1.06636,0.33104 0.19152,0.22803 0.29002,0.60208 0.29002,1.12202 v 6.09361 c 0,0.51995 -0.0985,0.89397 -0.29002,1.12202 C 334.5267,201.88789 334.17172,202 333.64276,202 h -8.28746 c -0.52896,0 -0.88493,-0.11211 -1.06734,-0.33104 -0.19152,-0.22805 -0.28905,-0.60207 -0.28905,-1.12202 v -6.09361 c 0,-0.51994 0.0975,-0.89399 0.28905,-1.12202 0.1824,-0.21892 0.53838,-0.33105 1.06734,-0.33105 z"
-         id="path958-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccsscsscsscsc" />
-      <path
-         id="rect17515"
-         style="opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-         d="M 325.35547 193 C 324.82651 193 324.46951 193.11311 324.28711 193.33203 C 324.09556 193.56006 323.99805 193.93319 323.99805 194.45312 L 323.99805 195 L 335 195 L 335 194.45312 C 335 193.93319 334.9005 193.56006 334.70898 193.33203 C 334.52656 193.11311 334.1715 192.993 333.64258 193 L 325.35547 193 z " />
-      <path
-         id="rect17558-0"
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
-         d="m 326.98633,241.94336 c -0.38469,0 -0.64274,0.081 -0.77539,0.24023 C 326.07163,242.34943 326,242.62187 326,243 v 1 h 7 v -1 c 0,-0.37813 -0.0716,-0.65057 -0.21094,-0.81641 -0.13267,-0.15925 -0.39073,-0.24523 -0.77539,-0.24023 z" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.99999976;enable-background:new"
-         d="m 329.01342,238.94325 c 0.38466,-0.005 0.64285,0.0815 0.77552,0.24075 0.13929,0.16584 0.21092,0.43787 0.21092,0.816 v 3.92952 c 0,0.37813 -0.0716,0.65015 -0.21092,0.81599 -0.13267,0.15922 -0.39083,0.24075 -0.77552,0.24075 h -5.02712 c -0.38469,0 -0.64357,-0.0815 -0.77623,-0.24075 -0.13928,-0.16584 -0.21021,-0.43786 -0.21021,-0.81599 V 240 c 0,-0.37813 0.0709,-0.65016 0.21021,-0.816 0.13265,-0.15921 0.39154,-0.24076 0.77623,-0.24076 z"
-         id="path971"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccsscsscsscsc" />
-      <path
-         id="rect17558"
-         style="opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-         d="M 323.98633 238.94336 C 323.60164 238.94336 323.34359 239.02438 323.21094 239.18359 C 323.07163 239.34943 323 239.62187 323 240 L 323 241 L 330 241 L 330 240 C 330 239.62187 329.92835 239.34943 329.78906 239.18359 C 329.65639 239.02434 329.39833 238.93836 329.01367 238.94336 L 323.98633 238.94336 z " />
+         d="m 85.818336,153.45456 c -2.820358,0 -5.0909,2.27054 -5.0909,5.0909 v 10.18179 H 172.3636 v -10.18179 c 0,-2.82036 -2.27055,-5.0909 -5.0909,-5.0909 z"
+         fill="#814ff4"
+         opacity="0.15"
+         style="display:inline;enable-background:new;stroke-width:5.09088;paint-order:fill markers stroke"
+         id="path294" />
       <circle
-         style="opacity:1;fill:#e95420;fill-opacity:1;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-         id="path17601"
-         cx="347"
-         cy="72"
-         r="1" />
+         style="display:inline;enable-background:new;opacity:0.7;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.185822;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1198"
+         cx="89.63205"
+         cy="162.29752"
+         r="3.5592546" />
+      <rect
+         x="136.72731"
+         y="117.81827"
+         width="91.636162"
+         height="61.090775"
+         rx="5.0908976"
+         ry="5.0908976"
+         fill="#ffffff"
+         opacity="0.75"
+         stroke="#000000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         stroke-opacity="0.196"
+         style="display:inline;enable-background:new;stroke-width:5.09088;paint-order:fill markers stroke"
+         id="rect701" />
+      <path
+         d="m 141.81821,117.81827 c -2.82036,0 -5.0909,2.27054 -5.0909,5.0909 v 10.1818 h 91.63616 v -10.1818 c 0,-2.82036 -2.27054,-5.0909 -5.0909,-5.0909 z"
+         fill="#814ff4"
+         opacity="0.15"
+         style="display:inline;enable-background:new;stroke-width:5.09088;paint-order:fill markers stroke"
+         id="path703" />
       <circle
-         style="opacity:0.2;fill:#000000;fill-opacity:1;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-         id="path17603"
-         cx="357"
-         cy="82"
-         r="1" />
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.185822;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle705"
+         cx="145.63193"
+         cy="126.66123"
+         r="3.5592546" />
       <rect
-         style="opacity:0.2;fill:#000000;fill-opacity:1;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-         id="rect17605"
-         width="1"
-         height="1"
-         x="344"
-         y="145" />
+         x="329.36365"
+         y="83.477272"
+         width="18.818182"
+         height="12.545455"
+         rx="1.0454545"
+         ry="1.0454545"
+         fill="#ffffff"
+         opacity="0.75"
+         stroke="#000000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         stroke-opacity="0.196"
+         style="display:inline;enable-background:new;stroke-width:1.04545;paint-order:fill markers stroke"
+         id="rect1536" />
+      <path
+         d="m 330.40909,83.477274 c -0.57918,0 -1.04545,0.466273 -1.04545,1.045455 v 2.090909 h 18.81818 v -2.090909 c 0,-0.579182 -0.46627,-1.045455 -1.04546,-1.045455 z"
+         fill="#814ff4"
+         opacity="0.15"
+         style="display:inline;enable-background:new;stroke-width:1.04545;paint-order:fill markers stroke"
+         id="path1538" />
+      <circle
+         style="display:inline;enable-background:new;opacity:0.7;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.0381599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1540"
+         cx="331.19226"
+         cy="85.293243"
+         r="0.73092002" />
       <rect
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
-         id="rect17605-9"
-         width="1"
-         height="1"
-         x="338"
-         y="199" />
+         x="340.86365"
+         y="76.159096"
+         width="18.818182"
+         height="12.545455"
+         rx="1.0454545"
+         ry="1.0454545"
+         fill="#ffffff"
+         opacity="0.75"
+         stroke="#000000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         stroke-opacity="0.196"
+         style="display:inline;enable-background:new;stroke-width:1.04545;paint-order:fill markers stroke"
+         id="rect1542" />
+      <path
+         d="m 341.90909,76.159092 c -0.57918,0 -1.04545,0.466273 -1.04545,1.045455 v 2.090909 h 18.81818 v -2.090909 c 0,-0.579182 -0.46627,-1.045455 -1.04546,-1.045455 z"
+         fill="#814ff4"
+         opacity="0.15"
+         style="display:inline;enable-background:new;stroke-width:1.04545;paint-order:fill markers stroke"
+         id="path1544" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.0381599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1546"
+         cx="342.69226"
+         cy="77.97506"
+         r="0.73092002" />
       <rect
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
-         id="rect17605-3"
-         width="1"
-         height="1"
-         x="331"
-         y="243" />
+         x="326.45453"
+         y="147.65909"
+         width="12.272728"
+         height="8.181819"
+         rx="0.68181819"
+         ry="0.68181819"
+         fill="#ffffff"
+         opacity="0.75"
+         stroke="#000000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         stroke-opacity="0.196"
+         style="display:inline;enable-background:new;stroke-width:0.681815;paint-order:fill markers stroke"
+         id="rect1560" />
+      <path
+         d="m 327.13636,147.6591 c -0.37773,0 -0.68182,0.30409 -0.68182,0.68181 v 1.36364 h 12.27273 v -1.36364 c 0,-0.37772 -0.30409,-0.68181 -0.68182,-0.68181 z"
+         fill="#814ff4"
+         opacity="0.15"
+         style="display:inline;enable-background:new;stroke-width:0.681815;paint-order:fill markers stroke"
+         id="path1562" />
+      <circle
+         style="display:inline;enable-background:new;opacity:0.7;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.0248869;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1564"
+         cx="327.64713"
+         cy="148.84343"
+         r="0.47668698" />
       <rect
-         style="opacity:1;fill:#e95420;fill-opacity:1;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-         id="rect17636"
-         width="1"
-         height="1"
-         x="338"
-         y="140" />
+         x="333.95453"
+         y="142.88637"
+         width="12.272728"
+         height="8.181819"
+         rx="0.68181819"
+         ry="0.68181819"
+         fill="#ffffff"
+         opacity="0.75"
+         stroke="#000000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         stroke-opacity="0.196"
+         style="display:inline;enable-background:new;stroke-width:0.681815;paint-order:fill markers stroke"
+         id="rect1566" />
+      <path
+         d="m 334.63636,142.88637 c -0.37773,0 -0.68182,0.30409 -0.68182,0.68182 v 1.36363 h 12.27273 v -1.36363 c 0,-0.37773 -0.30409,-0.68182 -0.68182,-0.68182 z"
+         fill="#814ff4"
+         opacity="0.15"
+         style="display:inline;enable-background:new;stroke-width:0.681815;paint-order:fill markers stroke"
+         id="path1568" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.0248869;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1570"
+         cx="335.14713"
+         cy="144.07069"
+         r="0.47668698" />
       <rect
-         style="display:inline;fill:#e95420;fill-opacity:1;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
-         id="rect17636-6"
-         width="1"
-         height="1"
-         x="333"
-         y="194" />
+         x="324.68182"
+         y="199.73863"
+         width="9.409091"
+         height="6.272728"
+         rx="0.52272725"
+         ry="0.52272725"
+         fill="#ffffff"
+         opacity="0.75"
+         stroke="#000000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         stroke-opacity="0.196"
+         style="display:inline;enable-background:new;stroke-width:0.522725;paint-order:fill markers stroke"
+         id="rect1584" />
+      <path
+         d="m 325.20455,199.73864 c -0.2896,0 -0.52273,0.23314 -0.52273,0.52273 v 1.04545 h 9.40909 v -1.04545 c 0,-0.28959 -0.23314,-0.52273 -0.52273,-0.52273 z"
+         fill="#814ff4"
+         opacity="0.15"
+         style="display:inline;enable-background:new;stroke-width:0.522725;paint-order:fill markers stroke"
+         id="path1586" />
+      <circle
+         style="display:inline;enable-background:new;opacity:0.7;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.0190799;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1588"
+         cx="325.59613"
+         cy="200.64662"
+         r="0.36546001" />
       <rect
-         style="display:inline;fill:#e95420;fill-opacity:1;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
-         id="rect17636-0"
-         width="1"
-         height="1"
-         x="328"
-         y="240" />
+         x="330.43182"
+         y="196.07954"
+         width="9.409091"
+         height="6.272728"
+         rx="0.52272725"
+         ry="0.52272725"
+         fill="#ffffff"
+         opacity="0.75"
+         stroke="#000000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         stroke-opacity="0.196"
+         style="display:inline;enable-background:new;stroke-width:0.522725;paint-order:fill markers stroke"
+         id="rect1590" />
+      <path
+         d="m 330.95455,196.07955 c -0.2896,0 -0.52273,0.23313 -0.52273,0.52272 v 1.04546 h 9.40909 v -1.04546 c 0,-0.28959 -0.23314,-0.52272 -0.52273,-0.52272 z"
+         fill="#814ff4"
+         opacity="0.15"
+         style="display:inline;enable-background:new;stroke-width:0.522725;paint-order:fill markers stroke"
+         id="path1592" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.0190799;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1594"
+         cx="331.34613"
+         cy="196.98753"
+         r="0.36546001" />
+      <rect
+         x="323.22742"
+         y="243.82954"
+         width="6.1361542"
+         height="4.0907693"
+         rx="0.34089744"
+         ry="0.34089744"
+         fill="#ffffff"
+         opacity="0.75"
+         stroke="#000000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         stroke-opacity="0.196"
+         style="display:inline;enable-background:new;stroke-width:0.340896;paint-order:fill markers stroke"
+         id="rect1608" />
+      <path
+         d="m 323.56833,243.82955 c -0.18886,0 -0.3409,0.15204 -0.3409,0.3409 v 0.68179 h 6.13616 v -0.68179 c 0,-0.18886 -0.15205,-0.3409 -0.3409,-0.3409 z"
+         fill="#814ff4"
+         opacity="0.15"
+         style="display:inline;enable-background:new;stroke-width:0.340896;paint-order:fill markers stroke"
+         id="path1610" />
+      <circle
+         style="display:inline;enable-background:new;opacity:0.7;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.012443;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1612"
+         cx="323.8237"
+         cy="244.42169"
+         r="0.23833534" />
+      <rect
+         x="326.97729"
+         y="241.44327"
+         width="6.1361542"
+         height="4.0907693"
+         rx="0.34089744"
+         ry="0.34089744"
+         fill="#ffffff"
+         opacity="0.75"
+         stroke="#000000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         stroke-opacity="0.196"
+         style="display:inline;enable-background:new;stroke-width:0.340896;paint-order:fill markers stroke"
+         id="rect1614" />
+      <path
+         d="m 327.3182,241.44327 c -0.18886,0 -0.3409,0.15204 -0.3409,0.3409 v 0.68179 h 6.13616 v -0.68179 c 0,-0.18886 -0.15204,-0.3409 -0.3409,-0.3409 z"
+         fill="#814ff4"
+         opacity="0.15"
+         style="display:inline;enable-background:new;stroke-width:0.340896;paint-order:fill markers stroke"
+         id="path1616" />
+      <circle
+         style="display:inline;enable-background:new;fill:#ff6159;fill-opacity:1;fill-rule:evenodd;stroke:#e1453f;stroke-width:0.012443;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+         id="circle1618"
+         cx="327.57358"
+         cy="242.03542"
+         r="0.23833534" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer4"
+       id="layer3"
        inkscape:label="Borders"
-       style="display:inline;opacity:1">
+       style="display:inline;enable-background:new">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92188,43.999698 c -35.296728,0 -39.09487,3.62603 -38.92188,38.99414 v 2 c -0.17299,-35.36811 3.625152,-38.99414 38.92188,-38.99414 h 146.15624 c 35.29673,0 38.92188,3.62561 38.92188,38.99414 v -2 c 0,-35.36853 -3.62515,-38.99414 -38.92188,-38.99414 z"
-         id="path931"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
+         d="m 261.4543,87.272885 v -20.36359 c 0,-4.230536 -3.40581,-7.636346 -7.63635,-7.636346 H 50.182051 c -4.230536,0 -7.636346,3.40581 -7.636346,7.636346 v 20.36359"
+         color="#000000"
+         fill="none"
+         opacity="0.5"
+         overflow="visible"
+         solid-color="#000000"
+         stroke="#111111"
+         stroke-linejoin="round"
+         style="display:inline;isolation:auto;mix-blend-mode:normal;stroke-width:5.0909;enable-background:new"
+         id="path288" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92728,267.9997 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 c -0.17299,35.36811 3.625154,38.99414 38.921885,38.99414 h 146.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 c 0,35.36853 -3.62515,38.99414 -38.92188,38.99414 z"
-         id="path931-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
+         d="m 366.47727,69.886365 v -4.181818 c 0,-0.868773 -0.69941,-1.568182 -1.56818,-1.568182 h -41.81818 c -0.86877,0 -1.56818,0.699409 -1.56818,1.568182 v 4.181818"
+         color="#000000"
+         fill="none"
+         opacity="0.5"
+         overflow="visible"
+         solid-color="#000000"
+         stroke="#111111"
+         stroke-linejoin="round"
+         style="display:inline;isolation:auto;mix-blend-mode:normal;stroke-width:1.04545;enable-background:new"
+         id="path1532" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500047 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 V 84 96.75181 c -0.0527,8.84203 1.82291,9.74838 11.83407,9.74838 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 350.65909,138.79546 v -2.72727 c 0,-0.5666 -0.45614,-1.02273 -1.02273,-1.02273 h -27.27273 c -0.56659,0 -1.02272,0.45613 -1.02272,1.02273 v 2.72727"
+         color="#000000"
+         fill="none"
+         opacity="0.5"
+         overflow="visible"
+         solid-color="#000000"
+         stroke="#111111"
+         stroke-linejoin="round"
+         style="display:inline;isolation:auto;mix-blend-mode:normal;stroke-width:0.681818;enable-background:new"
+         id="path1556" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 343.23864,192.94319 v -2.09091 c 0,-0.43439 -0.3497,-0.78409 -0.78409,-0.78409 h -20.90909 c -0.43439,0 -0.78409,0.3497 -0.78409,0.78409 v 2.09091"
+         color="#000000"
+         fill="none"
+         opacity="0.5"
+         overflow="visible"
+         solid-color="#000000"
+         stroke="#111111"
+         stroke-linejoin="round"
+         style="display:inline;isolation:auto;mix-blend-mode:normal;stroke-width:0.522727;enable-background:new"
+         id="path1580" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 337.97659,211.50015 c 4.67187,0 5.5471,-0.42296 5.52255,-4.54923 v -7.95037 -5.95084 c 0.0245,-4.12627 -0.85068,-4.54923 -5.52255,-4.54923 h -11.95364 c -4.67071,0 -5.52256,0.42291 -5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 0.85185,4.54923 5.52256,4.54923 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.55494,251.5 c 3.33705,0 3.96221,-0.30212 3.94468,-3.24946 v -4.2505 -4.25059 c 0.0175,-2.94734 -0.60763,-3.24945 -3.94468,-3.24945 h -7.11025 c -3.33622,0 -3.94469,0.30208 -3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 0.60847,3.24946 3.94469,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="opacity:0.7">
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 324.44531,237 c -1.65302,0 -2.54604,0.12548 -2.91601,0.41406 -0.18499,0.14429 -0.30479,0.33122 -0.39649,0.70313 C 321.0411,238.4891 321,239.03036 321,239.75 v 4.25 4.25 c 0,0.71964 0.0411,1.26082 0.13281,1.63281 0.0917,0.37191 0.2115,0.55884 0.39649,0.70313 0.36997,0.28858 1.26299,0.41406 2.91601,0.41406 h 7.10938 c 1.65343,0 2.55203,-0.12511 2.92383,-0.41406 0.18589,-0.14448 0.30578,-0.33208 0.39648,-0.70313 0.0907,-0.37105 0.129,-0.90979 0.125,-1.6289 v -0.002 V 244 v -4.25195 -0.002 c 0.004,-0.71911 -0.0343,-1.25785 -0.125,-1.6289 -0.0907,-0.37105 -0.21059,-0.55865 -0.39648,-0.70313 C 334.10673,237.12512 333.20812,237 331.55469,237 Z m 5.32813,1.04688 c 1.10767,-3.4e-4 2.21363,0.008 3.32031,0.0449 0.26616,0.0599 0.75737,-0.0208 0.79297,0.3457 0.13405,1.84438 0.0662,3.68774 0.10156,5.53906 -0.0126,1.86745 0.0543,3.67031 -0.10351,5.49805 0.0642,0.42314 -0.43946,0.35577 -0.70313,0.42187 -3.43277,0.0703 -6.87577,0.0589 -10.29883,0.002 -0.22288,-0.0398 -0.55622,-3.2e-4 -0.71093,-0.1875 -0.19863,-1.12995 -0.12696,-2.26946 -0.16016,-3.41992 0.0138,-2.55648 -0.029,-5.10728 0.0898,-7.65625 -0.03,-0.2727 0.10944,-0.49629 0.40039,-0.48829 1.30659,-0.161 2.63265,-0.0636 3.94727,-0.0976 1.10718,0.006 2.21655,-0.002 3.32422,-0.002 z"
-         id="path918-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none"
-         d="m 326.02383,189.00048 c -2.32027,0 -3.60941,0.15494 -4.20703,0.62109 -0.29882,0.23308 -0.48964,0.54668 -0.625,1.09571 -0.13541,0.54902 -0.19141,1.31765 -0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 0.056,1.783 0.19141,2.33203 0.13536,0.54903 0.32618,0.86263 0.625,1.09571 0.59762,0.46615 1.88676,0.62109 4.20703,0.62109 h 11.9524 c 2.32085,0 3.61652,-0.15457 4.2168,-0.62109 0.30014,-0.23327 0.49095,-0.54754 0.625,-1.09571 0.13404,-0.54816 0.18764,-1.31623 0.18164,-2.33008 v -7.95279 -5.95312 c 0.006,-1.01386 -0.0476,-1.78191 -0.18164,-2.33008 -0.13406,-0.54817 -0.32486,-0.86244 -0.625,-1.09571 -0.60028,-0.46652 -1.89595,-0.62109 -4.2168,-0.62109 z m 4.95859,1.00977 c 1.5798,-0.002 4.16014,-3.9e-4 5.73991,0.0117 1.50021,0.0511 3.02236,-0.0712 4.5,0.28321 0.55111,0.0919 0.61303,0.71807 0.67773,1.16601 0.1117,4.30832 0.075,10.62608 0.0508,14.94108 -0.0716,0.99089 0.13687,2.07606 -0.30078,3.01366 -0.34356,0.40964 -0.9694,0.35958 -1.45117,0.45509 -3.95407,0.0823 -9.92936,0.0499 -13.89381,0.0371 -1.16908,-0.0622 -2.37292,0.11291 -3.51758,-0.22266 -0.57935,-0.098 -0.6137,-0.75914 -0.6875,-1.2207 -0.1146,-4.11835 -0.0751,-10.24472 -0.0547,-14.36881 0.0572,-1.06305 -0.0797,-2.16734 0.18164,-3.21485 0.10495,-0.6386 0.8614,-0.66043 1.36719,-0.74023 2.1305,-0.19658 5.24071,-0.10662 7.38828,-0.14062 z"
-         id="path914-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 329.12695,134 c -3.21072,0 -5.03255,0.19514 -5.9375,0.89844 -0.45247,0.35165 -0.74178,0.83286 -0.93359,1.61718 -0.19176,0.78433 -0.26386,1.85686 -0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c -0.008,1.40682 0.0641,2.47935 0.25586,3.26368 0.1918,0.78431 0.48112,1.26553 0.93359,1.61718 0.90496,0.7033 2.72678,0.89844 5.9375,0.89844 h 13.7461 c 3.20992,0 5.02461,-0.19551 5.92578,-0.89844 0.45058,-0.35146 0.73805,-0.83201 0.93164,-1.61718 C 349.9241,158.69918 350,157.62415 350,156.2168 V 148 139.7832 c 0,-1.40735 -0.0759,-2.48237 -0.26953,-3.26758 -0.19359,-0.78517 -0.48106,-1.26572 -0.93164,-1.61718 C 347.89766,134.19551 346.08297,134 342.87305,134 Z m 6.49805,1.04688 c 3.45647,0.0171 6.9142,-0.0268 10.36133,0.0918 0.8211,0.13276 1.80664,0.14835 2.39062,0.82617 0.67884,1.16473 0.51296,2.58781 0.56446,3.87305 0.0431,6.02893 0.0678,12.06719 -0.0332,18.08789 -0.0775,0.77792 -0.12055,1.67263 -0.67968,2.27539 -0.70249,0.51038 -1.61833,0.59683 -2.45899,0.67383 -4.04742,0.0864 -8.16222,0.0456 -12.24023,0.0606 -2.45188,-0.0199 -4.91402,0.0317 -7.35352,-0.0606 -0.87784,-0.12055 -1.915,-0.14021 -2.56055,-0.83398 -0.64775,-1.02591 -0.50264,-2.30525 -0.56054,-3.46485 -0.035,-5.65575 -0.0351,-11.35518 0,-17.00976 0.0632,-1.22153 -0.10864,-2.57724 0.59179,-3.65235 0.6025,-0.62665 1.55621,-0.63986 2.35938,-0.77344 2.73743,-0.10739 5.48083,-0.0704 8.22656,-0.0918 0.46403,-2.9e-4 0.92855,-0.002 1.39258,-0.002 z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 333.33594,62 c -4.99049,0 -7.87051,0.276282 -9.38477,1.453125 -0.75713,0.588421 -1.23761,1.403518 -1.54492,2.660156 -0.3073,1.256638 -0.4173,2.940031 -0.4043,5.132813 V 84 96.753906 c -0.0131,2.19278 0.097,3.876174 0.4043,5.132814 0.30731,1.25663 0.78779,2.07172 1.54492,2.66016 1.51427,1.17683 4.39428,1.45312 9.38477,1.45312 h 21.33008 c 4.98923,0 7.85502,-0.27668 9.36328,-1.45312 0.75412,-0.58824 1.23293,-1.40461 1.54297,-2.66211 C 365.8823,100.62727 366,98.945281 366,96.751953 V 84 71.248047 c 0,-2.193329 -0.1177,-3.875313 -0.42773,-5.132813 -0.31004,-1.257499 -0.78884,-2.073874 -1.54297,-2.662109 C 362.52104,62.276656 359.65526,62 354.66602,62 Z m 2.40234,1.097656 c 6.94737,8.3e-4 13.91063,0.0034 20.84961,0.05469 2.14296,0.08293 4.46431,-0.147701 6.42383,0.93164 1.29609,0.695228 1.54862,2.250325 1.76953,3.564454 0.17551,2.202888 0.0915,4.442228 0.13867,6.669921 0.0227,8.479532 0.077,16.968993 -0.0801,25.447266 -0.16151,1.483233 -0.38135,3.305793 -1.79882,4.142573 -1.6055,0.82871 -3.47551,0.90643 -5.24805,0.95313 -9.49974,0.0678 -19.0243,0.0843 -28.52344,-0.0176 -1.57816,-0.11413 -3.27053,-0.24014 -4.63281,-1.12109 -1.22952,-0.99538 -1.36082,-2.72739 -1.50391,-4.193361 -0.1272,-8.998585 -0.0836,-18.004484 -0.0527,-27.007813 0.0997,-2.381275 -0.24538,-4.900002 0.70508,-7.160156 0.67165,-1.50972 2.46573,-1.859954 3.93945,-2.05664 2.66168,-0.316582 5.34184,-0.147022 8.01367,-0.207032 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
+         d="m 335.32929,239.39788 v -1.36359 c 0,-0.28329 -0.22806,-0.51135 -0.51134,-0.51135 h -13.6359 c -0.28329,0 -0.51135,0.22806 -0.51135,0.51135 v 1.36359"
+         color="#000000"
+         fill="none"
+         opacity="0.5"
+         overflow="visible"
+         solid-color="#000000"
+         stroke="#111111"
+         stroke-linejoin="round"
+         style="display:inline;isolation:auto;mix-blend-mode:normal;stroke-width:0.340897;enable-background:new"
+         id="path1604" />
+      <rect
+         x="42.545704"
+         y="59.272949"
+         width="218.9086"
+         height="193.4541"
+         rx="7.6363463"
+         ry="7.6363463"
+         color="#000000"
+         fill="none"
+         opacity="0.35"
+         overflow="visible"
+         solid-color="#000000"
+         stroke="#0e0063"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         style="display:inline;isolation:auto;mix-blend-mode:normal;stroke-width:5.0909;enable-background:new"
+         id="rect286" />
+      <rect
+         x="321.52274"
+         y="64.136368"
+         width="44.954544"
+         height="39.727272"
+         rx="1.5681818"
+         ry="1.5681818"
+         color="#000000"
+         fill="none"
+         opacity="0.35"
+         overflow="visible"
+         solid-color="#000000"
+         stroke="#0e0063"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         style="display:inline;isolation:auto;mix-blend-mode:normal;stroke-width:1.04545;enable-background:new"
+         id="rect1530" />
+      <rect
+         x="321.34091"
+         y="135.04546"
+         width="29.318182"
+         height="25.90909"
+         rx="1.0227273"
+         ry="1.0227273"
+         color="#000000"
+         fill="none"
+         opacity="0.35"
+         overflow="visible"
+         solid-color="#000000"
+         stroke="#0e0063"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         style="display:inline;isolation:auto;mix-blend-mode:normal;stroke-width:0.681818;enable-background:new"
+         id="rect1554" />
+      <rect
+         x="320.76138"
+         y="190.06819"
+         width="22.477272"
+         height="19.863636"
+         rx="0.78409088"
+         ry="0.78409088"
+         color="#000000"
+         fill="none"
+         opacity="0.35"
+         overflow="visible"
+         solid-color="#000000"
+         stroke="#0e0063"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         style="display:inline;isolation:auto;mix-blend-mode:normal;stroke-width:0.522727;enable-background:new"
+         id="rect1578" />
+      <rect
+         x="320.67072"
+         y="237.52295"
+         width="14.658589"
+         height="12.954103"
+         rx="0.51134616"
+         ry="0.51134616"
+         color="#000000"
+         fill="none"
+         opacity="0.35"
+         overflow="visible"
+         solid-color="#000000"
+         stroke="#0e0063"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         style="display:inline;isolation:auto;mix-blend-mode:normal;stroke-width:0.340897;enable-background:new"
+         id="rect1602" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/software-store.svg
+++ b/icons/src/fullcolor/default/apps/software-store.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="software-store.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png"
+   inkscape:export-filename="/home/sam/suru-template.png"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="4"
-     inkscape:cx="240.25"
-     inkscape:cy="211.125"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="260.2153"
+     inkscape:cy="84.145707"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -92,219 +92,227 @@
   </sodipodi:namedview>
   <defs
      id="defs3">
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4346"
-       x="-0.014454287"
-       width="1.0289086"
-       y="-0.011357288"
-       height="1.0227146">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="2.120027"
-         id="feGaussianBlur4348" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4380"
-       x="-0.057817147"
-       width="1.1156343"
-       y="-0.045429151"
-       height="1.0908583">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="8.4801079"
-         id="feGaussianBlur4382" />
-    </filter>
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="linearGradient940">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop936"
          offset="0"
-         id="stop923" />
+         style="stop-color:#f6f7f7;stop-opacity:1" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         id="stop938"
          offset="1"
-         id="stop925" />
+         style="stop-color:#dce7f0;stop-opacity:1" />
     </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004"
-       x1="344"
-       y1="66.000679"
-       x2="344"
-       y2="102.00067"
+       xlink:href="#linearGradient1197"
+       id="linearGradient1199"
+       x1="540.14288"
+       y1="29.770346"
+       x2="540.14288"
+       y2="1054.9744"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,344,84)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath971">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         id="path973"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
+       gradientTransform="matrix(0.22741108,0,0,0.22741108,35.565526,33.115668)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient981"
-       x1="331.99966"
-       y1="191.00034"
-       x2="331.99966"
-       y2="209.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,331.99966,200)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient993"
-       x1="328"
-       y1="238.00043"
-       x2="328"
-       y2="250"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,328,244)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1004-8"
-       x1="344"
-       y1="65.144272"
-       x2="344"
-       y2="102.85715"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.04758,0.95458104,0,263.81519,444.36752)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7537"
-       id="linearGradient4878"
-       x1="317.26004"
-       y1="255.44786"
-       x2="338.31595"
-       y2="230.85617"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,328.00001,244)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7537"
-       id="linearGradient4880"
-       x1="319.61288"
-       y1="215.806"
-       x2="344.89194"
-       y2="184.1002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,331.99997,199.99998)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7537"
-       id="linearGradient4882"
-       x1="319.2178"
-       y1="170.97945"
-       x2="355.70792"
-       y2="121.71233"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,336.00001,148.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7537"
-       id="linearGradient4884"
-       x1="325.00024"
-       y1="107.00019"
-       x2="372.25275"
-       y2="51.776531"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,344.00058,84.000121)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7537"
-       id="linearGradient4886"
-       x1="24.987097"
-       y1="298.46219"
-       x2="292.57532"
-       y2="-5.1179543"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,151.9973,156)" />
-    <linearGradient
-       id="linearGradient7537">
+       id="linearGradient1197">
       <stop
-         style="stop-color:#f37e40;stop-opacity:1"
+         style="stop-color:#ffffff;stop-opacity:0.58823532"
          offset="0"
-         id="stop7539" />
+         id="stop1193" />
       <stop
-         style="stop-color:#f34f17;stop-opacity:1"
+         style="stop-color:#ffffff;stop-opacity:0"
          offset="1"
-         id="stop7541" />
+         id="stop1195" />
     </linearGradient>
-    <filter
+    <linearGradient
        inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1066"
-       x="-0.0070588236"
-       width="1.0141176"
-       y="-0.040000001"
-       height="1.08">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.4"
-         id="feGaussianBlur1068" />
-    </filter>
+       xlink:href="#linearGradient940"
+       id="linearGradient1005"
+       gradientUnits="userSpaceOnUse"
+       x1="-248.92"
+       y1="400.46124"
+       x2="-248.92"
+       y2="666.86127"
+       gradientTransform="matrix(2.027027,0,0,2.027027,1119.0831,-444.41452)" />
     <filter
-       inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
-       id="filter1062-3"
-       x="-0.012910163"
-       width="1.0258203"
-       y="-0.013017735"
-       height="1.0260355">
+       inkscape:label="Drop Shadow"
+       id="filter1053-7"
+       x="-0.011999849"
+       y="-0.013386946"
+       width="1.0239997"
+       height="1.0323518">
+      <feFlood
+         flood-opacity="0.294118"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood1042-5" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite1044-3" />
       <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.67258301"
-         id="feGaussianBlur1064-6" />
+         in="composite1"
+         stdDeviation="3"
+         result="blur"
+         id="feGaussianBlur1047-5" />
+      <feOffset
+         dx="0"
+         dy="3"
+         result="offset"
+         id="feOffset1049-6" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite1051-2" />
     </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1346"
+       id="linearGradient4835"
+       x1="97.551018"
+       y1="-3.6734703"
+       x2="97.551018"
+       y2="204.48979"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1199996,0,0,1.1199996,40.000026,44.00006)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1346">
+      <stop
+         style="stop-color:#00b8ff;stop-opacity:1"
+         offset="0"
+         id="stop1342" />
+      <stop
+         style="stop-color:#007bff;stop-opacity:1"
+         offset="1"
+         id="stop1344" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1197"
+       id="linearGradient920"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04670049,0,0,0.04670049,320.08935,58.764827)"
+       x1="540.14288"
+       y1="29.770346"
+       x2="540.14288"
+       y2="1054.9744" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient922"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.027027,0,0,2.027027,1119.0831,-444.41452)"
+       x1="-248.92"
+       y1="400.46124"
+       x2="-248.92"
+       y2="666.86127" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1346"
+       id="linearGradient924"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22999993,0,0,0.22999993,321,61.000015)"
+       x1="97.551018"
+       y1="-3.6734703"
+       x2="97.551018"
+       y2="204.48979" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1197"
+       id="linearGradient932"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03045684,0,0,0.03045684,320.4061,131.54228)"
+       x1="540.14288"
+       y1="29.770346"
+       x2="540.14288"
+       y2="1054.9744" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.027027,0,0,2.027027,1119.0831,-444.41452)"
+       x1="-248.92"
+       y1="400.46124"
+       x2="-248.92"
+       y2="666.86127" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1346"
+       id="linearGradient936"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.14999996,0,0,0.14999996,321,133.00001)"
+       x1="97.551018"
+       y1="-3.6734703"
+       x2="97.551018"
+       y2="204.48979" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1197"
+       id="linearGradient944"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02335024,0,0,0.02335024,320.04468,187.38241)"
+       x1="540.14288"
+       y1="29.770346"
+       x2="540.14288"
+       y2="1054.9744" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient946"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.027027,0,0,2.027027,1119.0831,-444.41452)"
+       x1="-248.92"
+       y1="400.46124"
+       x2="-248.92"
+       y2="666.86127" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1346"
+       id="linearGradient948"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11499997,0,0,0.11499997,320.5,188.50001)"
+       x1="97.551018"
+       y1="-3.6734703"
+       x2="97.551018"
+       y2="204.48979" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1197"
+       id="linearGradient956"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01522842,0,0,0.01522842,320.20306,235.77114)"
+       x1="540.14288"
+       y1="29.770346"
+       x2="540.14288"
+       y2="1054.9744" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient940"
+       id="linearGradient958"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.027027,0,0,2.027027,1119.0831,-444.41452)"
+       x1="-248.92"
+       y1="400.46124"
+       x2="-248.92"
+       y2="666.86127" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1346"
+       id="linearGradient960"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07499998,0,0,0.07499998,320.50001,236.50001)"
+       x1="97.551018"
+       y1="-3.6734703"
+       x2="97.551018"
+       y2="204.48979" />
   </defs>
   <metadata
      id="metadata4">
@@ -404,7 +412,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">software-store</tspan></text>
+           id="tspan924">software-store</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -439,381 +447,109 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 343.99961,196.86562 c 0,-1.12014 -0.0241,-2.01524 -0.1543,-2.79101 -0.13022,-0.77577 -0.38763,-1.48014 -0.91601,-2.00977 -0.52838,-0.52962 -1.23687,-0.79079 -2.01367,-0.91992 -0.77681,-0.12912 -1.67169,-0.15002 -2.79493,-0.14453 h -6.12109 -6.125 c -1.12104,-0.005 -2.01529,0.0156 -2.79102,0.14453 -0.77681,0.12912 -1.48529,0.39029 -2.01367,0.91992 -0.52838,0.52964 -0.78579,1.234 -0.91601,2.00977 -0.13022,0.77577 -0.1543,1.67087 -0.1543,2.79101 v 8.26954 c 0,1.12013 0.024,2.01264 0.1543,2.78711 0.13033,0.77446 0.38927,1.48001 0.91797,2.00781 0.52869,0.5278 1.23438,0.78594 2.00976,0.91601 0.77539,0.13007 1.67062,0.1543 2.79297,0.1543 h 6.125 6.125 c 1.12235,0 2.01758,-0.0242 2.79297,-0.1543 0.77538,-0.13007 1.48107,-0.38821 2.00976,-0.91601 0.5287,-0.5278 0.78764,-1.23334 0.91797,-2.00781 0.13033,-0.77448 0.1543,-1.66697 0.1543,-2.78711 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.49972,241.59598 c 0,-0.71904 -0.0139,-1.30185 -0.10352,-1.83593 -0.0897,-0.53409 -0.27628,-1.0683 -0.68359,-1.47657 -0.4073,-0.40826 -0.94323,-0.59657 -1.47851,-0.68554 -0.53529,-0.089 -1.12048,-0.10119 -1.8418,-0.0977 h -2.89258 -3.89844 c -0.71816,-0.003 -1.30235,0.009 -1.83594,0.0977 -0.53528,0.089 -1.07121,0.27727 -1.47851,0.68554 -0.40731,0.40827 -0.59394,0.94248 -0.68359,1.47657 -0.0897,0.53408 -0.10352,1.11689 -0.10352,1.83593 v 5.8086 c 0,0.71904 0.0137,1.30058 0.10352,1.83398 0.0898,0.53341 0.27792,1.06768 0.68554,1.47461 0.40762,0.40693 0.94271,0.59404 1.47656,0.68359 0.53386,0.0896 1.11551,0.10352 1.83594,0.10352 h 3.89844 2.89844 c 0.72043,0 1.30208,-0.014 1.83594,-0.10352 0.53385,-0.0895 1.06894,-0.27666 1.47656,-0.68359 0.40762,-0.40693 0.59578,-0.9412 0.68554,-1.47461 0.0898,-0.5334 0.10352,-1.11494 0.10352,-1.83398 z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 350.99951,143.19385 c 0,-1.42096 -0.0308,-2.54883 -0.19141,-3.50586 -0.16064,-0.95703 -0.4726,-1.79146 -1.09179,-2.41211 -0.61919,-0.62065 -1.45612,-0.93647 -2.41407,-1.0957 -0.95795,-0.15924 -2.08705,-0.18666 -3.51171,-0.17969 h -7.79102 -7.79688 c -1.42131,-0.007 -2.5495,0.0207 -3.50585,0.17969 -0.95796,0.15923 -1.79488,0.47505 -2.41407,1.0957 -0.61919,0.62065 -0.93115,1.45508 -1.09179,2.41211 -0.16065,0.95703 -0.19141,2.0849 -0.19141,3.50586 v 11.61523 c 0,1.42097 0.0307,2.54669 0.19141,3.50196 0.16075,0.95527 0.47425,1.78779 1.09375,2.40625 0.6195,0.61845 1.45363,0.93134 2.41015,1.09179 0.95653,0.16046 2.08403,0.19141 3.50781,0.19141 h 7.79688 7.79688 c 1.42378,0 2.55128,-0.031 3.50781,-0.19141 0.95653,-0.16045 1.79065,-0.47334 2.41015,-1.09179 0.61951,-0.61846 0.933,-1.45098 1.09375,-2.40625 0.16076,-0.95527 0.19141,-2.08099 0.19141,-3.50196 z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 367.49969,76.231427 c 0,-2.22316 -0.0512,-3.97368 -0.29297,-5.41406 -0.24178,-1.44039 -0.69529,-2.61905 -1.55664,-3.48243 -0.86134,-0.86337 -2.03947,-1.31906 -3.48046,-1.55859 -1.441,-0.23953 -3.19535,-0.28629 -5.42383,-0.27539 H 343.99974 331.2476 c -2.22507,-0.0108 -3.97852,0.0361 -5.41797,0.27539 -1.441,0.23953 -2.61913,0.69522 -3.48047,1.55859 -0.86134,0.86338 -1.31486,2.04204 -1.55664,3.48243 -0.24179,1.44039 -0.29297,3.1909 -0.29297,5.41406 v 17.53883 c 0,2.22317 0.0511,3.97276 0.29297,5.41017 0.24189,1.437403 0.69694,2.612463 1.55859,3.472653 0.86165,0.8602 2.03894,1.31319 3.47852,1.55468 1.43957,0.24149 3.19035,0.29297 5.41797,0.29297 h 12.75214 12.75191 c 2.22761,0 3.97839,-0.0515 5.41797,-0.29297 1.43957,-0.24149 2.61686,-0.69449 3.47851,-1.55469 0.86165,-0.86019 1.31671,-2.03525 1.55859,-3.472653 0.24189,-1.4374 0.29297,-3.187 0.29297,-5.41016 z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0,0.5,-0.5,0,300.9973,13.002698)" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path4350"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 464,514.75001 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4380);enable-background:accumulate"
-         transform="matrix(0,0.5,-0.5,0,300.9973,13.002698)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.02028775;marker:none;enable-background:accumulate"
-         d="m 266.0025,105.8091 c 0,-36.098811 -3.69016,-39.983003 -39.68984,-39.806081 H 152.0025 77.69234 C 41.69265,65.826097 38.0025,69.710289 38.0025,105.8091 v 100.38732 c 0,36.09881 3.68973,39.80608 39.68984,39.80608 h 74.31016 74.31016 c 36.00011,0 39.68984,-3.70727 39.68984,-39.80608 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4884);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 321.50051,92.769164 c 0,8.231536 0.90635,9.773646 9.74838,9.730396 h 12.75157 12.75181 c 8.84203,0.0433 9.74838,-1.49886 9.74838,-9.730396 v -17.53897 c 0,-8.22949 -0.90625,-9.73039 -9.74838,-9.73039 h -12.75181 -12.75157 c -8.84213,0 -9.74838,1.5009 -9.74838,9.7304 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4886);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 39.9973,106.92432 c 0,-35.29673 3.62542,-39.09461 38.99353,-38.92162 h 73.00647 73.00647 c 35.36812,-0.17299 38.99353,3.62489 38.99353,38.92162 v 98.15676 c 0,35.29672 -3.625,38.92162 -38.99353,38.92162 H 151.9973 78.99083 c -35.36853,0 -38.99353,-3.6249 -38.99353,-38.92162 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 320.49999,204.36398 c 0,4.65703 0.47377,5.15811 5.09574,5.13529 h 6.40426 6.40425 c 4.62197,0.0229 5.09574,-0.47826 5.09574,-5.13529 v -8.7287 c 0,-4.65703 -0.47371,-5.13529 -5.09574,-5.13529 h -6.40425 -6.40426 c -4.62202,0 -5.09574,0.47827 -5.09574,5.1353 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4880);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4878);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 320.50001,247.1455 c 0,3.04166 0.30899,3.36894 3.32331,3.35403 h 4.17669 4.17669 c 3.01432,0.0149 3.32331,-0.31237 3.32331,-3.35403 v -6.29146 c 0,-3.04167 -0.30895,-3.35404 -3.32331,-3.35404 h -4.17669 -4.17669 c -3.01435,0 -3.32331,0.31238 -3.32331,3.35404 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4882);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 321.50001,153.92493 c 0,5.56175 0.58409,6.6037 6.28227,6.57447 h 8.21765 8.21781 c 5.69818,0.0293 6.28227,-1.01272 6.28227,-6.57447 v -11.85044 c 0,-5.56037 -0.58403,-6.57447 -6.28227,-6.57447 h -8.21781 -8.21765 c -5.69824,0 -6.28227,1.0141 -6.28227,6.57447 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 40,156 v 8 41.00586 C 40,240.37439 43.625165,244 78.921875,244 H 225.07813 C 260.37486,244 264.17299,240.37398 264,205.00586 V 164 156 Z"
-         id="rect4158-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 321.50781,84 v 8.751953 C 321.47611,102.40308 323.33064,102.5 333.3418,102.5 h 21.33008 c 10.00866,0 11.83398,-0.15592 11.83398,-9.748047 V 84 Z"
-         id="path964-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 321.50586,148 v 6.2168 c -0.034,5.69818 1.17532,6.2832 7.62695,6.2832 h 13.7461 c 6.45003,0 7.62695,-0.58496 7.62695,-6.2832 V 148 Z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate"
-         d="m 321.16308,200 v 3.84766 c -0.0253,4.22046 0.52718,4.65428 5.67383,4.65429 l 10.3252,3e-5 c 5.14665,1e-5 5.67578,-0.43378 5.67578,-4.65429 v -3.84767 z"
-         id="path914-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 320.57813,244 v 3.17589 c -0.017,3.01433 0.35794,3.32422 3.83398,3.32422 h 7.18945 c 3.47605,0 3.83203,-0.30985 3.83203,-3.32422 V 244 Z"
-         id="path918-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscc" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer6"
-       inkscape:label="Pictograms"
-       style="display:inline">
-      <path
-         sodipodi:nodetypes="ccccccccccccsccccccccccc"
-         inkscape:connector-curvature="0"
-         id="path967-7-1-7"
-         d="m 327.32292,240.89304 c -0.27272,0.56818 -0.53407,1.14395 -0.78406,1.72729 -0.25,0.57573 -0.50389,1.18183 -0.76146,1.81819 -0.24999,0.63635 -0.77266,2.02266 -0.77266,2.02266 l -0.58972,1.43177 h 1.49508 l 0.54088,-1.48616 3.04904,-0.40669 0.64786,1.89285 h 1.48895 l -0.64483,-1.40903 c 0,0 -0.5265,-1.38258 -0.78407,-2.01136 -0.25,-0.63637 -0.50004,-1.24619 -0.75003,-1.82951 -0.24999,-0.58332 -0.79538,-1.75001 -0.79538,-1.75001 h -0.67348 z m 1.20443,2.87495 c 0.27272,0.67422 0.55297,1.4015 0.84086,2.18178 l -2.68651,-0.10223 c 0.23484,-0.65908 0.46972,-1.29538 0.70456,-1.90901 0.19355,-0.496 0.39473,-0.97439 0.60278,-1.43662 v -0.009 c 0,0 0.30492,0.6989 0.53831,1.27489 z"
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;fill:#fff9f2;fill-opacity:1;stroke:none;stroke-width:0.64935064px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new" />
-      <path
-         sodipodi:nodetypes="cccccccsccccccccc"
-         inkscape:connector-curvature="0"
-         id="path969-5-8-9"
-         d="m 328.66252,240.89304 -0.65844,1.61874 c 0,0 0.29932,0.70255 0.52327,1.25621 0.27272,0.67422 0.55297,1.4015 0.84086,2.18178 v 0 l 1.43731,0.0387 c -0.20139,-0.52954 -0.40063,-1.03521 -0.59759,-1.51602 -0.25,-0.63635 -0.50004,-1.24617 -0.75003,-1.82949 -0.24999,-0.58334 -0.79538,-1.75002 -0.79538,-1.75002 z m -0.31069,5.4369 1.15456,0.0786 0.64106,1.48446 h 1.48784 l -0.65709,-1.48075 -0.0121,-0.0321 c -0.8594,-0.0171 6.21743,-0.28454 -2.61428,-0.0502 z"
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.1;fill:#f34f17;fill-opacity:1;stroke:none;stroke-width:0.64935064px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new" />
-      <path
-         sodipodi:nodetypes="ccccccccccccsccccccccccc"
-         inkscape:connector-curvature="0"
-         id="path967-7-1"
-         d="m 330.85809,194 c -0.46754,0.97402 -0.91557,1.96109 -1.34414,2.96109 -0.42857,0.98701 -0.86381,2.02604 -1.30537,3.11695 -0.42857,1.09091 -1.32456,3.46747 -1.32456,3.46747 L 325.87304,206 h 2.56305 l 0.92722,-2.54775 5.36262,0.29775 0.975,2.25 h 2.55252 l -1.10543,-2.41552 c 0,0 -0.90259,-2.37016 -1.34415,-3.44809 -0.42857,-1.09091 -0.85721,-2.13633 -1.28579,-3.13633 -0.42857,-1 -1.36352,-3.00006 -1.36352,-3.00006 h -1.15454 z m 2.06475,4.92854 c 0.46753,1.15585 0.94796,2.4026 1.44147,3.74026 l -4.6055,-0.17526 c 0.4026,-1.12987 0.80525,-2.22068 1.20785,-3.27263 0.33183,-0.85031 0.6767,-1.67041 1.03336,-2.46281 v -0.0152 c 0,0 0.52272,1.19813 0.92282,2.18556 z"
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;fill:#fff9f2;fill-opacity:1;stroke:none;stroke-width:0.64935064px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new" />
-      <path
-         sodipodi:nodetypes="cccccccsccccccccc"
-         inkscape:connector-curvature="0"
-         id="path969-5-8"
-         d="m 333.15456,194 -1.12875,2.77501 c 0,0 0.51311,1.2044 0.89703,2.15353 0.46753,1.15585 0.94796,2.4026 1.44147,3.74026 v 0 l 2.464,0.0665 c -0.34524,-0.9078 -0.68679,-1.77466 -1.02444,-2.59891 -0.42857,-1.09091 -0.85721,-2.13634 -1.28579,-3.13634 -0.42857,-1 -1.36352,-3.00006 -1.36352,-3.00006 z m -0.36042,9.66407 1.97925,0.13465 0.9268,2.20128 h 2.55061 l -0.95425,-2.19494 -0.0208,-0.055 z"
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.1;fill:#f34f17;fill-opacity:1;stroke:none;stroke-width:0.64935064px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4.90620422px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-         d="m 341.37893,73.070796 c -0.9697,2.02021 -1.69901,3.46694 -2.58789,5.54102 -0.8889,2.04714 -1.79317,4.20222 -2.70899,6.46484 -0.34278,0.87253 -0.69223,1.78275 -1.04297,2.69531 -0.21612,0.49366 -0.45931,1.08541 -0.83984,2.10743 -0.63766,1.69435 -1.06579,2.71459 -1.77734,4.59375 -0.25924,0.65574 -0.54211,1.38921 -0.99219,2.62695 h 3.02929 2.28516 l 2.24609,-6.25195 5.00977,-0.2168 3.47656,0.15039 1.53321,0.0664 2.24609,6.25195 h 2.28516 3.02929 c -0.45008,-1.23774 -0.73294,-1.9712 -0.99219,-2.62695 -0.71154,-1.87916 -1.13967,-2.8994 -1.77734,-4.59375 -0.38054,-1.02201 -0.62373,-1.61376 -0.83984,-2.10742 -0.35075,-0.91257 -0.70019,-1.82278 -1.04297,-2.69531 -0.91582,-2.26263 -1.62087,-3.81615 -2.50977,-5.86328 -0.57813,-1.349 -1.1787,-2.68342 -1.79101,-4.00977 -0.0666,-0.14413 -0.12836,-0.29168 -0.19531,-0.43555 l -0.0762,-0.14453 c -0.24153,-0.51763 -0.47784,-1.03864 -0.72461,-1.55273 h -0.0801 -2.6875 -0.10743 -2.28711 z m 2.62109,4.9668 c 0.0176,0.0411 0.035,0.0819 0.0527,0.12305 v 0.0312 c 0.73973,1.64347 1.4563,3.34382 2.14454,5.10742 0.41751,1.09091 0.62818,1.58404 0.83984,2.09765 0.21165,0.51362 0.4243,1.04704 0.8418,2.21875 l -1.25,0.0469 -0.0586,0.002 -2.57031,0.0918 -3.87891,-0.13867 c 0.835,-2.34343 0.84662,-2.13654 1.68164,-4.31836 0.68824,-1.7636 1.40479,-3.46394 2.14454,-5.10742 v -0.0312 c 0.0176,-0.0411 0.0351,-0.082 0.0527,-0.12305 z"
-         id="text954-5-2-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4.9062047px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter1062-3);enable-background:new"
-         d="m 140.4961,96.000096 c -4.70996,9.812414 -9.22355,19.756004 -13.54101,29.830084 -4.31746,9.94324 -8.7021,20.41049 -13.15039,31.40039 -1.66494,4.23801 -3.36668,8.65932 -5.07031,13.0918 -1.04969,2.39777 -2.22981,5.26835 -4.07813,10.23242 -3.0972,8.22972 -6.631803,17.55233 -10.087889,26.67969 -1.25915,3.18508 -2.64003,6.75373 -4.82617,12.76562 h 14.718749 11.10156 l 12.36328,-34.73633 24.33203,-1.05859 24.33399,1.05859 12.36329,34.73633 h 11.10156 14.71875 c -2.18614,-6.01189 -3.56702,-9.58054 -4.82617,-12.76562 -3.45609,-9.12736 -6.99069,-18.44997 -10.08789,-26.67969 -1.84833,-4.96407 -3.02844,-7.83465 -4.07813,-10.23242 -1.70363,-4.43248 -3.40538,-8.85379 -5.07031,-13.0918 -4.44829,-10.9899 -8.83294,-21.45715 -13.1504,-31.40039 -4.31746,-10.07409 -8.83106,-20.01767 -13.54102,-29.830084 h -0.39062 -11.11328 -0.51758 -11.11328 z m 11.76172,27.037114 c 0.0856,0.19974 0.17424,0.39587 0.25977,0.5957 v 0.15235 c 3.59305,7.98261 7.06728,16.24447 10.41015,24.81054 4.0558,10.59741 4.11217,9.58637 8.16797,20.96875 l -18.83789,0.67969 -18.83593,-0.67969 c 4.0558,-11.38238 4.11216,-10.37134 8.16796,-20.96875 3.34287,-8.56607 6.81711,-16.82793 10.41016,-24.81054 v -0.15235 c 0.0854,-0.19959 0.17233,-0.3962 0.25781,-0.5957 z"
-         id="path1052-7"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccccccccccsccccccccccc"
-         inkscape:connector-curvature="0"
-         id="path967-7"
-         d="m 334.44306,140.00008 c -0.62338,1.2987 -1.22076,2.61479 -1.79219,3.94813 -0.57143,1.31601 -1.15175,2.70138 -1.74049,4.15593 -0.57143,1.45455 -1.76609,4.6233 -1.76609,4.6233 l -1.34797,3.27266 h 3.4174 l 1.2363,-3.397 7.15017,0.397 1.3,3 h 3.40337 l -1.47392,-3.2207 c 0,0 -1.20345,-3.16022 -1.7922,-4.59745 -0.57143,-1.45455 -1.14295,-2.84845 -1.71438,-4.18179 -0.57143,-1.33333 -1.81804,-4.00008 -1.81804,-4.00008 h -1.53938 z m 2.75301,6.5714 c 0.62337,1.54113 1.26395,3.20347 1.92196,4.98702 l -6.14067,-0.23369 c 0.53679,-1.50649 1.07366,-2.96091 1.61046,-4.36351 0.44244,-1.13374 0.90227,-2.22722 1.37782,-3.28375 v -0.0202 c 0,0 0.69696,1.59751 1.23043,2.91409 z"
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;fill:#fff9f2;fill-opacity:1;stroke:none;stroke-width:0.64935064px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new" />
-      <path
-         sodipodi:nodetypes="cccccccsccccccccc"
-         inkscape:connector-curvature="0"
-         id="path969-5"
-         d="m 337.50502,140.00008 -1.505,3.70002 c 0,0 0.68415,1.60587 1.19605,2.87138 0.62337,1.54113 1.26395,3.20347 1.92196,4.98702 v 0 l 3.28534,0.0887 c -0.46032,-1.2104 -0.91573,-2.36621 -1.36593,-3.46522 -0.57143,-1.45455 -1.14295,-2.84845 -1.71438,-4.18179 -0.57143,-1.33333 -1.81804,-4.00008 -1.81804,-4.00008 z m -0.48056,12.88544 2.63901,0.17953 1.23574,2.93505 h 3.40081 l -1.27234,-2.92659 -0.0277,-0.0734 z"
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.1;fill:#f34f17;fill-opacity:1;stroke:none;stroke-width:0.64935064px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;fill:#fff9f2;fill-opacity:1;stroke:none;stroke-width:4.9062047px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-         d="m 140.4961,94.000096 c -4.70996,9.812414 -9.22355,19.756004 -13.54101,29.830084 -4.31746,9.94324 -8.7021,20.4105 -13.15039,31.40039 -1.66494,4.23801 -3.36668,8.65932 -5.07031,13.0918 -1.04969,2.39777 -2.22981,5.26836 -4.07813,10.23242 -3.0972,8.22972 -6.631803,17.55233 -10.087889,26.67969 -1.25915,3.18508 -2.64003,6.75373 -4.82617,12.76562 h 14.718749 11.10156 l 12.36328,-34.73633 24.33203,-1.05859 24.33399,1.05859 12.36329,34.73633 h 11.10156 14.71875 c -2.18614,-6.01189 -3.56702,-9.58054 -4.82617,-12.76562 -3.45609,-9.12736 -6.99069,-18.44997 -10.08789,-26.67969 -1.84833,-4.96406 -3.02844,-7.83465 -4.07813,-10.23242 -1.70363,-4.43248 -3.40538,-8.85379 -5.07031,-13.0918 -4.44829,-10.98989 -8.83294,-21.45715 -13.1504,-31.40039 -4.31746,-10.07409 -8.83106,-20.01767 -13.54102,-29.830084 h -0.39062 -11.11328 -0.51758 -11.11328 z m 11.76172,27.037114 c 0.0856,0.19974 0.17424,0.39587 0.25977,0.5957 v 0.15235 c 3.59305,7.98261 7.06728,16.24447 10.41015,24.81054 4.0558,10.59741 4.11217,9.58635 8.16797,20.96875 l -18.83789,0.67969 -18.83593,-0.67969 c 4.0558,-11.3824 4.11216,-10.37134 8.16796,-20.96875 3.34287,-8.56607 6.81711,-16.82793 10.41016,-24.81054 v -0.15235 c 0.0854,-0.19959 0.17233,-0.3962 0.25781,-0.5957 z"
-         id="text954-5"
-         inkscape:connector-curvature="0" />
-      <rect
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f8f8f8;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.00000005, 2.00000005;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="rect958"
-         width="17.999998"
-         height="3"
-         x="327.00003"
-         y="150.00009"
-         ry="1.4687499"
-         rx="1.4687499" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#f34f17;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.00000015, 2.00000015;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 328.59963,151.0001 c -0.3324,0 -0.59961,0.223 -0.59961,0.5 0,0.277 0.26721,0.5 0.59961,0.5 h 4 5.80078 5 c 0.3324,0 0.59961,-0.223 0.59961,-0.5 0,-0.277 -0.26721,-0.5 -0.59961,-0.5 h -5 -5.80078 z"
-         id="rect962"
-         inkscape:connector-curvature="0" />
-      <rect
-         ry="12"
-         y="168.00009"
-         x="84"
-         height="24"
-         width="136"
-         id="rect1040"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1066);enable-background:accumulate"
-         rx="12" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.1;fill:#f34f17;fill-opacity:1;stroke:none;stroke-width:4.9062047px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-         d="m 163.75782,94.349706 -11.05078,27.865234 c 3.52502,7.85046 6.93726,15.96708 10.2207,24.38086 4.0558,10.59741 4.11217,9.58635 8.16797,20.96875 l -6.35351,0.22852 4.40625,15.14648 7.44336,0.32422 12.36329,34.73633 h 11.10156 14.71875 c -2.18614,-6.01189 -3.56702,-9.58054 -4.82617,-12.76562 -3.45609,-9.12737 -6.99069,-18.44997 -10.08789,-26.67969 -1.84833,-4.96406 -3.02844,-7.83465 -4.07813,-10.23242 -1.70363,-4.43248 -3.40538,-8.85379 -5.07031,-13.0918 -4.44829,-10.98989 -8.83294,-21.45715 -13.1504,-31.40039 -3.113,-7.26369 -6.33141,-14.45625 -9.64844,-21.58399 z"
-         id="path1693"
-         inkscape:connector-curvature="0" />
-      <rect
-         rx="12"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="rect4270"
-         width="136"
-         height="24"
-         x="84"
-         y="166.00009"
-         ry="12" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#f34f17;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 96.000011,174.0001 c -2.216,0 -4,1.784 -4,4 0,2.216 1.784,4 4,4 h 39.624999 32.375 40.37501 c 2.00825,0 3.625,-1.61675 3.625,-3.625 v -0.75 c 0,-2.00825 -1.61675,-3.625 -3.625,-3.625 h -40.37501 -32.375 z"
-         id="rect4272"
-         inkscape:connector-curvature="0" />
-      <rect
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f8f8f8;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.00000001, 2.00000001;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="rect4270-9"
-         width="13.999936"
-         height="3"
-         x="325.00012"
-         y="201"
-         ry="1.5"
-         rx="1.5" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#f34f17;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.00000001, 2.00000001;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 326.50002,202 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 h 3.93359 3.06641 4.06641 c 0.24027,0 0.43359,-0.19332 0.43359,-0.43359 v -0.13282 c 0,-0.24027 -0.19332,-0.43359 -0.43359,-0.43359 h -4.06641 -3.06641 z"
-         id="rect4272-3"
-         inkscape:connector-curvature="0" />
-      <rect
-         rx="0.77142125"
-         ry="0.77777553"
-         y="244.88899"
-         x="324.00006"
-         height="1.5555511"
-         width="8"
-         id="rect4270-9-8"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#f8f8f8;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.00000001, 2.00000001;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;fill:#fff9f2;fill-opacity:1;stroke:none;stroke-width:4.90620422px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-         d="m 341.3785,72.070886 c -0.9697,2.02021 -1.69918,3.46721 -2.58806,5.54128 -0.8889,2.04714 -1.79162,4.20217 -2.70744,6.46479 -0.34278,0.87253 -0.69314,1.7828 -1.04388,2.69537 -0.21612,0.49366 -0.45909,1.08466 -0.83962,2.10668 -0.63766,1.69435 -1.06528,2.71382 -1.77683,4.59298 -0.25924,0.65575 -0.54354,1.39048 -0.99362,2.62822 h 3.03033 2.28561 l 2.24529,-6.25171 5.00954,-0.21794 5.00994,0.21794 2.24529,6.25171 h 2.28562 3.03032 c -0.45008,-1.23774 -0.73438,-1.97247 -0.99362,-2.62822 -0.71155,-1.87916 -1.13916,-2.89863 -1.77683,-4.59298 -0.38054,-1.02202 -0.6235,-1.61302 -0.83961,-2.10668 -0.35075,-0.91257 -0.70111,-1.82284 -1.04389,-2.69537 -0.91582,-2.26262 -1.61899,-3.81776 -2.50789,-5.86489 -0.88888,-2.07408 -1.81815,-4.12173 -2.78785,-6.14194 h -0.0804 l -2.68736,3.2e-4 h -0.10652 l -2.28803,8.6e-4 z m 2.62132,4.96626 c 0.0176,0.0411 0.0359,0.0815 0.0536,0.12264 v 0.0314 c 0.73973,1.64348 1.45502,3.34445 2.14326,5.10806 0.83502,2.18182 0.84662,1.97366 1.68164,4.31709 l -3.87838,0.13994 -3.87799,-0.13994 c 0.835,-2.34343 0.84661,-2.13527 1.68163,-4.31709 0.68824,-1.76361 1.40352,-3.46458 2.14327,-5.10806 v -0.0314 c 0.0176,-0.0411 0.0355,-0.0816 0.0531,-0.12264 z"
-         id="text954-5-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccc" />
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.1;fill:#f34f17;fill-opacity:1;stroke:none;stroke-width:4.90620422px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
-         d="m 346.56701,72.142106 -2.56699,4.85799 c 0.72575,1.61627 1.52055,3.56687 2.19655,5.29911 0.83502,2.18182 0.84663,1.97366 1.68163,4.3171 l -1.30807,0.0471 0.90717,3.11839 1.53246,0.0667 2.24529,6.25172 h 2.28562 3.03032 c -0.45008,-1.23774 -0.73438,-1.97248 -0.99362,-2.62822 -0.71155,-1.87917 -1.13916,-2.89864 -1.77683,-4.59299 -0.38054,-1.02202 -0.6235,-1.61302 -0.83961,-2.10668 -0.35075,-0.91257 -0.70111,-1.82284 -1.04389,-2.69537 -0.91582,-2.26262 -1.61899,-3.81776 -2.50789,-5.86489 -0.64092,-1.49547 -1.30352,-2.97674 -1.98643,-4.44421 z"
-         id="path1693-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccc" />
-      <rect
-         rx="2.4705882"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.00000007, 2.00000007;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="rect4270-93-6"
-         width="28"
-         height="5"
-         x="329.94672"
-         y="87.000099"
-         ry="2.5" />
-      <rect
-         rx="2.4705882"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.00000007, 2.00000007;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="rect4270-93"
-         width="28"
-         height="5"
-         x="329.94672"
-         y="86.000099"
-         ry="2.5" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#f34f17;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.00000008, 2.00000008;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 332.8008,88.000096 c -0.4432,0 -0.80078,0.223 -0.80078,0.5 0,0.277 0.35758,0.5 0.80078,0.5 h 7.92383 6.47461 8.07617 c 0.40165,0 0.72461,-0.20209 0.72461,-0.45312 v -0.0937 c 0,-0.25103 -0.32296,-0.45313 -0.72461,-0.45313 h -8.07617 -6.47461 z"
-         id="rect4272-6"
-         inkscape:connector-curvature="0" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer2"
-       inkscape:label="Highlights"
+       inkscape:label="Background"
+       style="display:inline">
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4835);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.2305;marker:none;enable-background:accumulate"
+         id="path4188"
+         cx="152"
+         cy="156"
+         r="111.99995" />
+      <circle
+         r="111.43143"
+         cy="156"
+         cx="152"
+         id="circle1191"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1199);stroke-width:1.13714;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate" />
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient924);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.10091;marker:none;enable-background:accumulate"
+         id="circle914"
+         cx="344"
+         cy="84"
+         r="22.99999" />
+      <circle
+         r="22.88324"
+         cy="84"
+         cx="344"
+         id="circle918"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient920);stroke-width:0.23352;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate" />
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient936);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.37016;marker:none;enable-background:accumulate"
+         id="circle926"
+         cx="336"
+         cy="148"
+         r="14.999994" />
+      <circle
+         r="14.923852"
+         cy="148"
+         cx="336"
+         id="circle930"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient932);stroke-width:0.152296;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate" />
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient948);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.05046;marker:none;enable-background:accumulate"
+         id="circle938"
+         cx="332"
+         cy="200"
+         r="11.499995" />
+      <circle
+         r="11.44162"
+         cy="200"
+         cx="332"
+         id="circle942"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient944);stroke-width:0.11676;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate" />
+      <circle
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient960);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.685083;marker:none;enable-background:accumulate"
+         id="circle950"
+         cx="328"
+         cy="244"
+         r="7.4999971" />
+      <circle
+         r="7.461926"
+         cy="244"
+         cx="328"
+         id="circle954"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient956);stroke-width:0.0761478;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.990234,67.998047 c -35.36853,0 -38.992187,3.623202 -38.992187,38.919923 v 98.1582 c 0,0.0882 0.0019,0.16224 0.002,0.25 V 108.91602 C 40,73.6193 43.625611,69.994141 78.994141,69.994141 H 152 225.00586 c 35.28016,0 38.97394,3.621035 38.99219,38.671879 v -1.74805 c 0,-35.296721 -3.62561,-38.919923 -38.99414,-38.919923 h -73.00586 z"
-         id="rect4158-78"
-         inkscape:connector-curvature="0" />
+         id="shape-3"
+         style="display:inline;enable-background:new;fill:url(#linearGradient1005);fill-opacity:1;stroke-width:2.02703;filter:url(#filter1053-7)"
+         d="m 575.3874,366.42501 c -6.0442,0.1577 -12.15035,1.78752 -17.75635,5.02441 -17.93918,10.3581 -24.08125,33.27911 -13.72315,51.21828 l 38.33253,66.37698 -122.55132,212.29012 h -95.66898 c -20.71619,0 -37.51222,16.79603 -37.51222,37.51223 0,20.71619 16.79603,37.49513 37.51222,37.49513 H 705.08228 C 721.56199,745.69354 700.32421,701.3348 662.68236,701.3348 H 546.2663 L 707.15015,422.6677 c 10.3581,-17.93917 4.21602,-40.86018 -13.72315,-51.21828 -17.93916,-10.35809 -40.86018,-4.21602 -51.21828,13.72315 0,0 -8.31781,28.83683 -16.66261,28.88185 -8.33107,0 -16.67969,-28.88185 -16.67969,-28.88185 -7.12118,-12.33319 -20.18177,-19.09465 -33.47902,-18.74756 z m 105.5811,143.58892 c -22.17566,18.32431 -44.60272,72.73877 -13.24464,127.06304 46.23645,80.06749 92.46796,160.16453 138.68414,240.23202 10.35809,17.93918 33.29621,24.08124 51.23537,13.72315 17.93917,-10.3581 24.08125,-33.27911 13.72315,-51.21828 l -36.65773,-63.48879 h 54.31155 c 20.71618,0 37.49513,-16.77893 37.49513,-37.49513 0,-20.71619 -16.77895,-37.51223 -37.49513,-37.51223 H 791.4202 C 754.60943,637.54751 717.77927,573.78414 680.9685,510.01393 Z M 437.06215,788.20251 c -11.37303,0.50888 -22.01044,6.35026 -27.92481,16.59425 l -26.96779,46.72365 c -9.46299,16.39039 -3.14395,37.63465 14.16749,47.62941 17.31144,9.99477 38.8671,4.85474 48.3301,-11.53565 l 26.96778,-46.72365 c 9.46299,-16.39039 3.14395,-37.63465 -14.16749,-47.62941 -6.49179,-3.74804 -13.58146,-5.36392 -20.40528,-5.0586 z"
+         transform="matrix(0.22857134,0,0,0.22857134,10.682141,3.0074634)" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 39.998047,203.07617 v 2 c 0,35.29673 3.624067,39.09487 38.992187,38.92188 h 73.007816 73.00586 c 35.36811,0.17299 38.99414,-3.62515 38.99414,-38.92188 v -2 c 0,35.29673 -3.62603,39.09487 -38.99414,38.92188 H 151.99805 78.990234 c -35.36812,0.17299 -38.992187,-3.62515 -38.992187,-38.92188 z"
-         id="rect4158-6"
-         inkscape:connector-curvature="0" />
+         id="path916"
+         style="display:inline;enable-background:new;fill:url(#linearGradient922);fill-opacity:1;stroke-width:2.02703;filter:url(#filter1053-7)"
+         d="m 575.3874,366.42501 c -6.0442,0.1577 -12.15035,1.78752 -17.75635,5.02441 -17.93918,10.3581 -24.08125,33.27911 -13.72315,51.21828 l 38.33253,66.37698 -122.55132,212.29012 h -95.66898 c -20.71619,0 -37.51222,16.79603 -37.51222,37.51223 0,20.71619 16.79603,37.49513 37.51222,37.49513 H 705.08228 C 721.56199,745.69354 700.32421,701.3348 662.68236,701.3348 H 546.2663 L 707.15015,422.6677 c 10.3581,-17.93917 4.21602,-40.86018 -13.72315,-51.21828 -17.93916,-10.35809 -40.86018,-4.21602 -51.21828,13.72315 0,0 -8.31781,28.83683 -16.66261,28.88185 -8.33107,0 -16.67969,-28.88185 -16.67969,-28.88185 -7.12118,-12.33319 -20.18177,-19.09465 -33.47902,-18.74756 z m 105.5811,143.58892 c -22.17566,18.32431 -44.60272,72.73877 -13.24464,127.06304 46.23645,80.06749 92.46796,160.16453 138.68414,240.23202 10.35809,17.93918 33.29621,24.08124 51.23537,13.72315 17.93917,-10.3581 24.08125,-33.27911 13.72315,-51.21828 l -36.65773,-63.48879 h 54.31155 c 20.71618,0 37.49513,-16.77893 37.49513,-37.49513 0,-20.71619 -16.77895,-37.51223 -37.49513,-37.51223 H 791.4202 C 754.60943,637.54751 717.77927,573.78414 680.9685,510.01393 Z M 437.06215,788.20251 c -11.37303,0.50888 -22.01044,6.35026 -27.92481,16.59425 l -26.96779,46.72365 c -9.46299,16.39039 -3.14395,37.63465 14.16749,47.62941 17.31144,9.99477 38.8671,4.85474 48.3301,-11.53565 l 26.96778,-46.72365 c 9.46299,-16.39039 3.14395,-37.63465 -14.16749,-47.62941 -6.49179,-3.74804 -13.58146,-5.36392 -20.40528,-5.0586 z"
+         transform="matrix(0.04693876,0,0,0.04693876,314.97937,52.581892)" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path937"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="url(#clipPath983)"
-         transform="rotate(90,328,244)" />
+         id="path928"
+         style="display:inline;enable-background:new;fill:url(#linearGradient934);fill-opacity:1;stroke-width:2.02703;filter:url(#filter1053-7)"
+         d="m 575.3874,366.42501 c -6.0442,0.1577 -12.15035,1.78752 -17.75635,5.02441 -17.93918,10.3581 -24.08125,33.27911 -13.72315,51.21828 l 38.33253,66.37698 -122.55132,212.29012 h -95.66898 c -20.71619,0 -37.51222,16.79603 -37.51222,37.51223 0,20.71619 16.79603,37.49513 37.51222,37.49513 H 705.08228 C 721.56199,745.69354 700.32421,701.3348 662.68236,701.3348 H 546.2663 L 707.15015,422.6677 c 10.3581,-17.93917 4.21602,-40.86018 -13.72315,-51.21828 -17.93916,-10.35809 -40.86018,-4.21602 -51.21828,13.72315 0,0 -8.31781,28.83683 -16.66261,28.88185 -8.33107,0 -16.67969,-28.88185 -16.67969,-28.88185 -7.12118,-12.33319 -20.18177,-19.09465 -33.47902,-18.74756 z m 105.5811,143.58892 c -22.17566,18.32431 -44.60272,72.73877 -13.24464,127.06304 46.23645,80.06749 92.46796,160.16453 138.68414,240.23202 10.35809,17.93918 33.29621,24.08124 51.23537,13.72315 17.93917,-10.3581 24.08125,-33.27911 13.72315,-51.21828 l -36.65773,-63.48879 h 54.31155 c 20.71618,0 37.49513,-16.77893 37.49513,-37.49513 0,-20.71619 -16.77895,-37.51223 -37.49513,-37.51223 H 791.4202 C 754.60943,637.54751 717.77927,573.78414 680.9685,510.01393 Z M 437.06215,788.20251 c -11.37303,0.50888 -22.01044,6.35026 -27.92481,16.59425 l -26.96779,46.72365 c -9.46299,16.39039 -3.14395,37.63465 14.16749,47.62941 17.31144,9.99477 38.8671,4.85474 48.3301,-11.53565 l 26.96778,-46.72365 c 9.46299,-16.39039 3.14395,-37.63465 -14.16749,-47.62941 -6.49179,-3.74804 -13.58146,-5.36392 -20.40528,-5.0586 z"
+         transform="matrix(0.03061224,0,0,0.03061224,317.0735,127.50993)" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.51173,240.91355 c 0,-2.89732 -0.30259,-3.44011 -3.25454,-3.42488 h -4.25716 -4.25724 c -2.95195,-0.0152 -3.25453,0.52756 -3.25453,3.42488 v 6.17331 c 0,2.8966 0.30255,3.42488 3.25453,3.42488 h 4.25724 4.25716 c 2.95199,0 3.25454,-0.52828 3.25454,-3.42488 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         id="path940"
+         style="display:inline;enable-background:new;fill:url(#linearGradient946);fill-opacity:1;stroke-width:2.02703;filter:url(#filter1053-7)"
+         d="m 575.3874,366.42501 c -6.0442,0.1577 -12.15035,1.78752 -17.75635,5.02441 -17.93918,10.3581 -24.08125,33.27911 -13.72315,51.21828 l 38.33253,66.37698 -122.55132,212.29012 h -95.66898 c -20.71619,0 -37.51222,16.79603 -37.51222,37.51223 0,20.71619 16.79603,37.49513 37.51222,37.49513 H 705.08228 C 721.56199,745.69354 700.32421,701.3348 662.68236,701.3348 H 546.2663 L 707.15015,422.6677 c 10.3581,-17.93917 4.21602,-40.86018 -13.72315,-51.21828 -17.93916,-10.35809 -40.86018,-4.21602 -51.21828,13.72315 0,0 -8.31781,28.83683 -16.66261,28.88185 -8.33107,0 -16.67969,-28.88185 -16.67969,-28.88185 -7.12118,-12.33319 -20.18177,-19.09465 -33.47902,-18.74756 z m 105.5811,143.58892 c -22.17566,18.32431 -44.60272,72.73877 -13.24464,127.06304 46.23645,80.06749 92.46796,160.16453 138.68414,240.23202 10.35809,17.93918 33.29621,24.08124 51.23537,13.72315 17.93917,-10.3581 24.08125,-33.27911 13.72315,-51.21828 l -36.65773,-63.48879 h 54.31155 c 20.71618,0 37.49513,-16.77893 37.49513,-37.49513 0,-20.71619 -16.77895,-37.51223 -37.49513,-37.51223 H 791.4202 C 754.60943,637.54751 717.77927,573.78414 680.9685,510.01393 Z M 437.06215,788.20251 c -11.37303,0.50888 -22.01044,6.35026 -27.92481,16.59425 l -26.96779,46.72365 c -9.46299,16.39039 -3.14395,37.63465 14.16749,47.62941 17.31144,9.99477 38.8671,4.85474 48.3301,-11.53565 l 26.96778,-46.72365 c 9.46299,-16.39039 3.14395,-37.63465 -14.16749,-47.62941 -6.49179,-3.74804 -13.58146,-5.36392 -20.40528,-5.0586 z"
+         transform="matrix(0.02346938,0,0,0.02346938,317.48968,184.29095)" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.97652888;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 343.51172,195.49156 c 0,-4.23214 -0.46371,-5.02499 -4.98757,-5.00275 h -6.5241 -6.52423 c -4.52386,-0.0222 -4.98757,0.77061 -4.98757,5.00275 v 9.01743 c 0,4.23108 0.46366,5.00275 4.98757,5.00275 h 6.52423 6.5241 c 4.52391,0 4.98757,-0.77167 4.98757,-5.00275 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path935"
-         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath971)"
-         transform="rotate(90,331.99966,200)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 350.50001,142.07508 c 0,-5.56175 -0.58409,-6.6037 -6.28227,-6.57447 h -8.21765 -8.21781 c -5.69818,-0.0293 -6.28227,1.01272 -6.28227,6.57447 v 11.85044 c 0,5.56037 0.58403,6.57447 6.28227,6.57447 h 8.21781 8.21765 c 5.69824,0 6.28227,-1.0141 6.28227,-6.57447 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         transform="matrix(0,0.66664182,-0.63636364,0,389.45455,-81.324786)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004-8);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994-1)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 366.50065,75.231076 c 0,-8.23154 -0.90635,-9.77365 -9.74838,-9.7304 H 344.0007 331.24889 c -8.84203,-0.0433 -9.74838,1.49886 -9.74838,9.7304 v 17.53897 c 0,8.229494 0.90625,9.730394 9.74838,9.730394 h 12.75181 12.75157 c 8.84213,0 9.74838,-1.5009 9.74838,-9.730404 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1004);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         clip-path="url(#clipPath994)"
-         transform="rotate(90,344,84)" />
-      <path
-         style="display:inline;fill:none;stroke:#fee8bc;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 337,68 c 0,0 0,-7 7,-7 7,0 7,7 7,7"
-         id="path24398"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csc" />
-      <path
-         style="display:inline;fill:none;stroke:#fee8bc;stroke-width:10;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 116.9973,72.000005 c 0,0 0,-35 35,-35 35,0 35,35 35,35"
-         id="path24398-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csc" />
-      <path
-         style="display:inline;fill:none;stroke:#fee8bc;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 331,138 c 0,0 0,-5 5,-5 5,0 5,5 5,5"
-         id="path24398-3"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csc" />
-      <path
-         style="display:inline;fill:none;stroke:#fee8bc;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 328,192 c 0,0 0,-3.5 4,-3.5 4,0 4,3.5 4,3.5"
-         id="path24398-3-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csc" />
-      <path
-         style="display:inline;fill:none;stroke:#fee8bc;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 325,239 c 0,0 0,-2.5 3,-2.5 3,0 3,2.5 3,2.5"
-         id="path24398-3-6-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csc" />
+         id="path952"
+         style="display:inline;enable-background:new;fill:url(#linearGradient958);fill-opacity:1;stroke-width:2.02703;filter:url(#filter1053-7)"
+         d="m 575.3874,366.42501 c -6.0442,0.1577 -12.15035,1.78752 -17.75635,5.02441 -17.93918,10.3581 -24.08125,33.27911 -13.72315,51.21828 l 38.33253,66.37698 -122.55132,212.29012 h -95.66898 c -20.71619,0 -37.51222,16.79603 -37.51222,37.51223 0,20.71619 16.79603,37.49513 37.51222,37.49513 H 705.08228 C 721.56199,745.69354 700.32421,701.3348 662.68236,701.3348 H 546.2663 L 707.15015,422.6677 c 10.3581,-17.93917 4.21602,-40.86018 -13.72315,-51.21828 -17.93916,-10.35809 -40.86018,-4.21602 -51.21828,13.72315 0,0 -8.31781,28.83683 -16.66261,28.88185 -8.33107,0 -16.67969,-28.88185 -16.67969,-28.88185 -7.12118,-12.33319 -20.18177,-19.09465 -33.47902,-18.74756 z m 105.5811,143.58892 c -22.17566,18.32431 -44.60272,72.73877 -13.24464,127.06304 46.23645,80.06749 92.46796,160.16453 138.68414,240.23202 10.35809,17.93918 33.29621,24.08124 51.23537,13.72315 17.93917,-10.3581 24.08125,-33.27911 13.72315,-51.21828 l -36.65773,-63.48879 h 54.31155 c 20.71618,0 37.49513,-16.77893 37.49513,-37.49513 0,-20.71619 -16.77895,-37.51223 -37.49513,-37.51223 H 791.4202 C 754.60943,637.54751 717.77927,573.78414 680.9685,510.01393 Z M 437.06215,788.20251 c -11.37303,0.50888 -22.01044,6.35026 -27.92481,16.59425 l -26.96779,46.72365 c -9.46299,16.39039 -3.14395,37.63465 14.16749,47.62941 17.31144,9.99477 38.8671,4.85474 48.3301,-11.53565 l 26.96778,-46.72365 c 9.46299,-16.39039 3.14395,-37.63465 -14.16749,-47.62941 -6.49179,-3.74804 -13.58146,-5.36392 -20.40528,-5.0586 z"
+         transform="matrix(0.01530612,0,0,0.01530612,318.53676,233.75497)" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/wine.svg
+++ b/icons/src/fullcolor/default/apps/wine.svg
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="wine.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,22 +31,22 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="173.10757"
-     inkscape:cy="93.549444"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="2"
+     inkscape:cx="417.5"
+     inkscape:cy="127"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1011"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
-     inkscape:snap-bbox="false"
+     inkscape:snap-bbox="true"
      gridtolerance="10000"
      inkscape:object-nodes="true"
      inkscape:snap-grids="true"
@@ -62,7 +62,7 @@
      inkscape:pagecheckerboard="false"
      showborder="false"
      inkscape:document-rotation="0"
-     inkscape:bbox-nodes="true">
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -93,262 +93,54 @@
   <defs
      id="defs3">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient938">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(0.0750367,-43.19,43.19,0.0750367,87.46,45.5869)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         id="stop934"
+         stop-color="#003fb6"
          offset="0"
-         style="stop-color:#e6e6e6;stop-opacity:1" />
+         id="stop2" />
       <stop
-         id="stop936"
+         stop-color="#21c6fb"
          offset="1"
-         style="stop-color:#f7f7f7;stop-opacity:1" />
+         id="stop4" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient931">
-      <stop
-         id="stop927"
-         offset="0"
-         style="stop-color:#e6e6e6;stop-opacity:1" />
-      <stop
-         id="stop929"
-         offset="1"
-         style="stop-color:#f7f7f7;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1332">
-      <stop
-         id="stop1328"
-         offset="0"
-         style="stop-color:#e6e6e6;stop-opacity:1" />
-      <stop
-         id="stop1330"
-         offset="1"
-         style="stop-color:#f7f7f7;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient962">
-      <stop
-         style="stop-color:#7b0619;stop-opacity:1;"
-         offset="0"
-         id="stop958" />
-      <stop
-         style="stop-color:#bb0212;stop-opacity:1"
-         offset="1"
-         id="stop960" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient956">
-      <stop
-         id="stop952"
-         offset="0"
-         style="stop-color:#e6e6e6;stop-opacity:1" />
-      <stop
-         id="stop954"
-         offset="1"
-         style="stop-color:#f7f7f7;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient931"
-       id="linearGradient1686"
-       x1="320.99991"
-       y1="92.000153"
-       x2="366.99991"
-       y2="76.000153"
+       xlink:href="#a"
+       id="linearGradient371"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000121)" />
+       gradientTransform="matrix(0.07964944,-45.845023,45.845023,0.07964944,411.36109,106.91391)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient938"
-       id="linearGradient1688"
-       x1="321.00003"
-       y1="153.00002"
-       x2="351.00003"
-       y2="143.00002"
+       xlink:href="#a"
+       id="linearGradient379"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00002,148)" />
+       gradientTransform="matrix(0.05194529,-29.898929,29.898929,0.05194529,379.93114,162.94386)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1690"
-       x1="320.9993"
-       y1="202.99928"
-       x2="342.9993"
-       y2="196.99928"
+       xlink:href="#a"
+       id="linearGradient387"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
+       gradientTransform="matrix(0.03982472,-22.922512,22.922512,0.03982472,365.68054,211.45695)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1332"
-       id="linearGradient1692"
-       x1="320.00031"
-       y1="247.00034"
-       x2="336.00031"
-       y2="241.00034"
+       xlink:href="#a"
+       id="linearGradient395"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
+       gradientTransform="matrix(0.02597264,-14.949465,14.949465,0.02597264,349.96557,251.47193)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient4338-7">
-      <stop
-         id="stop4342-6"
-         offset="0"
-         style="stop-color:#e6e6e6;stop-opacity:1" />
-      <stop
-         id="stop4340-2"
-         offset="1"
-         style="stop-color:#f7f7f7;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1692-6"
-       x1="321.00031"
-       y1="244.00034"
-       x2="335.00031"
-       y2="244.00034"
+       xlink:href="#a"
+       id="linearGradient414"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1690-9"
-       x1="320.9993"
-       y1="199.99928"
-       x2="342.9993"
-       y2="199.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1688-4"
-       x1="322"
-       y1="148.00002"
-       x2="350"
-       y2="148.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00001,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1686-0"
-       x1="321.99991"
-       y1="84.000153"
-       x2="365.99991"
-       y2="84.000153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000125)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58449"
-       x="-0.047999425"
-       width="1.0959988"
-       y="-0.048000575"
-       height="1.0960012">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.4800539"
-         id="feGaussianBlur58451" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58492"
-       x="-0.011999856"
-       width="1.0239997"
-       y="-0.012000144"
-       height="1.0240003">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1200135"
-         id="feGaussianBlur58494" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient956"
-       id="linearGradient943"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,151.9973,155.9997)"
-       x1="39.997601"
-       y1="155.99699"
-       x2="263.99759"
-       y2="155.99699" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient962"
-       id="linearGradient964"
-       x1="160"
-       y1="136"
-       x2="160"
-       y2="268"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient962"
-       id="linearGradient1336"
-       gradientUnits="userSpaceOnUse"
-       x1="160"
-       y1="136"
-       x2="160"
-       y2="268"
-       gradientTransform="translate(-3.9693958e-5,-1.637e-5)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient962"
-       id="linearGradient942"
-       gradientUnits="userSpaceOnUse"
-       x1="361"
-       y1="80"
-       x2="361"
-       y2="107"
-       gradientTransform="translate(-7.2716616e-6)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient962"
-       id="linearGradient963"
-       gradientUnits="userSpaceOnUse"
-       x1="344.00003"
-       y1="145"
-       x2="344.00003"
-       y2="163"
-       gradientTransform="translate(-1.8004249e-5)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient962"
-       id="linearGradient976"
-       gradientUnits="userSpaceOnUse"
-       x1="341.00003"
-       y1="197.99995"
-       x2="341.00003"
-       y2="211.99995"
-       gradientTransform="translate(-4.0996777e-5,4.8e-5)" />
+       gradientTransform="matrix(0.38785815,-223.24534,223.24534,0.38785815,480.0192,267.5808)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -360,13 +152,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -440,14 +232,15 @@
       <text
          y="-8.2548828"
          xml:space="preserve"
-         x="231.34375"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.6667px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="146.48828"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
          inkscape:label="icon-name"
          id="icon-name"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+           y="-8.2548828"
+           x="146.48828"
            sodipodi:role="line"
-           id="tspan913"
-           x="231.34375"
-           y="-8.2548828">wine</tspan></text>
+           id="tspan924">wine</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -482,199 +275,84 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer9"
-       inkscape:label="Optional outline for white icons"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 225.07297,43.99969 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 c 0.17299,35.36812 -3.62489,38.99353 -38.92162,38.99353 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 155.99969 82.99322 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline">
+         d="M 264,76.191988 C 264,58.421266 249.57873,43.999999 231.80801,43.999999 H 72.191988 c -17.770722,0 -32.191989,14.421267 -32.191989,32.191989 V 235.80801 C 39.999999,253.57873 54.421266,268 72.191988,268 H 231.80801 C 249.57873,268 264,253.57873 264,235.80801 Z"
+         fill="url(#a)"
+         id="path7"
+         style="fill:url(#linearGradient414);stroke-width:5.16891" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 367,67.610856 c 0,-3.649345 -2.96151,-6.610855 -6.61085,-6.610855 h -32.77829 c -3.64934,0 -6.61085,2.96151 -6.61085,6.610855 v 32.778294 c 0,3.64934 2.96151,6.61085 6.61085,6.61085 h 32.77829 C 364.03849,107 367,104.03849 367,100.38915 Z"
+         fill="url(#a)"
+         id="path365"
+         style="fill:url(#linearGradient371);stroke-width:1.06147" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 351,137.31143 C 351,134.93142 349.06858,133 346.68858,133 H 325.31143 C 322.93142,133 321,134.93142 321,137.31143 v 21.37715 c 0,2.38 1.93142,4.31142 4.31143,4.31142 h 21.37715 c 2.38,0 4.31142,-1.93142 4.31142,-4.31142 z"
+         fill="url(#a)"
+         id="path373"
+         style="fill:url(#linearGradient379);stroke-width:0.692265" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.12858,237.00001 c -3.74357,0 -4.14638,0.30899 -4.12803,3.32331 v 4.17669 4.17668 c -0.0183,3.01433 0.38446,3.32332 4.12803,3.32332 h 7.74335 c 3.7436,0 4.12805,-0.30895 4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 -0.38446,-3.32331 -4.12805,-3.32331 z"
-         id="path918-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 343.5,191.80543 c 0,-1.82468 -1.48076,-3.30543 -3.30543,-3.30543 h -16.38914 c -1.82468,0 -3.30543,1.48075 -3.30543,3.30543 v 16.38914 c 0,1.82467 1.48075,3.30543 3.30543,3.30543 h 16.38914 c 1.82467,0 3.30543,-1.48076 3.30543,-3.30543 z"
+         fill="url(#a)"
+         id="path381"
+         style="fill:url(#linearGradient387);stroke-width:0.530737" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 326.45275,189.00048 c -1.2321,0 -2.21668,0.0221 -3.06999,0.14144 -0.85332,0.11937 -1.62809,0.35533 -2.21066,0.83967 -0.58256,0.48436 -0.86983,1.13381 -1.01188,1.84587 -0.14202,0.71207 -0.16501,1.53239 -0.15897,2.56202 v 7.61066 4.6143 c -0.006,1.02762 0.0171,1.84735 0.15897,2.55843 0.14203,0.71208 0.42931,1.36152 1.01188,1.84587 0.58258,0.48434 1.35734,0.7203 2.21066,0.83967 0.85331,0.11936 1.83789,0.14144 3.06999,0.14144 h 11.09542 c 1.2321,0 2.21381,-0.022 3.0657,-0.14144 0.85187,-0.11947 1.62795,-0.35683 2.2085,-0.84146 0.58057,-0.48464 0.86451,-1.13152 1.00758,-1.84228 0.14307,-0.71077 0.16972,-1.5314 0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 -0.0266,-1.84946 -0.16972,-2.56023 -0.14307,-0.71076 -0.42701,-1.35765 -1.00758,-1.84228 -0.58055,-0.48464 -1.35661,-0.722 -2.2085,-0.84147 -0.8519,-0.11947 -1.83359,-0.14144 -3.0657,-0.14144 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 329.30094,134 c -1.63949,0 -2.94082,0.0308 -4.04505,0.19141 -1.10422,0.16064 -2.06697,0.4726 -2.78308,1.09179 -0.71611,0.61919 -1.0805,1.45612 -1.26421,2.41407 -0.18374,0.95795 -0.21537,2.08705 -0.20733,3.51171 V 149 v 7.79688 c -0.009,1.42131 0.0239,2.5495 0.20733,3.50585 0.18371,0.95796 0.5481,1.79488 1.26421,2.41407 0.71611,0.61919 1.67886,0.93115 2.78308,1.09179 1.10423,0.16065 2.40556,0.19141 4.04505,0.19141 h 13.40164 c 1.63949,0 2.93835,-0.0307 4.04054,-0.19141 1.10219,-0.16075 2.06274,-0.47425 2.77633,-1.09375 0.71357,-0.6195 1.07457,-1.45363 1.25969,-2.41015 C 350.96429,159.34816 351,158.22066 351,156.79688 V 149 141.20312 c 0,-1.42378 -0.0358,-2.55128 -0.22086,-3.50781 -0.18512,-0.95653 -0.54612,-1.79065 -1.25969,-2.41015 -0.71359,-0.61951 -1.67414,-0.933 -2.77633,-1.09375 C 345.64093,134.03065 344.34207,134 342.70258,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 333.65776,62 c -2.6221,0 -4.68675,0.05009 -6.38561,0.286735 -1.69887,0.236639 -3.08904,0.680503 -4.10735,1.523515 -1.0183,0.843013 -1.55577,1.996072 -1.83828,3.406406 -0.28252,1.410336 -0.33767,3.127346 -0.32482,5.308412 v 12.474816 12.480783 c -0.0127,2.177715 0.0426,3.893853 0.32482,5.302673 0.28251,1.41034 0.81998,2.5634 1.83828,3.40641 1.01831,0.84301 2.40848,1.28688 4.10735,1.52351 1.69888,0.23665 3.76351,0.28674 6.38561,0.28674 h 20.68618 c 2.62213,0 4.68568,-0.05 6.38104,-0.28674 1.69534,-0.23674 3.08126,-0.6821 4.09581,-1.52542 1.01457,-0.84331 1.54885,-1.99555 1.83367,-3.4045 C 366.93929,101.37441 367,99.660878 367,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0608,-3.893733 -0.34554,-5.302677 -0.28482,-1.408942 -0.81911,-2.561177 -1.83368,-3.404494 -1.01455,-0.843317 -2.40047,-1.288685 -4.09582,-1.525427 C 359.02962,62.049992 356.96605,62 354.34394,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500049 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 v 12.75157 12.75181 c -0.0527,8.842031 1.82291,9.748381 11.83407,9.748381 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.748381 v -12.75181 -12.75157 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 326.17688,188.49945 c -5.14666,0 -5.70043,0.43262 -5.67521,4.65309 v 5.84793 7.84761 c -0.0253,4.22046 0.52855,4.65307 5.67521,4.65307 h 11.64568 c 5.14665,0 5.67521,-0.43255 5.67521,-4.65307 v -7.84761 -5.84793 c 0,-4.22051 -0.52857,-4.65309 -5.67522,-4.65309 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.4056,236.50001 c -3.47604,0 -3.85006,0.30899 -3.83302,3.32331 v 4.17669 4.17668 c -0.017,3.01433 0.35698,3.32332 3.83302,3.32332 h 7.18996 c 3.47605,0 3.83303,-0.30895 3.83303,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.35699,-3.32331 -3.83303,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         id="path938"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient943);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 78.910156,44 C 43.613446,44 39.987797,47.625611 39.988281,82.994141 L 40.01172,216 H 264 L 263.98828,82.994141 C 264.16127,47.626031 260.36509,44 225.06836,44 Z"
-         sodipodi:nodetypes="sscccss" />
-      <path
-         id="path948"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient964);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.910156,268 c -35.29671,0 -38.922359,-3.62561 -38.921875,-38.99414 L 40,156 c 0,0 24,28 80,28 56,0 88,-48 116,-48 28,0 27.98828,20 27.98828,20 v 73.00586 C 264.16127,264.37397 260.36509,268 225.06836,268 Z"
-         sodipodi:nodetypes="ssczzccss" />
-      <path
-         id="path1334"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1336);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.57227,242 c -1.85713,0 -3.97908,3.1836 -7.69336,3.1836 -3.71428,0 -5.30664,-1.85743 -5.30664,-1.85743 v 4.84961 c -0.017,3.01433 0.35794,3.32422 3.83398,3.32422 h 7.18945 c 3.47605,0 3.83203,-0.30985 3.83203,-3.32422 v -4.84961 c 0,0 0.002,-1.32617 -1.85546,-1.32617 z"
-         sodipodi:nodetypes="ssccssccs" />
-      <path
-         id="path940"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient942);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 360.87695 80 C 355.25208 80 348.822 89.642578 337.57227 89.642578 C 326.32255 89.642578 321.50195 84.017578 321.50195 84.017578 L 321.5 93 L 321.50195 93 L 321.50195 96.751953 C 321.44925 105.59398 323.32478 106.5 333.33594 106.5 L 354.66602 106.5 C 364.67468 106.5 366.5 105.59408 366.5 96.751953 L 366.5 91 L 366.49805 91 L 366.49805 84.017578 C 366.49805 84.017578 366.50181 80 360.87695 80 z " />
-      <path
-         id="path959"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient963);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 331.85938,151 c -7.24983,0 -10.35743,-3.41016 -10.35743,-3.41016 l -0.002,8.62696 c -2e-5,0.004 2e-5,0.006 0,0.01 -0.0324,5.688 1.17945,6.27344 7.62695,6.27344 h 13.7461 c 6.45003,0 7.62695,-0.58496 7.62695,-6.2832 v -8.62696 c 0,0 0.002,-2.58984 -3.62296,-2.58996 C 343.25203,145 339.10919,151 331.85938,151 Z"
-         sodipodi:nodetypes="scccsssccs" />
-      <path
-         id="path974"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient976);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 340.62305 198.07227 C 337.74849 198.07227 334.46395 203 328.71484 203 C 322.96573 203 320.50195 200.125 320.50195 200.125 L 320.50195 206.84766 C 320.47665 211.06812 321.03107 211.50195 326.17773 211.50195 L 337.82227 211.50195 C 342.96892 211.50195 343.49805 211.06818 343.49805 206.84766 L 343.49805 200.125 C 343.49805 200.125 343.4976 198.07227 340.62305 198.07227 z " />
+         d="m 335.5,238.65571 c 0,-1.19 -0.96571,-2.15571 -2.15571,-2.15571 h -10.68858 c -1.19,0 -2.15571,0.96571 -2.15571,2.15571 v 10.68858 c 0,1.19 0.96571,2.15571 2.15571,2.15571 h 10.68858 c 1.19,0 2.15571,-0.96571 2.15571,-2.15571 z"
+         fill="url(#a)"
+         id="path389"
+         style="fill:url(#linearGradient395);stroke-width:0.346133" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms and folds"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.15;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none"
-         d="m 151.99458,267.99969 h 8.00001 65.00586 c 35.36853,0 38.99414,-3.62508 38.99414,-38.92094 V 82.926038 c 0,-35.295889 -3.62602,-39.093927 -38.99414,-38.920941 h -65.00586 -8.00001 z"
-         id="rect4158-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscccc" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer4"
-       inkscape:label="Borders"
-       style="display:inline;opacity:1">
+         d="M 89.027136,151.38933 88.980616,106.4353 139.39819,98.919697 V 151.38933 Z M 147.80284,97.586117 215.00905,86.850286 v 64.539044 h -67.20621 z m 67.21654,63.024553 -0.0103,64.53904 -67.20621,-10.374 v -54.16504 z m -75.62119,52.98652 -50.376223,-7.57762 -0.0052,-45.4089 h 50.381393 z"
+         fill="#eff9fe"
+         fill-opacity="0.75"
+         fill-rule="nonzero"
+         id="path9"
+         style="display:inline;enable-background:new;stroke-width:5.16891" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92188,43.999698 c -35.296728,0 -39.09487,3.62603 -38.92188,38.99414 v 2 c -0.17299,-35.36811 3.625152,-38.99414 38.92188,-38.99414 h 146.15624 c 35.29673,0 38.92188,3.62561 38.92188,38.99414 v -2 c 0,-35.36853 -3.62515,-38.99414 -38.92188,-38.99414 z"
-         id="path931"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
+         d="m 331.06808,83.053166 -0.01,-9.231631 10.35361,-1.543382 v 10.775013 z m 12.07001,-11.048873 13.80127,-2.20468 v 13.253553 h -13.80127 z m 13.80339,12.942541 -0.002,13.253554 -13.80127,-2.130377 V 84.946834 Z m -15.52935,10.881161 -10.34511,-1.556119 -0.001,-9.325042 h 10.34618 z"
+         fill="#eff9fe"
+         fill-opacity="0.75"
+         fill-rule="nonzero"
+         id="path367"
+         style="display:inline;enable-background:new;stroke-width:1.06147" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92728,267.9997 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 c -0.17299,35.36811 3.625154,38.99414 38.921885,38.99414 h 146.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 c 0,35.36853 -3.62515,38.99414 -38.92188,38.99414 z"
-         id="path931-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
+         d="m 327.56614,147.3825 -0.006,-6.02063 6.75235,-1.00655 v 7.02718 z m 7.87174,-7.20579 9.00083,-1.43783 v 8.64362 h -9.00083 z m 9.00222,8.44079 -10e-4,8.64362 -9.00083,-1.38937 v -7.25425 z m -10.12784,7.09641 -6.74682,-1.01486 -6.9e-4,-6.08155 h 6.74751 z"
+         fill="#eff9fe"
+         fill-opacity="0.75"
+         fill-rule="nonzero"
+         id="path375"
+         style="display:inline;enable-background:new;stroke-width:0.692265" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500047 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 V 84 96.75181 c -0.0527,8.84203 1.82291,9.74838 11.83407,9.74838 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 325.53403,199.52658 -0.005,-4.61582 5.1768,-0.77169 v 5.38751 z m 6.03501,-5.52444 6.90064,-1.10234 v 6.62678 h -6.90064 z m 6.9017,6.47127 -10e-4,6.62678 -6.90064,-1.06519 v -5.56159 z m -7.76468,5.44059 -5.17256,-0.77806 -5.3e-4,-4.66253 h 5.17309 z"
+         fill="#eff9fe"
+         fill-opacity="0.75"
+         fill-rule="nonzero"
+         id="path383"
+         style="display:inline;enable-background:new;stroke-width:0.530737" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 337.97659,211.50015 c 4.67187,0 5.5471,-0.42296 5.52255,-4.54923 v -7.95037 -5.95084 c 0.0245,-4.12627 -0.85068,-4.54923 -5.52255,-4.54923 h -11.95364 c -4.67071,0 -5.52256,0.42291 -5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 0.85185,4.54923 5.52256,4.54923 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.55494,251.5 c 3.33705,0 3.96221,-0.30212 3.94468,-3.24946 v -4.2505 -4.25059 c 0.0175,-2.94734 -0.60763,-3.24945 -3.94468,-3.24945 h -7.11025 c -3.33622,0 -3.94469,0.30208 -3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 0.60847,3.24946 3.94469,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="opacity:0.7">
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 324.44531,237 c -1.65302,0 -2.54604,0.12548 -2.91601,0.41406 -0.18499,0.14429 -0.30479,0.33122 -0.39649,0.70313 C 321.0411,238.4891 321,239.03036 321,239.75 v 4.25 4.25 c 0,0.71964 0.0411,1.26082 0.13281,1.63281 0.0917,0.37191 0.2115,0.55884 0.39649,0.70313 0.36997,0.28858 1.26299,0.41406 2.91601,0.41406 h 7.10938 c 1.65343,0 2.55203,-0.12511 2.92383,-0.41406 0.18589,-0.14448 0.30578,-0.33208 0.39648,-0.70313 0.0907,-0.37105 0.129,-0.90979 0.125,-1.6289 v -0.002 V 244 v -4.25195 -0.002 c 0.004,-0.71911 -0.0343,-1.25785 -0.125,-1.6289 -0.0907,-0.37105 -0.21059,-0.55865 -0.39648,-0.70313 C 334.10673,237.12512 333.20812,237 331.55469,237 Z m 5.32813,1.04688 c 1.10767,-3.4e-4 2.21363,0.008 3.32031,0.0449 0.26616,0.0599 0.75737,-0.0208 0.79297,0.3457 0.13405,1.84438 0.0662,3.68774 0.10156,5.53906 -0.0126,1.86745 0.0543,3.67031 -0.10351,5.49805 0.0642,0.42314 -0.43946,0.35577 -0.70313,0.42187 -3.43277,0.0703 -6.87577,0.0589 -10.29883,0.002 -0.22288,-0.0398 -0.55622,-3.2e-4 -0.71093,-0.1875 -0.19863,-1.12995 -0.12696,-2.26946 -0.16016,-3.41992 0.0138,-2.55648 -0.029,-5.10728 0.0898,-7.65625 -0.03,-0.2727 0.10944,-0.49629 0.40039,-0.48829 1.30659,-0.161 2.63265,-0.0636 3.94727,-0.0976 1.10718,0.006 2.21655,-0.002 3.32422,-0.002 z"
-         id="path918-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none"
-         d="m 326.02383,189.00048 c -2.32027,0 -3.60941,0.15494 -4.20703,0.62109 -0.29882,0.23308 -0.48964,0.54668 -0.625,1.09571 -0.13541,0.54902 -0.19141,1.31765 -0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 0.056,1.783 0.19141,2.33203 0.13536,0.54903 0.32618,0.86263 0.625,1.09571 0.59762,0.46615 1.88676,0.62109 4.20703,0.62109 h 11.9524 c 2.32085,0 3.61652,-0.15457 4.2168,-0.62109 0.30014,-0.23327 0.49095,-0.54754 0.625,-1.09571 0.13404,-0.54816 0.18764,-1.31623 0.18164,-2.33008 v -7.95279 -5.95312 c 0.006,-1.01386 -0.0476,-1.78191 -0.18164,-2.33008 -0.13406,-0.54817 -0.32486,-0.86244 -0.625,-1.09571 -0.60028,-0.46652 -1.89595,-0.62109 -4.2168,-0.62109 z m 4.95859,1.00977 c 1.5798,-0.002 4.16014,-3.9e-4 5.73991,0.0117 1.50021,0.0511 3.02236,-0.0712 4.5,0.28321 0.55111,0.0919 0.61303,0.71807 0.67773,1.16601 0.1117,4.30832 0.075,10.62608 0.0508,14.94108 -0.0716,0.99089 0.13687,2.07606 -0.30078,3.01366 -0.34356,0.40964 -0.9694,0.35958 -1.45117,0.45509 -3.95407,0.0823 -9.92936,0.0499 -13.89381,0.0371 -1.16908,-0.0622 -2.37292,0.11291 -3.51758,-0.22266 -0.57935,-0.098 -0.6137,-0.75914 -0.6875,-1.2207 -0.1146,-4.11835 -0.0751,-10.24472 -0.0547,-14.36881 0.0572,-1.06305 -0.0797,-2.16734 0.18164,-3.21485 0.10495,-0.6386 0.8614,-0.66043 1.36719,-0.74023 2.1305,-0.19658 5.24071,-0.10662 7.38828,-0.14062 z"
-         id="path914-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 329.12695,134 c -3.21072,0 -5.03255,0.19514 -5.9375,0.89844 -0.45247,0.35165 -0.74178,0.83286 -0.93359,1.61718 -0.19176,0.78433 -0.26386,1.85686 -0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c -0.008,1.40682 0.0641,2.47935 0.25586,3.26368 0.1918,0.78431 0.48112,1.26553 0.93359,1.61718 0.90496,0.7033 2.72678,0.89844 5.9375,0.89844 h 13.7461 c 3.20992,0 5.02461,-0.19551 5.92578,-0.89844 0.45058,-0.35146 0.73805,-0.83201 0.93164,-1.61718 C 349.9241,158.69918 350,157.62415 350,156.2168 V 148 139.7832 c 0,-1.40735 -0.0759,-2.48237 -0.26953,-3.26758 -0.19359,-0.78517 -0.48106,-1.26572 -0.93164,-1.61718 C 347.89766,134.19551 346.08297,134 342.87305,134 Z m 6.49805,1.04688 c 3.45647,0.0171 6.9142,-0.0268 10.36133,0.0918 0.8211,0.13276 1.80664,0.14835 2.39062,0.82617 0.67884,1.16473 0.51296,2.58781 0.56446,3.87305 0.0431,6.02893 0.0678,12.06719 -0.0332,18.08789 -0.0775,0.77792 -0.12055,1.67263 -0.67968,2.27539 -0.70249,0.51038 -1.61833,0.59683 -2.45899,0.67383 -4.04742,0.0864 -8.16222,0.0456 -12.24023,0.0606 -2.45188,-0.0199 -4.91402,0.0317 -7.35352,-0.0606 -0.87784,-0.12055 -1.915,-0.14021 -2.56055,-0.83398 -0.64775,-1.02591 -0.50264,-2.30525 -0.56054,-3.46485 -0.035,-5.65575 -0.0351,-11.35518 0,-17.00976 0.0632,-1.22153 -0.10864,-2.57724 0.59179,-3.65235 0.6025,-0.62665 1.55621,-0.63986 2.35938,-0.77344 2.73743,-0.10739 5.48083,-0.0704 8.22656,-0.0918 0.46403,-2.9e-4 0.92855,-0.002 1.39258,-0.002 z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 333.33594,62 c -4.99049,0 -7.87051,0.276282 -9.38477,1.453125 -0.75713,0.588421 -1.23761,1.403518 -1.54492,2.660156 -0.3073,1.256638 -0.4173,2.940031 -0.4043,5.132813 V 84 96.753906 c -0.0131,2.19278 0.097,3.876174 0.4043,5.132814 0.30731,1.25663 0.78779,2.07172 1.54492,2.66016 1.51427,1.17683 4.39428,1.45312 9.38477,1.45312 h 21.33008 c 4.98923,0 7.85502,-0.27668 9.36328,-1.45312 0.75412,-0.58824 1.23293,-1.40461 1.54297,-2.66211 C 365.8823,100.62727 366,98.945281 366,96.751953 V 84 71.248047 c 0,-2.193329 -0.1177,-3.875313 -0.42773,-5.132813 -0.31004,-1.257499 -0.78884,-2.073874 -1.54297,-2.662109 C 362.52104,62.276656 359.65526,62 354.66602,62 Z m 2.40234,1.097656 c 6.94737,8.3e-4 13.91063,0.0034 20.84961,0.05469 2.14296,0.08293 4.46431,-0.147701 6.42383,0.93164 1.29609,0.695228 1.54862,2.250325 1.76953,3.564454 0.17551,2.202888 0.0915,4.442228 0.13867,6.669921 0.0227,8.479532 0.077,16.968993 -0.0801,25.447266 -0.16151,1.483233 -0.38135,3.305793 -1.79882,4.142573 -1.6055,0.82871 -3.47551,0.90643 -5.24805,0.95313 -9.49974,0.0678 -19.0243,0.0843 -28.52344,-0.0176 -1.57816,-0.11413 -3.27053,-0.24014 -4.63281,-1.12109 -1.22952,-0.99538 -1.36082,-2.72739 -1.50391,-4.193361 -0.1272,-8.998585 -0.0836,-18.004484 -0.0527,-27.007813 0.0997,-2.381275 -0.24538,-4.900002 0.70508,-7.160156 0.67165,-1.50972 2.46573,-1.859954 3.93945,-2.05664 2.66168,-0.316582 5.34184,-0.147022 8.01367,-0.207032 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
+         d="m 323.78307,243.69125 -0.003,-3.01031 3.37618,-0.50328 v 3.51359 z m 3.93587,-3.60289 4.50042,-0.71892 v 4.32181 h -4.50042 z m 4.50111,4.22039 -6.9e-4,4.32181 -4.50042,-0.69469 v -3.62712 z m -5.06392,3.54821 -3.37341,-0.50743 -3.4e-4,-3.04078 h 3.37375 z"
+         fill="#eff9fe"
+         fill-opacity="0.75"
+         fill-rule="nonzero"
+         id="path391"
+         style="display:inline;enable-background:new;stroke-width:0.346133" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/winetricks.svg
+++ b/icons/src/fullcolor/default/apps/winetricks.svg
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="winetricks.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,22 +31,22 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.99999995"
-     inkscape:cx="345.71766"
-     inkscape:cy="229.58273"
-     inkscape:current-layer="layer6"
+     inkscape:zoom="2"
+     inkscape:cx="362"
+     inkscape:cy="102"
+     inkscape:current-layer="layer7"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1294"
-     inkscape:window-height="704"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
-     inkscape:snap-bbox="false"
+     inkscape:snap-bbox="true"
      gridtolerance="10000"
      inkscape:object-nodes="true"
      inkscape:snap-grids="true"
@@ -62,7 +62,7 @@
      inkscape:pagecheckerboard="false"
      showborder="false"
      inkscape:document-rotation="0"
-     inkscape:bbox-nodes="true">
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -93,274 +93,64 @@
   <defs
      id="defs3">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1540">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(0.0750367,-43.19,43.19,0.0750367,87.46,45.5869)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#ededed;stop-opacity:1"
+         stop-color="#003fb6"
          offset="0"
-         id="stop1536" />
+         id="stop2" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
+         stop-color="#21c6fb"
          offset="1"
-         id="stop1538" />
+         id="stop4" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient938">
-      <stop
-         id="stop934"
-         offset="0"
-         style="stop-color:#e6e6e6;stop-opacity:1" />
-      <stop
-         id="stop936"
-         offset="1"
-         style="stop-color:#f7f7f7;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient931">
-      <stop
-         id="stop927"
-         offset="0"
-         style="stop-color:#e6e6e6;stop-opacity:1" />
-      <stop
-         id="stop929"
-         offset="1"
-         style="stop-color:#f7f7f7;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1332">
-      <stop
-         id="stop1328"
-         offset="0"
-         style="stop-color:#e6e6e6;stop-opacity:1" />
-      <stop
-         id="stop1330"
-         offset="1"
-         style="stop-color:#f7f7f7;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient962">
-      <stop
-         style="stop-color:#7b0619;stop-opacity:1;"
-         offset="0"
-         id="stop958" />
-      <stop
-         style="stop-color:#bb0212;stop-opacity:1"
-         offset="1"
-         id="stop960" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient956">
-      <stop
-         id="stop952"
-         offset="0"
-         style="stop-color:#e6e6e6;stop-opacity:1" />
-      <stop
-         id="stop954"
-         offset="1"
-         style="stop-color:#f7f7f7;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient931"
-       id="linearGradient1686"
-       x1="320.99991"
-       y1="92.000153"
-       x2="366.99991"
-       y2="76.000153"
+       xlink:href="#a"
+       id="linearGradient371"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000121)" />
+       gradientTransform="matrix(0.07964944,-45.845023,45.845023,0.07964944,411.36109,106.91391)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient938"
-       id="linearGradient1688"
-       x1="321.00003"
-       y1="153.00002"
-       x2="351.00003"
-       y2="143.00002"
+       xlink:href="#a"
+       id="linearGradient379"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00002,148)" />
+       gradientTransform="matrix(0.05194529,-29.898929,29.898929,0.05194529,379.93114,162.94386)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4338-7"
-       id="linearGradient1690"
-       x1="320.9993"
-       y1="202.99928"
-       x2="342.9993"
-       y2="196.99928"
+       xlink:href="#a"
+       id="linearGradient387"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
+       gradientTransform="matrix(0.03982472,-22.922512,22.922512,0.03982472,365.68054,211.45695)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1332"
-       id="linearGradient1692"
-       x1="320.00031"
-       y1="247.00034"
-       x2="336.00031"
-       y2="241.00034"
+       xlink:href="#a"
+       id="linearGradient395"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.0096562,-1.0096562,0,574.35612,-87.095146)" />
+       gradientTransform="matrix(0.02597264,-14.949465,14.949465,0.02597264,349.96557,251.47193)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient4338-7">
-      <stop
-         id="stop4342-6"
-         offset="0"
-         style="stop-color:#e6e6e6;stop-opacity:1" />
-      <stop
-         id="stop4340-2"
-         offset="1"
-         style="stop-color:#f7f7f7;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1692-6"
-       x1="321.00031"
-       y1="244.00034"
-       x2="335.00031"
-       y2="244.00034"
+       xlink:href="#a"
+       id="linearGradient414"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1690-9"
-       x1="320.9993"
-       y1="199.99928"
-       x2="342.9993"
-       y2="199.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1688-4"
-       x1="322"
-       y1="148.00002"
-       x2="350"
-       y2="148.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00001,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1686-0"
-       x1="321.99991"
-       y1="84.000153"
-       x2="365.99991"
-       y2="84.000153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000125)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58449"
-       x="-0.047999425"
-       width="1.0959988"
-       y="-0.048000575"
-       height="1.0960012">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.4800539"
-         id="feGaussianBlur58451" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58492"
-       x="-0.011999856"
-       width="1.0239997"
-       y="-0.012000144"
-       height="1.0240003">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1200135"
-         id="feGaussianBlur58494" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient956"
-       id="linearGradient943"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,151.9973,155.9997)"
-       x1="39.997601"
-       y1="155.99699"
-       x2="263.99759"
-       y2="155.99699" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient962"
-       id="linearGradient964"
-       x1="160"
-       y1="166"
-       x2="160"
-       y2="268"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient962"
-       id="linearGradient942"
-       gradientUnits="userSpaceOnUse"
-       x1="359"
-       y1="85"
-       x2="359"
-       y2="107"
-       gradientTransform="translate(-7.2716616e-6)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient962"
-       id="linearGradient963"
-       gradientUnits="userSpaceOnUse"
-       x1="344.00003"
-       y1="148"
-       x2="344.00003"
-       y2="163"
-       gradientTransform="translate(-1.8004249e-5)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient962"
-       id="linearGradient976"
-       gradientUnits="userSpaceOnUse"
-       x1="342.00003"
-       y1="199.99995"
-       x2="342.00003"
-       y2="211.99995"
-       gradientTransform="translate(-4.0996777e-5,4.8e-5)" />
+       gradientTransform="matrix(0.38785815,-223.24534,223.24534,0.38785815,480.0192,267.5808)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4387"
-       id="linearGradient5044"
+       id="linearGradient1457"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.75236891,0.43551337,-0.43438039,0.75433128,345.9866,58.513883)"
-       x1="9.6967573"
-       y1="24.661448"
-       x2="33.232052"
-       y2="24.661448" />
+       gradientTransform="matrix(3.9439007,2.2388432,-2.2770121,3.8777903,162.06998,39.325495)"
+       x1="19.5"
+       y1="28.5"
+       x2="23.5"
+       y2="28.5" />
     <linearGradient
        id="linearGradient4387"
        inkscape:collect="always">
@@ -373,49 +163,25 @@
          offset="1"
          style="stop-color:#000000;stop-opacity:1" />
     </linearGradient>
-    <linearGradient
+    <filter
        inkscape:collect="always"
-       xlink:href="#linearGradient4387"
-       id="linearGradient5046"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.75236891,0.43551337,-0.43438039,0.75433128,345.9866,58.513883)"
-       x1="19.5"
-       y1="28.5"
-       x2="23.5"
-       y2="28.5" />
-    <linearGradient
-       id="linearGradient4481">
-      <stop
-         id="stop4483"
-         offset="0"
-         style="stop-color:#a40000;stop-opacity:1" />
-      <stop
-         style="stop-color:#f57900;stop-opacity:1"
-         offset="0.15978512"
-         id="stop4491" />
-      <stop
-         style="stop-color:#edd400;stop-opacity:1"
-         offset="0.34338808"
-         id="stop4489" />
-      <stop
-         id="stop4495"
-         offset="0.5544045"
-         style="stop-color:#73d216;stop-opacity:1" />
-      <stop
-         style="stop-color:#3465a4;stop-opacity:1"
-         offset="1"
-         id="stop4499" />
-      <stop
-         id="stop4485"
-         offset="1"
-         style="stop-color:#5c3566;stop-opacity:1" />
-    </linearGradient>
+       style="color-interpolation-filters:sRGB"
+       id="filter1459"
+       x="-0.020109891"
+       width="1.040205"
+       y="-0.013072511"
+       height="1.0261453">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.65095879"
+         id="feGaussianBlur1461" />
+    </filter>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4387"
        id="linearGradient1075"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(3.9439007,2.2388432,-2.2770121,3.8777903,160.96968,29.78853)"
+       gradientTransform="matrix(3.9438871,2.2388432,-2.2770042,3.8777903,160.96915,29.788314)"
        x1="9.6967573"
        y1="24.661448"
        x2="33.232052"
@@ -425,7 +191,7 @@
        xlink:href="#linearGradient4387"
        id="linearGradient1077"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(3.9439007,2.2388432,-2.2770121,3.8777903,160.96968,29.78853)"
+       gradientTransform="matrix(3.9438871,2.2388432,-2.2770042,3.8777903,160.96915,29.788314)"
        x1="19.5"
        y1="28.5"
        x2="23.5"
@@ -433,9 +199,9 @@
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4387"
-       id="linearGradient1091"
+       id="linearGradient5044"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45833908,0.26816362,-0.26462219,0.464473,338.61349,132.18103)"
+       gradientTransform="matrix(0.75236891,0.43551337,-0.43438039,0.75433128,345.98628,58.514366)"
        x1="9.6967573"
        y1="24.661448"
        x2="33.232052"
@@ -443,9 +209,9 @@
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4387"
-       id="linearGradient1093"
+       id="linearGradient5046"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45833908,0.26816362,-0.26462219,0.464473,338.61349,132.18103)"
+       gradientTransform="matrix(0.75236891,0.43551337,-0.43438039,0.75433128,345.98628,58.514366)"
        x1="19.5"
        y1="28.5"
        x2="23.5"
@@ -455,7 +221,7 @@
        xlink:href="#linearGradient4387"
        id="linearGradient1107"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.37166917,0.2184266,-0.21458329,0.37832597,333.37285,188.25515)"
+       gradientTransform="matrix(0.37167776,0.21842643,-0.21458825,0.37832568,333.37322,188.25521)"
        x1="9.6967573"
        y1="24.661448"
        x2="33.232052"
@@ -465,7 +231,27 @@
        xlink:href="#linearGradient4387"
        id="linearGradient1109"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.37166917,0.2184266,-0.21458329,0.37832597,333.37285,188.25515)"
+       gradientTransform="matrix(0.37167776,0.21842643,-0.21458825,0.37832568,333.37322,188.25521)"
+       x1="19.5"
+       y1="28.5"
+       x2="23.5"
+       y2="28.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4387"
+       id="linearGradient1091"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45833908,0.26816362,-0.26462219,0.464473,338.61349,132.18082)"
+       x1="9.6967573"
+       y1="24.661448"
+       x2="33.232052"
+       y2="24.661448" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4387"
+       id="linearGradient1093"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45833908,0.26816362,-0.26462219,0.464473,338.61349,132.18082)"
        x1="19.5"
        y1="28.5"
        x2="23.5"
@@ -475,7 +261,7 @@
        xlink:href="#linearGradient4387"
        id="linearGradient1123"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2351695,0.13978414,-0.13577517,0.24211323,327.84249,237.11371)"
+       gradientTransform="matrix(0.2351695,0.13978414,-0.13577517,0.24211323,327.8429,237.11327)"
        x1="9.6967573"
        y1="24.661448"
        x2="33.232052"
@@ -485,163 +271,11 @@
        xlink:href="#linearGradient4387"
        id="linearGradient1125"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2351695,0.13978414,-0.13577517,0.24211323,327.84249,237.11371)"
+       gradientTransform="matrix(0.2351695,0.13978414,-0.13577517,0.24211323,327.8429,237.11327)"
        x1="19.5"
        y1="28.5"
        x2="23.5"
        y2="28.5" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient962"
-       id="linearGradient1427"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0096995,0,0,0.99998143,-3.181234,0.0045234)"
-       x1="332.00003"
-       y1="244.00002"
-       x2="332.00003"
-       y2="252.00002" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4387"
-       id="linearGradient1457"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(3.9439007,2.2388432,-2.2770121,3.8777903,162.07043,31.577026)"
-       x1="19.5"
-       y1="28.5"
-       x2="23.5"
-       y2="28.5" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter1459"
-       x="-0.015223208"
-       width="1.0304464"
-       y="-0.0099031973"
-       height="1.0198064">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.65095879"
-         id="feGaussianBlur1461" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4481"
-       id="linearGradient1432"
-       gradientUnits="userSpaceOnUse"
-       x1="235.99998"
-       y1="166"
-       x2="3.0001907"
-       y2="166.40036"
-       gradientTransform="translate(0.0117391,-104)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1540"
-       id="linearGradient1542"
-       x1="149.11337"
-       y1="209.56998"
-       x2="152.06709"
-       y2="104.61821"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4481"
-       id="linearGradient1590"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(330.01177,-181.99999)"
-       x1="235.99998"
-       y1="166"
-       x2="3.0001907"
-       y2="166.40036" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1540"
-       id="linearGradient1592"
-       gradientUnits="userSpaceOnUse"
-       x1="149.11337"
-       y1="209.56998"
-       x2="152.06709"
-       y2="104.61821"
-       gradientTransform="translate(330.00003,-77.999994)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4481"
-       id="linearGradient1590-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.12946859,0,0,0.12946859,316.32311,112.82893)"
-       x1="235.99998"
-       y1="166"
-       x2="3.0001907"
-       y2="166.40036" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1540"
-       id="linearGradient1592-8"
-       gradientUnits="userSpaceOnUse"
-       x1="149.11337"
-       y1="209.56998"
-       x2="152.06709"
-       y2="104.61821"
-       gradientTransform="matrix(0.12946859,0,0,0.12946859,316.32163,126.29374)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient962"
-       id="linearGradient2603"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.02893946,-3.342036e-5)"
-       x1="344.00003"
-       y1="148"
-       x2="344.00003"
-       y2="163" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4481"
-       id="linearGradient2751"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.12946859,0,0,0.12946859,316.32311,112.82893)"
-       x1="235.99998"
-       y1="166"
-       x2="3.0001907"
-       y2="166.40036" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1540"
-       id="linearGradient2753"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.12946859,0,0,0.12946859,316.32163,126.29374)"
-       x1="149.11337"
-       y1="209.56998"
-       x2="152.06709"
-       y2="104.61821" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient962"
-       id="linearGradient2907"
-       gradientUnits="userSpaceOnUse"
-       x1="160"
-       y1="166"
-       x2="160"
-       y2="268"
-       gradientTransform="translate(-2.2e-6)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4481"
-       id="linearGradient2960"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.06696614,0,0,0.06636344,317.82235,225.97996)"
-       x1="235.99998"
-       y1="166"
-       x2="3.0001907"
-       y2="166.40036" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1540"
-       id="linearGradient2962"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.06696614,0,0,0.06636344,317.82159,232.8818)"
-       x1="149.11337"
-       y1="209.56998"
-       x2="152.06709"
-       y2="104.61821" />
   </defs>
   <metadata
      id="metadata4">
@@ -653,13 +287,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -733,14 +367,15 @@
       <text
          y="-8.2548828"
          xml:space="preserve"
-         x="231.34375"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.6667px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         x="146.48828"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
          inkscape:label="icon-name"
          id="icon-name"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+           y="-8.2548828"
+           x="146.48828"
            sodipodi:role="line"
-           id="tspan970"
-           x="231.34375"
-           y="-8.2548828">winetricks</tspan></text>
+           id="tspan924">winetricks</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -775,401 +410,213 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer9"
-       inkscape:label="Optional outline for white icons"
-       style="display:inline">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
-         d="m 225.07297,43.99969 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 c 0.17299,35.36812 -3.62489,38.99353 -38.92162,38.99353 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 155.99969 82.99322 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.12858,237.00001 c -3.74357,0 -4.14638,0.30899 -4.12803,3.32331 v 4.17669 4.17668 c -0.0183,3.01433 0.38446,3.32332 4.12803,3.32332 h 7.74335 c 3.7436,0 4.12805,-0.30895 4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 -0.38446,-3.32331 -4.12805,-3.32331 z"
-         id="path918-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 326.45275,189.00048 c -1.2321,0 -2.21668,0.0221 -3.06999,0.14144 -0.85332,0.11937 -1.62809,0.35533 -2.21066,0.83967 -0.58256,0.48436 -0.86983,1.13381 -1.01188,1.84587 -0.14202,0.71207 -0.16501,1.53239 -0.15897,2.56202 v 7.61066 4.6143 c -0.006,1.02762 0.0171,1.84735 0.15897,2.55843 0.14203,0.71208 0.42931,1.36152 1.01188,1.84587 0.58258,0.48434 1.35734,0.7203 2.21066,0.83967 0.85331,0.11936 1.83789,0.14144 3.06999,0.14144 h 11.09542 c 1.2321,0 2.21381,-0.022 3.0657,-0.14144 0.85187,-0.11947 1.62795,-0.35683 2.2085,-0.84146 0.58057,-0.48464 0.86451,-1.13152 1.00758,-1.84228 0.14307,-0.71077 0.16972,-1.5314 0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 -0.0266,-1.84946 -0.16972,-2.56023 -0.14307,-0.71076 -0.42701,-1.35765 -1.00758,-1.84228 -0.58055,-0.48464 -1.35661,-0.722 -2.2085,-0.84147 -0.8519,-0.11947 -1.83359,-0.14144 -3.0657,-0.14144 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 329.30094,134 c -1.63949,0 -2.94082,0.0308 -4.04505,0.19141 -1.10422,0.16064 -2.06697,0.4726 -2.78308,1.09179 -0.71611,0.61919 -1.0805,1.45612 -1.26421,2.41407 -0.18374,0.95795 -0.21537,2.08705 -0.20733,3.51171 V 149 v 7.79688 c -0.009,1.42131 0.0239,2.5495 0.20733,3.50585 0.18371,0.95796 0.5481,1.79488 1.26421,2.41407 0.71611,0.61919 1.67886,0.93115 2.78308,1.09179 1.10423,0.16065 2.40556,0.19141 4.04505,0.19141 h 13.40164 c 1.63949,0 2.93835,-0.0307 4.04054,-0.19141 1.10219,-0.16075 2.06274,-0.47425 2.77633,-1.09375 0.71357,-0.6195 1.07457,-1.45363 1.25969,-2.41015 C 350.96429,159.34816 351,158.22066 351,156.79688 V 149 141.20312 c 0,-1.42378 -0.0358,-2.55128 -0.22086,-3.50781 -0.18512,-0.95653 -0.54612,-1.79065 -1.25969,-2.41015 -0.71359,-0.61951 -1.67414,-0.933 -2.77633,-1.09375 C 345.64093,134.03065 344.34207,134 342.70258,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 333.65776,62 c -2.6221,0 -4.68675,0.05009 -6.38561,0.286735 -1.69887,0.236639 -3.08904,0.680503 -4.10735,1.523515 -1.0183,0.843013 -1.55577,1.996072 -1.83828,3.406406 -0.28252,1.410336 -0.33767,3.127346 -0.32482,5.308412 v 12.474816 12.480783 c -0.0127,2.177715 0.0426,3.893853 0.32482,5.302673 0.28251,1.41034 0.81998,2.5634 1.83828,3.40641 1.01831,0.84301 2.40848,1.28688 4.10735,1.52351 1.69888,0.23665 3.76351,0.28674 6.38561,0.28674 h 20.68618 c 2.62213,0 4.68568,-0.05 6.38104,-0.28674 1.69534,-0.23674 3.08126,-0.6821 4.09581,-1.52542 1.01457,-0.84331 1.54885,-1.99555 1.83367,-3.4045 C 366.93929,101.37441 367,99.660878 367,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0608,-3.893733 -0.34554,-5.302677 -0.28482,-1.408942 -0.81911,-2.561177 -1.83368,-3.404494 -1.01455,-0.843317 -2.40047,-1.288685 -4.09582,-1.525427 C 359.02962,62.049992 356.96605,62 354.34394,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         id="path964"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 333.33594 61.5 C 323.32478 61.5 321.44935 62.406017 321.50195 71.248047 L 321.50195 84 L 321.50195 89.017578 C 321.50195 89.017578 326.32255 94.642578 337.57227 94.642578 C 348.822 94.642578 355.25199 85 360.87695 85 C 366.50191 85 366.49805 89.017578 366.49805 89.017578 L 366.49805 96.882812 C 366.49815 96.837077 366.5 96.798121 366.5 96.751953 L 366.5 84 L 366.5 71.248047 C 366.5 62.405917 364.67469 61.5 354.66602 61.5 L 333.33594 61.5 z M 366.47656 98.318359 C 366.44494 99.303055 366.37913 100.1714 366.26562 100.93555 C 366.37913 100.17138 366.44494 99.30306 366.47656 98.318359 z M 366.26562 100.93555 C 366.09537 102.08177 365.81886 102.99542 365.39453 103.72266 C 365.81887 102.99539 366.09537 102.08179 366.26562 100.93555 z M 365.39453 103.72266 C 365.25309 103.96507 365.09385 104.18595 364.91797 104.38867 C 365.09423 104.18565 365.25284 103.96551 365.39453 103.72266 z M 324.34766 105.39062 C 324.85774 105.65794 325.45295 105.86292 326.14453 106.01953 C 325.45296 105.86293 324.85773 105.65792 324.34766 105.39062 z M 363.63477 105.39062 C 363.12662 105.65792 362.53507 105.86294 361.8457 106.01953 C 362.53439 105.86308 363.12695 105.65755 363.63477 105.39062 z " />
-      <path
-         id="path914"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate"
-         d="M 326.17773 188.5 C 321.03107 188.5 320.47673 188.93187 320.50195 193.15234 L 320.50195 199 L 320.50195 202.19336 C 320.50715 202.19942 322.96985 205.06641 328.71289 205.06641 C 334.462 205.06641 337.74653 200.13867 340.62109 200.13867 C 343.49564 200.13867 343.49609 202.19141 343.49609 202.19141 L 343.49609 206.93164 C 343.49615 206.90068 343.49805 206.87903 343.49805 206.84766 L 343.49805 199 L 343.49805 193.15234 C 343.49805 188.93183 342.96892 188.5 337.82227 188.5 L 326.17773 188.5 z " />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.37055,236.49999 c -3.5096,0 -3.88723,0.31197 -3.87003,3.3554 v 4.21702 4.21701 c -0.0172,3.04344 0.36043,3.35541 3.87003,3.35541 h 7.25939 c 3.50962,0 3.87004,-0.31193 3.87004,-3.35541 v -4.21701 -4.21702 c 0,-3.04347 -0.36043,-3.3554 -3.87004,-3.3554 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         id="path964-7"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 329.12695 133.5 C 322.67532 133.5 321.46609 134.08502 321.5 139.7832 L 321.5 148 L 321.5 150.60156 C 321.5347 150.63939 324.63459 154 331.84375 154 C 339.09356 154 343.23637 147.99988 346.86133 148 C 350.48629 148.00012 350.48438 150.58984 350.48438 150.58984 L 350.48438 156.2168 C 350.48438 160.95894 349.62199 162.14656 345.63086 162.41602 C 349.63587 162.14893 350.5 160.96535 350.5 156.2168 L 350.5 148 L 350.5 139.7832 C 350.5 134.08496 349.32308 133.5 342.87305 133.5 L 329.12695 133.5 z " />
-      <path
-         id="path938"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient943);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.910156,44 c -35.29671,0 -38.922359,3.625611 -38.921875,38.994141 l 0.02344,137.005859 h 223.98828 l -0.0117,-137.005859 c 0.17299,-35.36811 -3.62319,-38.994141 -38.91992,-38.994141 z"
-         sodipodi:nodetypes="sscccss" />
-      <path
-         id="path948"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient964);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.910156,268 c -35.29671,0 -38.931514,-3.62561 -38.921875,-38.99414 l 0.01172,-43.00586 c 0,0 24,28 79.999999,28 56,0 88,-48 116,-48 28,0 27.98828,20 27.98828,20 v 43.00586 c 0.17299,35.36811 -3.62319,38.99414 -38.91992,38.99414 z"
-         sodipodi:nodetypes="ssczzccss" />
-      <path
-         id="path1334"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1427);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.62695,244 c -1.87514,0 -4.01725,3.18359 -7.76757,3.18359 -3.7503,0 -5.35938,-1.85742 -5.35938,-1.85742 v 2.84961 c -0.002,0.28642 0.006,0.52795 0.0137,0.76758 0.001,0.1109 0.008,0.2036 0.0117,0.30469 0.10309,1.72229 0.62063,2.14755 2.66992,2.23242 0.37577,0.006 0.68346,0.0195 1.17578,0.0195 h 7.25977 c 0.4387,0 0.82809,-0.005 1.17383,-0.0195 2.0545,-0.0852 2.56098,-0.51116 2.66797,-2.25 0.003,-0.0718 0.008,-0.13821 0.01,-0.21485 0.0109,-0.25759 0.0176,-0.52645 0.0176,-0.83984 v -2.84961 c 0,0 0.002,-1.32617 -1.87305,-1.32617 z" />
-      <path
-         id="path940"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient942);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 337.57227,94.642578 c -11.24972,0 -16.07032,-5.625 -16.07032,-5.625 l -0.002,2.482422 h 0.002 l 0,5.251953 c -0.0527,8.842027 1.82283,9.748047 11.83399,9.748047 h 21.33008 c 10.00866,0 11.83398,-0.90592 11.83398,-9.748047 v 0.748047 h -0.002 l 0,-8.482422 c 0,0 0.004,-4.017578 -5.62096,-4.017578 -5.62496,0 -12.05504,9.642578 -23.30477,9.642578 z"
-         sodipodi:nodetypes="sccccsssccccs" />
-      <path
-         id="path959"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient963);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 331.85938,153.99994 c -7.24983,0 -10.35743,-3.41016 -10.35743,-3.41016 l -0.002,5.62702 c -2e-5,0.004 2e-5,0.006 0,0.01 -0.0324,5.688 1.17945,6.27344 7.62695,6.27344 h 13.7461 c 6.45003,0 7.62695,-0.58496 7.62695,-6.2832 v -5.62702 c 0,0 0.002,-2.58984 -3.62296,-2.58996 -3.62496,-1.2e-4 -7.7678,5.99988 -15.01761,5.99988 z"
-         sodipodi:nodetypes="scccsssccs" />
-      <path
-         id="path974"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient976);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 340.62305,200.03613 c -2.87456,0 -6.1591,4.92773 -11.90821,4.92773 -5.74911,0 -8.21289,-2.875 -8.21289,-2.875 v 4.7588 c -0.0253,4.22046 0.52912,4.65429 5.67578,4.65429 h 11.64454 c 5.14665,0 5.67578,-0.43377 5.67578,-4.65429 v -4.7588 c 0,0 -4.5e-4,-2.05273 -2.875,-2.05273 z"
-         sodipodi:nodetypes="ssccssscs" />
-      <path
-         id="path959-3"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2603);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 331.88834,153.99991 c -7.24983,0 -10.35743,-3.41016 -10.35743,-3.41016 l -0.002,5.62702 c -2e-5,0.004 2e-5,0.006 0,0.01 -0.0324,5.688 1.17945,6.27344 7.62695,6.27344 h 13.7461 c 6.45003,0 7.62695,-0.58496 7.62695,-6.2832 v -5.62702 c 0,0 0.002,-2.58984 -3.62296,-2.58996 -3.62496,-1.2e-4 -7.7678,5.99988 -15.01761,5.99988 z"
-         sodipodi:nodetypes="scccsssccs" />
-      <path
-         id="path948-74"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2907);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 78.910154,268 C 43.613444,268 39.97864,264.37439 39.988279,229.00586 L 39.999999,186 c 0,0 24,28 80.000001,28 56,0 88,-48 116,-48 28,0 27.98828,20 27.98828,20 v 43.00586 C 264.16127,264.37397 260.36509,268 225.06836,268 Z"
-         sodipodi:nodetypes="ssczzccss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer6"
-       inkscape:label="Pictograms and folds"
-       style="display:inline">
-      <g
-         id="g2686"
-         style="display:inline;enable-background:new">
-        <path
-           id="path948-7-2-6"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:url(#linearGradient1590-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-           d="m 346.87695,137.60938 c -3.62512,0 -7.76734,6.21484 -15.01757,6.21484 -7.25025,0 -10.35743,-3.625 -10.35743,-3.625 l -0.002,7.45703 c -1e-5,0.0514 -9e-5,0.0961 0,0.14648 v 3.9961 l 0.002,-1.20899 V 150.375 c 0,0 0.0964,0.21239 0.34375,0.52148 0.78225,0.71805 3.80435,3.10352 10.01368,3.10352 0.45244,0 0.89339,-0.0245 1.32226,-0.0684 6.5e-4,-7e-5 10e-4,7e-5 0.002,0 6.44128,-0.66497 10.29519,-5.96359 13.69336,-5.94726 0.32372,0.002 0.61309,0.0331 0.88282,0.0801 2.05861,0.29033 2.56453,1.54363 2.68945,2.16211 0.0121,0.0428 0.0508,0.14844 0.0508,0.14844 v -6.0332 -4.14258 c 0,0 0.003,-2.58984 -3.62305,-2.58984 z" />
-        <path
-           id="path948-7-6-0-1"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient1592-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-           d="m 346.87695,137.60938 c -3.62512,0 -7.76734,6.21484 -15.01757,6.21484 -7.25025,0 -10.35743,-3.625 -10.35743,-3.625 l -0.002,9.45703 c -1e-5,0.0514 -9e-5,0.0961 0,0.14648 v 3.99805 l 0.002,-0.82031 v -0.60547 -1.78516 c 0,0 3.1076,3.41016 10.35743,3.41016 7.2498,0 11.39261,-6.00012 15.01757,-6 3.62496,1.2e-4 3.62305,2.58984 3.62305,2.58984 v -6.24804 -4.14258 c 0,0 0.003,-2.58984 -3.62305,-2.58984 z" />
-      </g>
-      <g
-         id="g1598"
-         transform="matrix(0.2008926,0,0,0.2008926,247.16818,67.321182)"
-         style="display:inline;enable-background:new;stroke-width:4.97778">
-        <path
-           id="path948-7-2"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:url(#linearGradient1590);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.97778;marker:none;enable-background:accumulate"
-           d="m 566.01175,-6.0444257 c -28,0 -60,47.9999997 -116,47.9999997 -56,0 -80,-28 -80,-28 l -0.0117,73.050292 c -6e-5,0.3969 0.007,0.73605 0.008,1.125 l -0.008,30.875004 c -1.1e-4,0.3969 0.007,0.73605 0.008,1.125 l 0.004,-12.13086 c 0,0 24,28 80,28 56,0 88,-48.000004 116,-48.000004 28,0 27.98828,20.000004 27.98828,20.000004 v -62.044436 -32 c 0,0 0.0117,-19.9999997 -27.98828,-19.9999997 z"
-           sodipodi:nodetypes="sscsccccsscccss" />
-        <path
-           id="path948-7-6-0"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient1592);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.97778;marker:none;enable-background:accumulate"
-           d="m 566.01175,-6.0444327 c -28,0 -60,48.0000067 -116,48.0000067 -56,0 -80,-28.000005 -80,-28.000005 l -0.0117,73.050297 c -6e-5,0.3969 0.007,0.73605 0.008,1.125 l -0.008,30.875004 c -1.1e-4,0.3969 0.007,0.73605 0.008,1.125 l 0.004,-12.13086 c 0,0 24,28 80,28 56,0 88,-48.000004 116,-48.000004 28,0 27.98828,20.000004 27.98828,20.000004 V 45.955574 13.955569 c 0,0 0.0117,-20.0000017 -27.98828,-20.0000017 z"
-           sodipodi:nodetypes="sscsccccsscccss" />
-      </g>
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.15;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none"
-         d="m 152.0671,268.99458 h 8.00001 65.00586 c 35.36853,0 38.99414,-3.62508 38.99414,-38.92094 v -146.152709 c 0,-35.295889 -3.62602,-39.093927 -38.99414,-38.920941 h -65.00586 -8.00001 z"
-         id="rect4158-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccssscccc" />
-      <g
-         id="g2697"
-         style="display:inline;enable-background:new">
-        <path
-           id="path948-7"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:url(#linearGradient1432);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-           d="m 236.01172,62 c -28,0 -60,48 -116,48 C 64.011717,110 40.011719,82 40.011719,82 L 40,165.00586 c -5.6e-5,0.3969 0.007,0.73605 0.0078,1.125 L 40,197.00586 c -1.08e-4,0.3969 0.007,0.73605 0.0078,1.125 L 40.011719,186 c 0,0 23.999999,28 80.000001,28 56,0 88,-48 116,-48 28,0 27.98828,20 27.98828,20 V 114 82 c 0,0 0.0117,-20 -27.98828,-20 z"
-           sodipodi:nodetypes="sscsccccsscccs" />
-        <path
-           id="path948-7-6"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient1542);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-           d="m 236.01172,61.999993 c -28,0 -60,48.000007 -116,48.000007 C 64.011716,110 40.011718,81.999995 40.011718,81.999995 l -0.01172,83.005865 c -5.6e-5,0.3969 0.007,0.73605 0.0078,1.125 l -0.0078,30.875 c -1.08e-4,0.3969 0.007,0.73605 0.0078,1.125 L 40.011698,186 c 0,0 23.999999,28 80.000002,28 56,0 88,-48 116,-48 28,0 27.98828,20 27.98828,20 V 114 81.999995 c 0,0 0.0117,-20.000002 -27.98828,-20.000002 z"
-           sodipodi:nodetypes="sscsccccsscccs" />
-      </g>
-      <g
-         id="g2686-1"
-         style="display:inline;stroke-width:1.26104;enable-background:new"
-         transform="matrix(0.79299556,0,0,0.79299556,65.552331,82.671785)">
-        <path
-           id="path948-7-2-6-5"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:url(#linearGradient2751);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.26104;marker:none;enable-background:accumulate"
-           d="m 346.87695,137.60938 c -3.62512,0 -7.76734,6.21484 -15.01757,6.21484 -7.25025,0 -10.35743,-3.625 -10.35743,-3.625 l -0.002,7.45703 c -1e-5,0.0514 -9e-5,0.0961 0,0.14648 v 3.9961 l 0.002,-1.20899 V 150.375 c 0,0 0.0964,0.21239 0.34375,0.52148 0.78225,0.71805 3.80435,3.10352 10.01368,3.10352 0.45244,0 0.89339,-0.0245 1.32226,-0.0684 6.5e-4,-7e-5 10e-4,7e-5 0.002,0 6.44128,-0.66497 10.29519,-5.96359 13.69336,-5.94726 0.32372,0.002 0.61309,0.0331 0.88282,0.0801 2.05861,0.29033 2.56453,1.54363 2.68945,2.16211 0.0121,0.0428 0.0508,0.14844 0.0508,0.14844 v -6.0332 -4.14258 c 0,0 0.003,-2.58984 -3.62305,-2.58984 z" />
-        <path
-           id="path948-7-6-0-1-5"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2753);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.26104;marker:none;enable-background:accumulate"
-           d="m 346.87695,137.60938 c -3.62512,0 -7.76734,6.21484 -15.01757,6.21484 -7.25025,0 -10.35743,-3.625 -10.35743,-3.625 l -0.002,9.45703 c -1e-5,0.0514 -9e-5,0.0961 0,0.14648 v 3.99805 l 0.002,-0.82031 v -0.60547 -1.78516 c 0,0 3.1076,3.41016 10.35743,3.41016 7.2498,0 11.39261,-6.00012 15.01757,-6 3.62496,1.2e-4 3.62305,2.58984 3.62305,2.58984 v -6.24804 -4.14258 c 0,0 0.003,-2.58984 -3.62305,-2.58984 z" />
-      </g>
-      <path
-         id="path948-7-2-6-5-4"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:url(#linearGradient2960);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none;enable-background:accumulate"
-         d="m 333.62598,238.68201 c -1.87506,0 -4.01757,3.18562 -7.76767,3.18562 -3.75011,0 -5.35726,-1.85812 -5.35726,-1.85812 l -0.001,3.82235 c -10e-6,0.0264 -5e-5,0.0493 0,0.0751 v 2.04833 l 0.001,-0.61971 v -0.11012 c 0,0 0.0499,0.10887 0.1778,0.2673 0.40461,0.36806 1.96776,1.69079 5.17946,1.69079 0.23402,0 0.4621,-0.0126 0.68393,-0.0351 3.3e-4,-3e-5 5.1e-4,4e-5 0.001,0 3.33168,-0.34085 5.32507,-3.15681 7.08273,-3.14844 0.16744,0.001 0.31712,0.017 0.45663,0.0411 1.06479,0.14881 1.32647,0.79123 1.39109,1.10826 0.006,0.0219 0.0263,0.0761 0.0263,0.0761 v -3.09251 -2.12342 c 0,0 0.002,-1.32751 -1.87398,-1.32751 z"
-         sodipodi:nodetypes="sscccccccsscccccccss" />
-      <path
-         id="path948-7-6-0-1-5-9"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient2962);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none;enable-background:accumulate"
-         d="m 333.62598,238.68201 c -1.87506,0 -4.01757,3.18562 -7.76767,3.18562 -3.75011,0 -5.35726,-1.85812 -5.35726,-1.85812 l -0.001,4.84752 c -10e-6,0.0263 -5e-5,0.0493 0,0.0751 v 2.04934 l 0.001,-0.42048 v -0.31035 -0.91505 c 0,0 1.60737,1.84843 5.35726,1.84843 3.74988,0 5.8927,-3.176 7.76767,-3.17594 1.87497,7e-5 1.87398,1.32751 1.87398,1.32751 v -3.20264 -2.12342 c 0,0 0.002,-1.3275 -1.87398,-1.3275 z"
-         sodipodi:nodetypes="sscccccccsscccs" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer4"
-       inkscape:label="Borders"
-       style="display:inline;opacity:1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92188,43.999698 c -35.296728,0 -39.09487,3.62603 -38.92188,38.99414 v 2 c -0.17299,-35.36811 3.625152,-38.99414 38.92188,-38.99414 h 146.15624 c 35.29673,0 38.92188,3.62561 38.92188,38.99414 v -2 c 0,-35.36853 -3.62515,-38.99414 -38.92188,-38.99414 z"
-         id="path931"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92728,267.9997 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 c -0.17299,35.36811 3.625154,38.99414 38.921885,38.99414 h 146.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 c 0,35.36853 -3.62515,38.99414 -38.92188,38.99414 z"
-         id="path931-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500047 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 V 84 96.75181 c -0.0527,8.84203 1.82291,9.74838 11.83407,9.74838 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 337.97659,211.50015 c 4.67187,0 5.5471,-0.42296 5.52255,-4.54923 v -7.95037 -5.95084 c 0.0245,-4.12627 -0.85068,-4.54923 -5.52255,-4.54923 h -11.95364 c -4.67071,0 -5.52256,0.42291 -5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 0.85185,4.54923 5.52256,4.54923 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.55494,251.5 c 3.33705,0 3.96221,-0.30212 3.94468,-3.24946 v -4.2505 -4.25059 c 0.0175,-2.94734 -0.60763,-3.24945 -3.94468,-3.24945 h -7.11025 c -3.33622,0 -3.94469,0.30208 -3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 0.60847,3.24946 3.94469,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="opacity:0.5">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.44531,237 c -1.65302,0 -2.54604,0.12548 -2.91601,0.41406 -0.18499,0.14429 -0.30479,0.33122 -0.39649,0.70313 C 321.0411,238.4891 321,239.03036 321,239.75 v 4.25 4.25 c 0,0.71964 0.0411,1.26082 0.13281,1.63281 0.0917,0.37191 0.2115,0.55884 0.39649,0.70313 0.36997,0.28858 1.26299,0.41406 2.91601,0.41406 h 7.10938 c 1.65343,0 2.55203,-0.12511 2.92383,-0.41406 0.18589,-0.14448 0.30578,-0.33208 0.39648,-0.70313 0.0907,-0.37105 0.129,-0.90979 0.125,-1.6289 v -0.002 V 244 v -4.25195 -0.002 c 0.004,-0.71911 -0.0343,-1.25785 -0.125,-1.6289 -0.0907,-0.37105 -0.21059,-0.55865 -0.39648,-0.70313 C 334.10673,237.12512 333.20812,237 331.55469,237 Z m 5.32813,1.04688 c 1.10767,-3.4e-4 2.21363,0.008 3.32031,0.0449 0.26616,0.0599 0.75737,-0.0208 0.79297,0.3457 0.13405,1.84438 0.0662,3.68774 0.10156,5.53906 -0.0126,1.86745 0.0543,3.67031 -0.10351,5.49805 0.0642,0.42314 -0.43946,0.35577 -0.70313,0.42187 -3.43277,0.0703 -6.87577,0.0589 -10.29883,0.002 -0.22288,-0.0398 -0.55622,-3.2e-4 -0.71093,-0.1875 -0.19863,-1.12995 -0.12696,-2.26946 -0.16016,-3.41992 0.0138,-2.55648 -0.029,-5.10728 0.0898,-7.65625 -0.03,-0.2727 0.10944,-0.49629 0.40039,-0.48829 1.30659,-0.161 2.63265,-0.0636 3.94727,-0.0976 1.10718,0.006 2.21655,-0.002 3.32422,-0.002 z"
-         id="path918-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 329.12695,134 c -3.21072,0 -5.03255,0.19514 -5.9375,0.89844 -0.45247,0.35165 -0.74178,0.83286 -0.93359,1.61718 -0.19176,0.78433 -0.26386,1.85686 -0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c -0.008,1.40682 0.0641,2.47935 0.25586,3.26368 0.1918,0.78431 0.48112,1.26553 0.93359,1.61718 0.90496,0.7033 2.72678,0.89844 5.9375,0.89844 h 13.7461 c 3.20992,0 5.02461,-0.19551 5.92578,-0.89844 0.45058,-0.35146 0.73805,-0.83201 0.93164,-1.61718 C 349.9241,158.69918 350,157.62415 350,156.2168 V 148 139.7832 c 0,-1.40735 -0.0759,-2.48237 -0.26953,-3.26758 -0.19359,-0.78517 -0.48106,-1.26572 -0.93164,-1.61718 C 347.89766,134.19551 346.08297,134 342.87305,134 Z m 6.49805,1.04688 c 3.45647,0.0171 6.9142,-0.0268 10.36133,0.0918 0.8211,0.13276 1.80664,0.14835 2.39062,0.82617 0.67884,1.16473 0.51296,2.58781 0.56446,3.87305 0.0431,6.02893 0.0678,12.06719 -0.0332,18.08789 -0.0775,0.77792 -0.12055,1.67263 -0.67968,2.27539 -0.70249,0.51038 -1.61833,0.59683 -2.45899,0.67383 -4.04742,0.0864 -8.16222,0.0456 -12.24023,0.0606 -2.45188,-0.0199 -4.91402,0.0317 -7.35352,-0.0606 -0.87784,-0.12055 -1.915,-0.14021 -2.56055,-0.83398 -0.64775,-1.02591 -0.50264,-2.30525 -0.56054,-3.46485 -0.035,-5.65575 -0.0351,-11.35518 0,-17.00976 0.0632,-1.22153 -0.10864,-2.57724 0.59179,-3.65235 0.6025,-0.62665 1.55621,-0.63986 2.35938,-0.77344 2.73743,-0.10739 5.48083,-0.0704 8.22656,-0.0918 0.46403,-2.9e-4 0.92855,-0.002 1.39258,-0.002 z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 333.33594,62 c -4.99049,0 -7.87051,0.276282 -9.38477,1.453125 -0.75713,0.588421 -1.23761,1.403518 -1.54492,2.660156 -0.3073,1.256638 -0.4173,2.940031 -0.4043,5.132813 V 84 96.753906 c -0.0131,2.19278 0.097,3.876174 0.4043,5.132814 0.30731,1.25663 0.78779,2.07172 1.54492,2.66016 1.51427,1.17683 4.39428,1.45312 9.38477,1.45312 h 21.33008 c 4.98923,0 7.85502,-0.27668 9.36328,-1.45312 0.75412,-0.58824 1.23293,-1.40461 1.54297,-2.66211 C 365.8823,100.62727 366,98.945281 366,96.751953 V 84 71.248047 c 0,-2.193329 -0.1177,-3.875313 -0.42773,-5.132813 -0.31004,-1.257499 -0.78884,-2.073874 -1.54297,-2.662109 C 362.52104,62.276656 359.65526,62 354.66602,62 Z m 2.40234,1.097656 c 6.94737,8.3e-4 13.91063,0.0034 20.84961,0.05469 2.14296,0.08293 4.46431,-0.147701 6.42383,0.93164 1.29609,0.695228 1.54862,2.250325 1.76953,3.564454 0.17551,2.202888 0.0915,4.442228 0.13867,6.669921 0.0227,8.479532 0.077,16.968993 -0.0801,25.447266 -0.16151,1.483233 -0.38135,3.305793 -1.79882,4.142573 -1.6055,0.82871 -3.47551,0.90643 -5.24805,0.95313 -9.49974,0.0678 -19.0243,0.0843 -28.52344,-0.0176 -1.57816,-0.11413 -3.27053,-0.24014 -4.63281,-1.12109 -1.22952,-0.99538 -1.36082,-2.72739 -1.50391,-4.193361 -0.1272,-8.998585 -0.0836,-18.004484 -0.0527,-27.007813 0.0997,-2.381275 -0.24538,-4.900002 0.70508,-7.160156 0.67165,-1.50972 2.46573,-1.859954 3.93945,-2.05664 2.66168,-0.316582 5.34184,-0.147022 8.01367,-0.207032 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 326.02383,189.00048 c -2.32027,0 -3.60941,0.15494 -4.20703,0.62109 -0.29882,0.23308 -0.48964,0.54668 -0.625,1.09571 -0.13541,0.54902 -0.19141,1.31765 -0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 0.056,1.783 0.19141,2.33203 0.13536,0.54903 0.32618,0.86263 0.625,1.09571 0.59762,0.46615 1.88676,0.62109 4.20703,0.62109 h 11.9524 c 2.32085,0 3.61652,-0.15457 4.2168,-0.62109 0.30014,-0.23327 0.49095,-0.54754 0.625,-1.09571 0.13404,-0.54816 0.18764,-1.31623 0.18164,-2.33008 v -7.95279 -5.95312 c 0.006,-1.01386 -0.0476,-1.78191 -0.18164,-2.33008 -0.13406,-0.54817 -0.32486,-0.86244 -0.625,-1.09571 -0.60028,-0.46652 -1.89595,-0.62109 -4.2168,-0.62109 z m 4.95859,1.00977 c 1.5798,-0.002 4.16014,-3.9e-4 5.73991,0.0117 1.50021,0.0511 3.02236,-0.0712 4.5,0.28321 0.55111,0.0919 0.61303,0.71807 0.67773,1.16601 0.1117,4.30832 0.075,10.62608 0.0508,14.94108 -0.0716,0.99089 0.13687,2.07606 -0.30078,3.01366 -0.34356,0.40964 -0.9694,0.35958 -1.45117,0.45509 -3.95407,0.0823 -9.92936,0.0499 -13.89381,0.0371 -1.16908,-0.0622 -2.37292,0.11291 -3.51758,-0.22266 -0.57935,-0.098 -0.6137,-0.75914 -0.6875,-1.2207 -0.1146,-4.11835 -0.0751,-10.24472 -0.0547,-14.36881 0.0572,-1.06305 -0.0797,-2.16734 0.18164,-3.21485 0.10495,-0.6386 0.8614,-0.66043 1.36719,-0.74023 2.1305,-0.19658 5.24071,-0.10662 7.38828,-0.14062 z"
-         id="path914-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer2"
-       inkscape:label="Emblem">
+       inkscape:label="Background"
+       style="display:inline">
+      <path
+         d="M 264,76.191988 C 264,58.421266 249.57873,43.999999 231.80801,43.999999 H 72.191988 c -17.770722,0 -32.191989,14.421267 -32.191989,32.191989 V 235.80801 C 39.999999,253.57873 54.421266,268 72.191988,268 H 231.80801 C 249.57873,268 264,253.57873 264,235.80801 Z"
+         fill="url(#a)"
+         id="path7"
+         style="fill:url(#linearGradient414);stroke-width:5.16891" />
+      <path
+         d="m 367,67.610856 c 0,-3.649345 -2.96151,-6.610855 -6.61085,-6.610855 h -32.77829 c -3.64934,0 -6.61085,2.96151 -6.61085,6.610855 v 32.778294 c 0,3.64934 2.96151,6.61085 6.61085,6.61085 h 32.77829 C 364.03849,107 367,104.03849 367,100.38915 Z"
+         fill="url(#a)"
+         id="path365"
+         style="fill:url(#linearGradient371);stroke-width:1.06147" />
+      <path
+         d="M 351,137.31143 C 351,134.93142 349.06858,133 346.68858,133 H 325.31143 C 322.93142,133 321,134.93142 321,137.31143 v 21.37715 c 0,2.38 1.93142,4.31142 4.31143,4.31142 h 21.37715 c 2.38,0 4.31142,-1.93142 4.31142,-4.31142 z"
+         fill="url(#a)"
+         id="path373"
+         style="fill:url(#linearGradient379);stroke-width:0.692265" />
+      <path
+         d="m 343.5,191.80543 c 0,-1.82468 -1.48076,-3.30543 -3.30543,-3.30543 h -16.38914 c -1.82468,0 -3.30543,1.48075 -3.30543,3.30543 v 16.38914 c 0,1.82467 1.48075,3.30543 3.30543,3.30543 h 16.38914 c 1.82467,0 3.30543,-1.48076 3.30543,-3.30543 z"
+         fill="url(#a)"
+         id="path381"
+         style="fill:url(#linearGradient387);stroke-width:0.530737" />
+      <path
+         d="m 335.5,238.65571 c 0,-1.19 -0.96571,-2.15571 -2.15571,-2.15571 h -10.68858 c -1.19,0 -2.15571,0.96571 -2.15571,2.15571 v 10.68858 c 0,1.19 0.96571,2.15571 2.15571,2.15571 h 10.68858 c 1.19,0 2.15571,-0.96571 2.15571,-2.15571 z"
+         fill="url(#a)"
+         id="path389"
+         style="fill:url(#linearGradient395);stroke-width:0.346133" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictogram"
+       style="display:inline">
+      <path
+         d="M 89.027136,151.38933 88.980616,106.4353 139.39819,98.919697 V 151.38933 Z M 147.80284,97.586117 215.00905,86.850286 v 64.539044 h -67.20621 z m 67.21654,63.024553 -0.0103,64.53904 -67.20621,-10.374 v -54.16504 z m -75.62119,52.98652 -50.376223,-7.57762 -0.0052,-45.4089 h 50.381393 z"
+         fill="#eff9fe"
+         fill-opacity="0.75"
+         fill-rule="nonzero"
+         id="path9"
+         style="display:inline;enable-background:new;stroke-width:5.16891" />
+      <path
+         d="m 331.06808,83.053166 -0.01,-9.231631 10.35361,-1.543382 v 10.775013 z m 12.07001,-11.048873 13.80127,-2.20468 v 13.253553 h -13.80127 z m 13.80339,12.942541 -0.002,13.253554 -13.80127,-2.130377 V 84.946834 Z m -15.52935,10.881161 -10.34511,-1.556119 -0.001,-9.325042 h 10.34618 z"
+         fill="#eff9fe"
+         fill-opacity="0.75"
+         fill-rule="nonzero"
+         id="path367"
+         style="display:inline;enable-background:new;stroke-width:1.06147" />
+      <path
+         d="m 327.56614,147.3825 -0.006,-6.02063 6.75235,-1.00655 v 7.02718 z m 7.87174,-7.20579 9.00083,-1.43783 v 8.64362 h -9.00083 z m 9.00222,8.44079 -10e-4,8.64362 -9.00083,-1.38937 v -7.25425 z m -10.12784,7.09641 -6.74682,-1.01486 -6.9e-4,-6.08155 h 6.74751 z"
+         fill="#eff9fe"
+         fill-opacity="0.75"
+         fill-rule="nonzero"
+         id="path375"
+         style="display:inline;enable-background:new;stroke-width:0.692265" />
+      <path
+         d="m 325.53403,199.52658 -0.005,-4.61582 5.1768,-0.77169 v 5.38751 z m 6.03501,-5.52444 6.90064,-1.10234 v 6.62678 h -6.90064 z m 6.9017,6.47127 -10e-4,6.62678 -6.90064,-1.06519 v -5.56159 z m -7.76468,5.44059 -5.17256,-0.77806 -5.3e-4,-4.66253 h 5.17309 z"
+         fill="#eff9fe"
+         fill-opacity="0.75"
+         fill-rule="nonzero"
+         id="path383"
+         style="display:inline;enable-background:new;stroke-width:0.530737" />
+      <path
+         d="m 323.78307,243.69125 -0.003,-3.01031 3.37618,-0.50328 v 3.51359 z m 3.93587,-3.60289 4.50042,-0.71892 v 4.32181 h -4.50042 z m 4.50111,4.22039 -6.9e-4,4.32181 -4.50042,-0.69469 v -3.62712 z m -5.06392,3.54821 -3.37341,-0.50743 -3.4e-4,-3.04078 h 3.37375 z"
+         fill="#eff9fe"
+         fill-opacity="0.75"
+         fill-rule="nonzero"
+         id="path391"
+         style="display:inline;enable-background:new;stroke-width:0.346133" />
       <path
          inkscape:connector-curvature="0"
-         id="path1477"
-         d="m 332.68128,242.17098 -4.15962,7.20029 c -0.075,0.13373 0.0748,0.36729 0.33457,0.52169 0.25976,0.1544 0.53112,0.17117 0.60611,0.0374 l 4.15962,-7.2003 z"
-         style="opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linejoin:round"
-         sodipodi:nodetypes="ccsccc" />
+         id="path1453"
+         d="m 226.45249,104.31077 -86.52646,147.35606 c -1.2576,2.14163 1.25445,5.8825 5.61079,8.35544 4.35629,2.47298 8.90721,2.74156 10.1648,0.59992 l 86.52646,-147.35604 z"
+         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1457);stroke-width:1;stroke-linejoin:round;filter:url(#filter1459);enable-background:new"
+         transform="matrix(0.99999655,0,0,1,4.7664533e-4,-7.7486851)" />
       <path
          inkscape:connector-curvature="0"
-         id="path1475"
-         d="m 340.43975,195.59498 -7.15409,12.37638 c -0.1185,0.20896 0.11823,0.57392 0.52876,0.81518 0.41054,0.24127 0.8394,0.26747 0.95792,0.0585 l 7.15409,-12.37639 z"
-         style="opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999997;stroke-linejoin:round"
-         sodipodi:nodetypes="ccsccc" />
+         id="path1067"
+         d="M 225.35144,94.773588 138.82528,242.12965 c -1.2576,2.14163 1.25444,5.8825 5.61077,8.35544 4.35627,2.47298 8.90718,2.74156 10.16476,0.59992 l 86.52616,-147.35603 z"
+         style="display:inline;fill:url(#linearGradient1075);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1077);stroke-width:0.999998;stroke-linejoin:round;enable-background:new" />
       <path
+         sodipodi:nodetypes="cssscc"
          inkscape:connector-curvature="0"
-         id="path1469"
-         d="m 346.0234,142.89364 -9.05565,15.64997 c -0.14614,0.25653 0.14579,0.7046 0.65206,1.0008 0.50627,0.29621 1.03515,0.32838 1.1813,0.0718 l 9.05564,-15.64996 z"
-         style="opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linejoin:round"
-         sodipodi:nodetypes="ccsccc" />
+         style="display:inline;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#eeeeec;stroke-width:0.999998;stroke-linejoin:round;stroke-opacity:1;enable-background:new"
+         d="m 225.35144,94.773588 -22.77005,38.777932 c -1.25759,2.14163 1.25445,5.88251 5.61077,8.35545 4.35627,2.47298 8.90724,2.74156 10.16478,0.59993 l 22.77003,-38.77793 z"
+         id="path1069" />
+      <ellipse
+         id="ellipse1071"
+         style="display:inline;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:#d3d7cf;stroke-width:1.00005;stroke-opacity:1;enable-background:new"
+         transform="matrix(0.86964607,0.49367572,-0.50635105,0.86232744,0,0)"
+         cx="251.41154"
+         cy="-28.834122"
+         rx="9.070097"
+         ry="4.4968877" />
       <path
          inkscape:connector-curvature="0"
          id="path1463"
-         d="m 358.26826,74.154982 -15.50633,26.664598 c -0.23991,0.4166 0.23931,1.1443 1.07036,1.62535 0.83103,0.48106 1.6992,0.5333 1.93911,0.1167 l 15.50634,-26.664595 z"
-         style="opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linejoin:round"
+         d="m 358.26794,74.155465 -15.50633,26.664605 c -0.23991,0.4166 0.23931,1.1443 1.07036,1.62535 0.83103,0.48106 1.6992,0.5333 1.93911,0.1167 l 15.50634,-26.664602 z"
+         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linejoin:round;enable-background:new"
          sodipodi:nodetypes="ccsccc" />
       <path
          inkscape:connector-curvature="0"
          id="rect4403"
-         d="M 357.26826,73.155215 341.76225,99.81981 c -0.23991,0.4166 0.23931,1.1443 1.07036,1.62535 0.83103,0.48106 1.6992,0.5333 1.93911,0.1167 l 15.50602,-26.664592 z"
-         style="fill:url(#linearGradient5044);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient5046);stroke-width:1;stroke-linejoin:round"
+         d="m 357.26794,73.155698 -15.50601,26.664598 c -0.23991,0.416604 0.23931,1.144304 1.07036,1.625354 0.83103,0.48106 1.6992,0.5333 1.93911,0.1167 l 15.50602,-26.664599 z"
+         style="display:inline;fill:url(#linearGradient5044);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient5046);stroke-width:1;stroke-linejoin:round;enable-background:new"
          sodipodi:nodetypes="ccsccc" />
       <path
          sodipodi:nodetypes="cssscc"
          inkscape:connector-curvature="0"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#eeeeec;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
-         d="m 357.26826,73.155215 -4.40299,7.543758 c -0.24234,0.415197 0.2393,1.144303 1.07036,1.625358 0.83103,0.481054 1.69677,0.531888 1.93911,0.116695 l 4.403,-7.543758 z"
+         style="display:inline;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#eeeeec;stroke-width:1;stroke-linejoin:round;stroke-opacity:1;enable-background:new"
+         d="m 357.26794,73.155698 -4.40299,7.543758 c -0.24234,0.415197 0.2393,1.144303 1.07036,1.625358 0.83103,0.481054 1.69677,0.531888 1.93911,0.116695 l 4.403,-7.543758 z"
          id="path4410" />
       <ellipse
          id="path4407"
-         style="fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:#d3d7cf;stroke-width:0.999995;stroke-opacity:1"
+         style="display:inline;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:#d3d7cf;stroke-width:0.999995;stroke-opacity:1;enable-background:new"
          transform="matrix(0.86546052,0.50097714,-0.49902349,0.86658846,0,0)"
-         cx="347.85062"
-         cy="-115.67081"
+         cx="347.85059"
+         cy="-115.67023"
          rx="1.7386557"
          ry="0.87046063" />
       <path
          inkscape:connector-curvature="0"
-         id="path1083"
-         d="m 345.09531,141.96481 -9.05528,15.64998 c -0.14613,0.25652 0.1458,0.70459 0.65206,1.00079 0.50627,0.29621 1.03515,0.32838 1.18131,0.0718 l 9.05528,-15.64997 z"
-         style="fill:url(#linearGradient1091);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1093);stroke-width:1;stroke-linejoin:round"
+         id="path1475"
+         d="m 340.4403,195.59503 -7.15426,12.37637 c -0.1185,0.20896 0.11824,0.57392 0.52878,0.81518 0.41055,0.24127 0.83942,0.26747 0.95794,0.0585 l 7.15425,-12.37638 z"
+         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00001;stroke-linejoin:round;enable-background:new"
+         sodipodi:nodetypes="ccsccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1099"
+         d="m 339.44072,194.59531 -6.95469,12.37637 c -0.11851,0.20896 0.11823,0.57392 0.52877,0.81518 0.41055,0.24127 0.83942,0.26747 0.95794,0.0585 l 6.95469,-12.37638 z"
+         style="display:inline;fill:url(#linearGradient1107);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1109);stroke-width:1.00001;stroke-linejoin:round;enable-background:new"
          sodipodi:nodetypes="ccsccc" />
       <path
          sodipodi:nodetypes="cssscc"
          inkscape:connector-curvature="0"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#eeeeec;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
-         d="m 345.04626,141.96481 -2.64622,4.64473 c -0.14615,0.25653 0.14579,0.7046 0.65206,1.0008 0.50627,0.29621 1.03515,0.32838 1.18129,0.0718 l 2.64624,-4.64473 z"
+         style="display:inline;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#eeeeec;stroke-width:1.00001;stroke-linejoin:round;stroke-opacity:1;enable-background:new"
+         d="m 339.44072,194.59531 -2.14588,3.78325 c -0.11852,0.20895 0.11821,0.57392 0.52877,0.81519 0.41054,0.24126 0.83942,0.26747 0.95793,0.0585 l 2.14589,-3.78326 z"
+         id="path1101" />
+      <ellipse
+         id="ellipse1103"
+         style="display:inline;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:#d3d7cf;stroke-width:1.00007;stroke-opacity:1;enable-background:new"
+         transform="matrix(0.86214451,0.50666245,-0.49336702,0.86982124,0,0)"
+         cx="392.16803"
+         cy="-4.2130642"
+         rx="0.86221683"
+         ry="0.43494645" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1469"
+         d="m 346.0234,142.89343 -9.05565,15.64997 c -0.14614,0.25653 0.14579,0.7046 0.65206,1.0008 0.50627,0.29621 1.03515,0.32838 1.1813,0.0718 l 9.05564,-15.64996 z"
+         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linejoin:round;enable-background:new"
+         sodipodi:nodetypes="ccsccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1083"
+         d="m 345.09531,141.9646 -9.05528,15.64998 c -0.14613,0.25652 0.1458,0.70459 0.65206,1.00079 0.50627,0.29621 1.03515,0.32838 1.18131,0.0718 l 9.05528,-15.64997 z"
+         style="display:inline;fill:url(#linearGradient1091);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1093);stroke-width:1;stroke-linejoin:round;enable-background:new"
+         sodipodi:nodetypes="ccsccc" />
+      <path
+         sodipodi:nodetypes="cssscc"
+         inkscape:connector-curvature="0"
+         style="display:inline;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#eeeeec;stroke-width:1;stroke-linejoin:round;stroke-opacity:1;enable-background:new"
+         d="m 345.04626,141.9646 -2.64622,4.64473 c -0.14615,0.25653 0.14579,0.7046 0.65206,1.0008 0.50627,0.29621 1.03515,0.32838 1.18129,0.0718 l 2.64624,-4.64473 z"
          id="path1085" />
       <ellipse
          id="ellipse1087"
-         style="fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:#d3d7cf;stroke-width:1.00004;stroke-opacity:1"
+         style="display:inline;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:#d3d7cf;stroke-width:1.00004;stroke-opacity:1;enable-background:new"
          transform="matrix(0.86312318,0.50499344,-0.49502311,0.86887981,0,0)"
-         cx="371.1662"
-         cy="-51.716396"
+         cx="371.16608"
+         cy="-51.716576"
          rx="1.0620478"
          ry="0.53456527" />
       <path
          inkscape:connector-curvature="0"
-         id="path1099"
-         d="m 339.44019,194.59526 -6.95453,12.37638 c -0.1185,0.20896 0.11823,0.57392 0.52876,0.81518 0.41054,0.24127 0.8394,0.26747 0.95792,0.0585 l 6.95453,-12.37639 z"
-         style="fill:url(#linearGradient1107);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1109);stroke-width:0.999997;stroke-linejoin:round"
+         id="path1477"
+         d="m 332.68169,242.17054 -4.15962,7.20029 c -0.075,0.13373 0.0748,0.36729 0.33457,0.52169 0.25976,0.1544 0.53112,0.17117 0.60611,0.0374 l 4.15962,-7.2003 z"
+         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linejoin:round;enable-background:new"
          sodipodi:nodetypes="ccsccc" />
-      <path
-         sodipodi:nodetypes="cssscc"
-         inkscape:connector-curvature="0"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#eeeeec;stroke-width:0.999997;stroke-linejoin:round;stroke-opacity:1"
-         d="m 339.44019,194.59526 -2.14583,3.78325 c -0.11851,0.20895 0.11821,0.57392 0.52876,0.81519 0.41053,0.24126 0.8394,0.26747 0.95791,0.0585 l 2.14584,-3.78326 z"
-         id="path1101" />
-      <ellipse
-         id="ellipse1103"
-         style="fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:#d3d7cf;stroke-width:1.00006;stroke-opacity:1"
-         transform="matrix(0.86213922,0.50667145,-0.49335809,0.8698263,0,0)"
-         cx="392.16763"
-         cy="-4.2169304"
-         rx="0.86220217"
-         ry="0.43494424" />
       <path
          inkscape:connector-curvature="0"
          id="path1115"
-         d="m 331.68153,241.17113 -3.99187,7.20029 c -0.075,0.13373 0.0748,0.36729 0.33457,0.52169 0.25976,0.1544 0.53112,0.17117 0.60611,0.0374 l 3.99187,-7.2003 z"
-         style="fill:url(#linearGradient1123);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1125);stroke-width:1;stroke-linejoin:round"
+         d="m 331.68194,241.17069 -3.99187,7.20029 c -0.075,0.13373 0.0748,0.36729 0.33457,0.52169 0.25976,0.1544 0.53112,0.17117 0.60611,0.0374 l 3.99187,-7.2003 z"
+         style="display:inline;fill:url(#linearGradient1123);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1125);stroke-width:1;stroke-linejoin:round;enable-background:new"
          sodipodi:nodetypes="ccsccc" />
       <path
          sodipodi:nodetypes="cssscc"
          inkscape:connector-curvature="0"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#eeeeec;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
-         d="m 331.68153,241.17113 -0.78187,1.42132 c -0.0739,0.13434 0.0748,0.36729 0.33457,0.52169 0.25975,0.15441 0.53219,0.17177 0.6061,0.0374 l 0.78188,-1.42133 z"
+         style="display:inline;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#eeeeec;stroke-width:1;stroke-linejoin:round;stroke-opacity:1;enable-background:new"
+         d="m 331.68194,241.17069 -0.78187,1.42132 c -0.0739,0.13434 0.0748,0.36729 0.33457,0.52169 0.25975,0.15441 0.53219,0.17177 0.6061,0.0374 l 0.78188,-1.42133 z"
          id="path1117" />
       <ellipse
          id="ellipse1119"
-         style="fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:#d3d7cf;stroke-width:1.00016;stroke-opacity:1"
+         style="display:inline;fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:#d3d7cf;stroke-width:1.00016;stroke-opacity:1;enable-background:new"
          transform="matrix(0.85961033,0.51095018,-0.48912916,0.87221136,0,0)"
-         cx="407.93677"
-         cy="37.852474"
+         cx="407.93692"
+         cy="37.851875"
          rx="0.54715371"
          ry="0.27758548" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1453"
-         d="M 226.45294,96.562301 139.92648,243.91836 c -1.2576,2.14163 1.25445,5.8825 5.61079,8.35544 4.35629,2.47298 8.90721,2.74156 10.1648,0.59992 l 86.52646,-147.35604 z"
-         style="opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1457);stroke-width:1;stroke-linejoin:round;filter:url(#filter1459)" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1067"
-         d="M 225.35219,94.773805 138.82573,242.12986 c -1.2576,2.14163 1.25445,5.8825 5.61079,8.35544 4.35629,2.47298 8.90721,2.74156 10.1648,0.59992 l 86.52646,-147.35603 z"
-         style="fill:url(#linearGradient1075);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1077);stroke-width:1;stroke-linejoin:round" />
-      <path
-         sodipodi:nodetypes="cssscc"
-         inkscape:connector-curvature="0"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#eeeeec;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
-         d="m 225.35219,94.773805 -22.77013,38.777925 c -1.25759,2.14163 1.25446,5.88251 5.61079,8.35545 4.35629,2.47298 8.90727,2.74156 10.16482,0.59993 l 22.77011,-38.77793 z"
-         id="path1069" />
-      <ellipse
-         id="ellipse1071"
-         style="fill:#d3d7cf;fill-opacity:1;fill-rule:nonzero;stroke:#d3d7cf;stroke-width:1.00005;stroke-opacity:1"
-         transform="matrix(0.8696468,0.49367442,-0.50635236,0.86232667,0,0)"
-         cx="251.41228"
-         cy="-28.833946"
-         rx="9.0701208"
-         ry="4.4968915" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/workspace-switcher-left-bottom.svg
+++ b/icons/src/fullcolor/default/apps/workspace-switcher-left-bottom.svg
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="workspace-switcher-left-bottom.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.5"
-     inkscape:cx="329.10912"
-     inkscape:cy="236.9365"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="303.34881"
+     inkscape:cy="149.55308"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1301"
-     inkscape:window-height="744"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,164 +93,54 @@
   <defs
      id="defs3">
     <linearGradient
-       id="linearGradient906"
-       inkscape:collect="always">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(0,-174.1262,174.1262,0,3988.1706,241.02965)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#e95420;stop-opacity:1"
+         stop-color="#006783"
          offset="0"
-         id="stop902" />
+         id="stop22" />
       <stop
-         style="stop-color:#f34f17;stop-opacity:1"
+         stop-color="#20ccff"
          offset="1"
-         id="stop904" />
+         id="stop24" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1686"
-       x1="319.99991"
-       y1="92.000153"
-       x2="367.99991"
-       y2="76.000153"
+       xlink:href="#a"
+       id="linearGradient598"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,1,0,259.9988,-259.99991)" />
+       gradientTransform="matrix(0,-35.758058,35.758058,0,1131.785,101.46145)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1688"
-       x1="320.00003"
-       y1="152.00002"
-       x2="352.00003"
-       y2="144.00002"
+       xlink:href="#a"
+       id="linearGradient606"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,1,0,187.99992,-188.00002)" />
+       gradientTransform="matrix(0,-23.320473,23.320473,0,849.77285,159.3879)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1690"
-       x1="319.9993"
-       y1="203.99928"
-       x2="343.9993"
-       y2="195.99928"
+       xlink:href="#a"
+       id="linearGradient614"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,1,0,132.00078,-131.9993)" />
+       gradientTransform="matrix(0,-17.879029,17.879029,0,725.89251,208.73072)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1692"
-       x1="320.00031"
-       y1="246.00034"
-       x2="336.00031"
-       y2="242.00034"
+       xlink:href="#a"
+       id="linearGradient622"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,1,0,83.999654,-84.00031)" />
+       gradientTransform="matrix(0,-11.660237,11.660237,0,584.88644,249.69395)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1692-6"
-       x1="321.00031"
-       y1="244.00034"
-       x2="335.00031"
-       y2="244.00034"
+       xlink:href="#a"
+       id="linearGradient630"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,1,0,83.999654,-84.00031)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1690-9"
-       x1="320.9993"
-       y1="199.99928"
-       x2="342.9993"
-       y2="199.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,1,0,132.00078,-131.9993)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1688-4"
-       x1="322"
-       y1="148.00002"
-       x2="350"
-       y2="148.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,1,0,187.99993,-188.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1686-0"
-       x1="321.99991"
-       y1="84.000153"
-       x2="365.99991"
-       y2="84.000153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,1,0,259.99879,-259.9999)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58449"
-       x="-0.047999425"
-       width="1.0959988"
-       y="-0.048000575"
-       height="1.0960012">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.4800539"
-         id="feGaussianBlur58451" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58492"
-       x="-0.011999856"
-       width="1.0239997"
-       y="-0.012000144"
-       height="1.0240003">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1200135"
-         id="feGaussianBlur58494" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient3155"
-       x1="109.29108"
-       y1="42.311958"
-       x2="187.63246"
-       y2="265.99969"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,303.99457,0)" />
-    <linearGradient
-       id="linearGradient7537">
-      <stop
-         style="stop-color:#f37e40;stop-opacity:1"
-         offset="0"
-         id="stop7539" />
-      <stop
-         style="stop-color:#f34f17;stop-opacity:1"
-         offset="1"
-         id="stop7541" />
-    </linearGradient>
+       gradientTransform="matrix(0,-174.1262,174.1262,0,3988.1706,241.02965)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -261,13 +152,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -349,7 +240,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">workspace-switcher-left-bottom</tspan></text>
+           id="tspan924">workspace-switcher-left-bottom</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -384,239 +275,69 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(-1,0,0,1,303.99457,0)" />
+         d="M 231.80801,268 H 72.19199 C 54.42127,268 40,253.57873 40,235.80801 V 76.19199 C 40,58.42127 54.42127,44 72.19199,44 H 231.80801 C 249.57873,44 264,58.42127 264,76.19199 V 235.80801 C 264,253.57873 249.57873,268 231.80801,268 Z"
+         fill="url(#a)"
+         id="path27"
+         style="display:inline;fill:url(#linearGradient630);stroke-width:5.16891;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(-1,0,0,1,303.99457,0)" />
+         d="M 360.38914,107 H 327.61085 C 323.96151,107 321,104.03849 321,100.38914 V 67.610855 C 321,63.961511 323.96151,61 327.61085,61 h 32.77829 c 3.64934,0 6.61085,2.961511 6.61085,6.610855 v 32.778285 c 0,3.64935 -2.96151,6.61086 -6.61085,6.61086 z"
+         fill="url(#a)"
+         id="path592"
+         style="display:inline;fill:url(#linearGradient598);stroke-width:1.06147;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 331.8714,237.00001 c 3.74357,0 4.14638,0.30899 4.12803,3.32331 v 4.17669 4.17668 c 0.0183,3.01433 -0.38446,3.32332 -4.12803,3.32332 h -7.74335 c -3.7436,0 -4.12805,-0.30895 -4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 0.38446,-3.32331 4.12805,-3.32331 z"
-         id="path918-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 346.68858,163 H 325.31143 C 322.93142,163 321,161.06858 321,158.68857 v -21.37715 c 0,-2.38 1.93142,-4.31142 4.31143,-4.31142 h 21.37715 c 2.38,0 4.31142,1.93142 4.31142,4.31142 v 21.37715 C 351,161.06858 349.06858,163 346.68858,163 Z"
+         fill="url(#a)"
+         id="path600"
+         style="display:inline;fill:url(#linearGradient606);stroke-width:0.692265;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 337.54731,189.00048 c 1.2321,0 2.21668,0.0221 3.06999,0.14144 0.85332,0.11937 1.62809,0.35533 2.21066,0.83967 0.58256,0.48436 0.86983,1.13381 1.01188,1.84587 0.14202,0.71207 0.16501,1.53239 0.15897,2.56202 v 7.61066 4.6143 c 0.006,1.02762 -0.0171,1.84735 -0.15897,2.55843 -0.14203,0.71208 -0.42931,1.36152 -1.01188,1.84587 -0.58258,0.48434 -1.35734,0.7203 -2.21066,0.83967 -0.85331,0.11936 -1.83789,0.14144 -3.06999,0.14144 h -11.09542 c -1.2321,0 -2.21381,-0.022 -3.0657,-0.14144 -0.85187,-0.11947 -1.62795,-0.35683 -2.2085,-0.84146 -0.58057,-0.48464 -0.86451,-1.13152 -1.00758,-1.84228 -0.14307,-0.71077 -0.16972,-1.5314 -0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 0.0266,-1.84946 0.16972,-2.56023 0.14307,-0.71076 0.42701,-1.35765 1.00758,-1.84228 0.58055,-0.48464 1.35661,-0.722 2.2085,-0.84147 0.8519,-0.11947 1.83359,-0.14144 3.0657,-0.14144 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         d="m 340.19457,211.5 h -16.38914 c -1.82467,0 -3.30543,-1.48076 -3.30543,-3.30543 v -16.38915 c 0,-1.82467 1.48076,-3.30542 3.30543,-3.30542 h 16.38914 c 1.82468,0 3.30543,1.48075 3.30543,3.30542 v 16.38915 c 0,1.82467 -1.48075,3.30543 -3.30543,3.30543 z"
+         fill="url(#a)"
+         id="path608"
+         style="display:inline;fill:url(#linearGradient614);stroke-width:0.530736;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 342.699,134 c 1.63949,0 2.94082,0.0308 4.04505,0.19141 1.10422,0.16064 2.06697,0.4726 2.78308,1.09179 0.71611,0.61919 1.0805,1.45612 1.26421,2.41407 0.18374,0.95795 0.21537,2.08705 0.20733,3.51171 V 149 v 7.79688 c 0.009,1.42131 -0.0239,2.5495 -0.20733,3.50585 -0.18371,0.95796 -0.5481,1.79488 -1.26421,2.41407 -0.71611,0.61919 -1.67886,0.93115 -2.78308,1.09179 C 345.63982,163.96924 344.33849,164 342.699,164 h -13.40164 c -1.63949,0 -2.93835,-0.0307 -4.04054,-0.19141 -1.10219,-0.16075 -2.06274,-0.47425 -2.77633,-1.09375 -0.71357,-0.6195 -1.07457,-1.45363 -1.25969,-2.41015 -0.18515,-0.95653 -0.22086,-2.08403 -0.22086,-3.50781 V 149 141.20312 c 0,-1.42378 0.0358,-2.55128 0.22086,-3.50781 0.18512,-0.95653 0.54612,-1.79065 1.25969,-2.41015 0.71359,-0.61951 1.67414,-0.933 2.77633,-1.09375 C 326.35901,134.03065 327.65787,134 329.29736,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 354.34119,62 c 2.6221,0 4.68675,0.05009 6.38561,0.286735 1.69887,0.236639 3.08904,0.680503 4.10735,1.523515 1.0183,0.843013 1.55577,1.996072 1.83828,3.406406 0.28252,1.410336 0.33767,3.127346 0.32482,5.308412 v 12.474816 12.480783 c 0.0127,2.177715 -0.0426,3.893853 -0.32482,5.302673 -0.28251,1.41034 -0.81998,2.5634 -1.83828,3.40641 -1.01831,0.84301 -2.40848,1.28688 -4.10735,1.52351 C 359.02792,107.94991 356.96329,108 354.34119,108 h -20.68618 c -2.62213,0 -4.68568,-0.05 -6.38104,-0.28674 -1.69534,-0.23674 -3.08126,-0.6821 -4.09581,-1.52542 -1.01457,-0.84331 -1.54885,-1.99555 -1.83367,-3.4045 -0.28483,-1.40893 -0.34554,-3.122462 -0.34554,-5.302673 V 84.999884 72.519333 c 0,-2.180211 0.0608,-3.893733 0.34554,-5.302677 0.28482,-1.408942 0.81911,-2.561177 1.83368,-3.404494 1.01455,-0.843317 2.40047,-1.288685 4.09582,-1.525427 C 328.96933,62.049992 331.0329,62 333.65501,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 354.66378,61.500049 c 10.01116,0 11.88667,0.90635 11.83407,9.74838 v 12.75157 12.75181 c 0.0527,8.842031 -1.82291,9.748381 -11.83407,9.748381 h -21.3308 c -10.00866,0 -11.83405,-0.90625 -11.83405,-9.748381 v -12.75181 -12.75157 c 0,-8.84213 1.82539,-9.74838 11.83406,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.921604,43.999694 c -35.29673,0 -39.09461,3.62542 -38.92162,38.99353 v 73.006466 73.00648 c -0.17299,35.36812 3.62489,38.99353 38.92162,38.99353 H 225.07836 c 35.29671,0 38.92161,-3.625 38.92161,-38.99353 V 155.99969 82.993224 c 0,-35.36853 -3.6249,-38.99353 -38.92161,-38.99353 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 337.82318,188.49945 c 5.14666,0 5.70043,0.43262 5.67521,4.65309 v 5.84793 7.84761 c 0.0253,4.22046 -0.52855,4.65307 -5.67521,4.65307 H 326.1775 c -5.14665,0 -5.67521,-0.43255 -5.67521,-4.65307 v -7.84761 -5.84793 c 0,-4.22051 0.52857,-4.65309 5.67522,-4.65309 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 331.59438,236.50001 c 3.47604,0 3.85006,0.30899 3.83302,3.32331 v 4.17669 4.17668 c 0.017,3.01433 -0.35698,3.32332 -3.83302,3.32332 h -7.18996 c -3.47605,0 -3.83303,-0.30895 -3.83303,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 0.35699,-3.32331 3.83303,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 342.87283,133.5 c 6.45163,0 7.6603,0.58409 7.62639,6.28227 v 8.21765 8.21781 c 0.034,5.69818 -1.17476,6.28227 -7.62639,6.28227 h -13.74651 c -6.45003,0 -7.62639,-0.58403 -7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 1.17636,-6.28227 7.62639,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 333.34429,251.5 h -10.68857 c -1.19001,0 -2.15572,-0.96571 -2.15572,-2.15571 v -10.68858 c 0,-1.19 0.96571,-2.15571 2.15572,-2.15571 h 10.68857 c 1.19,0 2.15571,0.96571 2.15571,2.15571 v 10.68858 c 0,1.19 -0.96571,2.15571 -2.15571,2.15571 z"
+         fill="url(#a)"
+         id="path616"
+         style="display:inline;fill:url(#linearGradient622);stroke-width:0.346132;enable-background:new" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms and folds"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         sodipodi:nodetypes="sssssssss"
-         inkscape:connector-curvature="0"
-         id="path983"
-         d="m 336.06784,62.499886 c -13.62163,0 -15.56836,1.94187 -15.56836,15.55078 v 11.89844 c 0,13.608864 1.94673,15.550784 15.56836,15.550784 h 15.86327 c 13.62162,0 15.56836,-1.94192 15.56836,-15.550784 v -11.89844 c 0,-13.60891 -1.94674,-15.55078 -15.56836,-15.55078 z"
-         style="display:inline;opacity:1;fill:url(#linearGradient986);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+         id="path29-3"
+         d="m 102.78864,177.8952 -17.91958,0.1008 0.0207,5.01746 -9.65134,0.0413 c -9.30404,0.062 -16.8307,7.64638 -16.76868,16.95042 l 0.20211,33.6888 c 0.0569,9.30404 7.62621,16.82057 16.9302,16.75855 l 37.25251,-0.20211 c 9.30404,-0.062 16.81055,-7.65645 16.74852,-16.96049 l -0.19177,-33.69889 c -0.0413,-9.28336 -7.64637,-16.78444 -16.95041,-16.75859 l -9.6715,0.0605 z m 7.04668,19.7469 c 4.82259,-0.0103 8.77232,3.86423 8.80333,8.70233 0.0362,4.83811 -3.86428,8.77232 -8.70238,8.80333 -4.8381,0.031 -8.77227,-3.86427 -8.80328,-8.70238 -0.0155,-4.82259 3.86423,-8.76709 8.70233,-8.80328 z m -29.84241,0.19177 c 4.8226,-0.0517 8.76761,3.86966 8.78312,8.69225 0.0517,4.8226 -3.85957,8.76761 -8.68217,8.78312 -4.81737,0.0465 -8.76756,-3.86474 -8.78307,-8.68217 -0.0517,-4.8226 3.86469,-8.77769 8.68212,-8.7932 z"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:5.16891" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 332.1597,83.974089 c 1.14882,0 0.94111,0.0028 2.2455,0.02591 1.44422,0 -1.18767,-0.02173 0,0 h 2.28125 7.3125 v 9.701172 c 0,-2.388672 0,-1.17755 0,0 7.5e-4,2.111408 7.5e-4,0.962598 7.5e-4,2.111408 0,1.14881 0,0 0.005,1.851021 -0.006,0.635388 -0.006,3.0239 -0.006,0.635228 V 106.5 h -10.66602 c -10.00866,0 -11.83398,-0.90592 -11.83398,-9.748047 V 84 h 0.10742 5.70508 2.49609 c -1.72157,0 -1.15088,0 0,0 0.9566,-0.01734 1.20335,-0.02591 2.35216,-0.02591 z"
-         id="path21860"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccscccsscccccs" />
+         id="path594"
+         d="m 333.89409,88.496335 -3.67991,0.0207 0.004,1.030372 -1.98197,0.0085 c -1.91065,0.01273 -3.45631,1.570239 -3.44357,3.48089 l 0.0415,6.918235 c 0.0117,1.910648 1.5661,3.454228 3.47674,3.441488 l 7.65007,-0.0415 c 1.91065,-0.0127 3.45217,-1.57231 3.43943,-3.482962 l -0.0394,-6.920308 c -0.008,-1.906404 -1.57024,-3.446804 -3.48089,-3.441496 l -1.98611,0.01242 z m 1.44709,4.055167 c 0.99035,-0.0021 1.80146,0.793548 1.80782,1.787086 0.007,0.99354 -0.79355,1.801459 -1.78709,1.807827 -0.99354,0.0064 -1.80145,-0.793556 -1.80782,-1.787096 -0.003,-0.990353 0.79355,-1.800385 1.78709,-1.807817 z m -6.12835,0.03938 c 0.99035,-0.01062 1.80049,0.794662 1.80367,1.785015 0.0106,0.990356 -0.79259,1.800492 -1.78294,1.803677 -0.98929,0.0095 -1.80049,-0.793652 -1.80367,-1.782946 -0.0106,-0.990355 0.79364,-1.802561 1.78294,-1.805746 z"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:1.06147" />
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 343.9982,71.974087 c 0,1.14882 2e-5,0.702038 7.5e-4,2.432163 0,1.550883 0,2.28125 0,0 V 76.6875 84 h -9.59375 c 2.28125,-10e-7 1.11481,0.01995 0,-10e-7 -1.27776,-0.02287 -1.09669,-0.02591 -2.2455,-0.02591 -1.14881,0 -0.62235,0.0011 -2.35216,0.02591 -0.67088,0 -1.32157,0 0,0 h -8.20117 V 73.33398 c 0,-10.00866 0.90592,-11.83398 9.74805,-11.83398 h 12.64453 v 0.10742 5.70508 2.49609 c 0,-1.721567 0,-1.310883 0,0 -7.5e-4,2.165497 -7.5e-4,1.016687 -7.5e-4,2.165497 z"
-         id="path21860-7"
-         sodipodi:nodetypes="scccccsscccsscccccs" />
+         id="path602"
+         d="m 329.4092,150.93239 -2.39995,0.0135 0.003,0.67198 -1.29259,0.006 c -1.24607,0.008 -2.25411,1.02407 -2.2458,2.27015 l 0.0271,4.51189 c 0.008,1.24608 1.02136,2.25276 2.26743,2.24445 l 4.98918,-0.0271 c 1.24608,-0.008 2.25141,-1.02542 2.24311,-2.27149 l -0.0257,-4.51325 c -0.006,-1.2433 -1.02407,-2.24791 -2.27014,-2.24445 l -1.29529,0.008 z m 0.94375,2.64467 c 0.64588,-10e-4 1.17486,0.51753 1.17901,1.16549 0.005,0.64797 -0.51753,1.17487 -1.16549,1.17902 -0.64796,0.004 -1.17486,-0.51753 -1.17901,-1.1655 -0.002,-0.64588 0.51753,-1.17416 1.16549,-1.17901 z m -3.99675,0.0257 c 0.64588,-0.007 1.17423,0.51826 1.17631,1.16414 0.007,0.64588 -0.51691,1.17423 -1.16279,1.17631 -0.64519,0.006 -1.17423,-0.5176 -1.17631,-1.16279 -0.007,-0.64589 0.51759,-1.17559 1.16279,-1.17766 z"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:0.692265" />
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 343.9997,95.81258 c 0,-1.14882 -0.0588,-0.807945 -7.5e-4,-2.111408 0,-1.364217 0,-2.388672 0,-0.107422 V 91.3125 84 h 9.70117 c -0.8149,1.67376 -1.11492,-0.01188 0,0 2.43216,0.02591 1.28335,0.02591 2.43216,0.02591 1.14881,0 0.80865,-0.0016 2.1655,-0.02591 1.68422,0 0.8149,1.67376 0,0 h 8.20117 v 10.66602 c 0,10.00866 -0.90592,11.83398 -9.74805,11.83398 h -12.75195 v -0.10742 -5.70508 -2.49609 c 0,2.49609 0,1.684217 0,0 0.022,-1.916797 7.5e-4,-1.23002 7.5e-4,-2.37883 z"
-         id="path21860-7-4"
-         sodipodi:nodetypes="scccccsscccsscccccs" />
+         id="path610"
+         d="m 326.94705,202.24816 -1.83996,0.0103 0.002,0.51519 -0.99099,0.004 c -0.95532,0.006 -1.72815,0.78512 -1.72178,1.74045 l 0.0207,3.45911 c 0.006,0.95533 0.78305,1.72712 1.73837,1.72075 l 3.82503,-0.0207 c 0.95533,-0.006 1.72609,-0.78616 1.71972,-1.74148 l -0.0197,-3.46016 c -0.004,-0.9532 -0.78512,-1.7234 -1.74045,-1.72075 l -0.99305,0.006 z m 0.72354,2.02759 c 0.49518,-10e-4 0.90073,0.39677 0.90392,0.89354 0.004,0.49677 -0.39678,0.90073 -0.89355,0.90391 -0.49677,0.003 -0.90073,-0.39677 -0.90391,-0.89354 -0.002,-0.49518 0.39677,-0.9002 0.89354,-0.90391 z m -3.06417,0.0197 c 0.49518,-0.005 0.90024,0.39733 0.90184,0.89251 0.005,0.49517 -0.3963,0.90024 -0.89148,0.90183 -0.49464,0.005 -0.90024,-0.39682 -0.90183,-0.89147 -0.005,-0.49518 0.39682,-0.90128 0.89147,-0.90287 z"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:0.530736" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.99994,133.5 v 0.0684 3.67773 2.15625 c 0.39707,-0.2396 0,0 0,0 v 0 c 0.0689,1.56883 -8.4e-4,0.46566 0.0689,1.56883 0.0706,1.10318 -0.0689,3.04078 -0.0689,1.75171 V 142.59961 148 H 321.5683 v -6.87305 c 0,-6.45002 0.58494,-7.62695 6.2832,-7.62695 z"
-         id="path21860-7-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccssc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 350.49994,148 v 6.87305 c 0,6.45002 -0.58299,7.62695 -6.28125,7.62695 h -8.21875 v -0.0684 -5.83203 0 c -0.0324,-1.62844 -0.10302,-0.52526 -0.0324,-1.62844 0.0697,-1.10317 0,0 0.0324,-1.56879 v 0 c 0,0 -0.39705,-0.23961 0,0 V 148 h 5.40039 c -0.28091,0.4674 -1.078,0 0,0 v 0 c 1.11072,0.0261 0.48948,0.0667 1.59208,-0.004 1.10317,-0.0697 0,0 1.60519,0.004 0,0 0.78535,0 0,0 z"
-         id="path21860-7-4-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csscccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.66997,148 c 4.32244,0 4.2756,-0.003 4.32244,0 1.10317,0.0697 0,0 1.60519,0 0,0 -1.60519,0 0,0 h 5.40234 v 5.40234 0 l -0.0324,1.56879 c 0,0 0.0697,-1.10317 0,0 -0.0706,1.10318 0.0324,-1.56879 0,0 0.0324,-1.56879 0.0324,1.62844 0.0324,1.62848 V 162.5 h -6.87305 c -6.45002,0 -7.62695,-0.58299 -7.62695,-6.28125 V 148 h 0.0684 5.83203 c 0,0 1.59204,0 0,0 v 0 c -1.25436,0 0.54297,0.0251 1.59204,0 z"
-         id="path21860-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccssccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 332.00006,188.5 v 0.0547 2.91601 1.71094 c 0,-0.461 0.0485,0.74669 0,0 v 0 c 0,-1.06355 -0.0724,0.28481 -0.0171,1.15974 0.056,0.87494 0,0 0.0172,1.37542 0,0.58634 0,0.6357 0,0 V 200 h -11.44531 l -0.0527,-0.19727 V 199 193.15234 c 0,-4.22051 0.52913,-4.65234 5.67578,-4.65234 z m 0,11.5 h 4.2832 c -0.22279,0.3707 -0.87021,0 0,0 v 0 c 1.28509,-0.004 0.41061,0.0517 1.28509,-0.004 0.87493,-0.0553 0,0 1.25007,0.004 -0.64941,-0.0127 0.59026,0 0,0 h 4.67969 v 6.84766 c 0.0253,4.22046 -0.52912,4.65429 -5.67578,4.65429 h -5.81446 l -0.008,-0.002 v -0.0547 -4.625 c -5e-5,0.60989 0,0 0,0 0.0301,-1.27219 -0.0259,-0.39726 0.0301,-1.27219 -0.009,-0.86203 -0.003,-0.26196 -0.0301,-1.26291 v 0 c 4e-5,-0.7959 0.17546,0.70023 5e-5,-5e-5 z"
-         id="path21860-7-7-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccssccccccccccscccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 326.4287,200 c 0.0372,-9.6e-4 -2.6684,0 0,0 0.87493,0.0553 0,0 1.28622,0 0.7704,4e-5 -1.28622,0 -2e-5,4e-5 h 4.28516 v 4.28516 c 0,-0.57713 0.0286,1.12293 0,0 v 0 c 0.0301,1.26291 0.0854,0.38798 0.0301,1.26291 -0.056,0.87494 -0.0301,2.18232 -0.0301,1.27219 0,0 0,0.58415 -5e-5,5e-5 V 211.5 l -0.008,0.002 h -5.81446 c -5.14665,0 -5.67578,-0.43377 -5.67578,-4.65429 V 200 h 0.0527 4.625 c -0.85505,0 0,0 0,0 v 0 c 1.24923,0 0.41721,0.0199 1.24923,0 z"
-         id="path21860-4-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccssccccccc" />
-      <path
-         style="display:inline;opacity:1;vector-effect:none;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 96.741184,156.15486 C 112.1279,156.13333 137.06124,156.00003 103.99457,156 l 48,5e-5 V 204 c 0,0 0.15987,-7.67972 0.15987,8.32028 0,16 -0.15987,7.67972 -0.15987,7.67972 v 48 H 78.922304 c -35.29673,0 -39.09486,-3.62602 -38.92187,-38.99414 V 156 h 47.99414 c -30,0 -7.86667,0.13333 8.74661,0.15486 z"
-         id="rect1772-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccscccc" />
-      <path
-         style="display:inline;opacity:0.1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 151.98378,101.41305 c 0.0215,15.38672 0.0215,32.98672 0.0215,6.58672 l -5e-5,48 h -47.99995 c 29.86667,2.6e-4 8.73586,0.15509 -7.264126,0.15509 -16,0 -35.66919,-0.15486 -8.73586,-0.15509 h -48 V 82.927499 c 0,-35.29673 3.62602,-39.09486 38.99414,-38.92187 h 73.005846 v 47.99414 c 0,-29.066667 0,-7.2 -0.0215,9.413281 z"
-         id="rect1772-7-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccscccc" />
-      <path
-         style="display:inline;opacity:0.1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 152.15444,212.32028 c -0.0215,-15.38672 -0.0215,-0.85338 -0.15486,-8.32005 l 5e-5,-48 h 47.99995 c -30.4,0 -7.86667,-0.13333 8.13333,-0.13333 16,0 36.66666,0.13333 7.86666,0.13333 h 48 v 73.07227 c 0,35.29673 -3.62602,39.09486 -38.99414,38.92187 h -73.00585 v -47.99414 c 0,-9.46667 0.13333,8.93333 0.15486,-7.67995 z"
-         id="rect1772-7-5-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccscccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.56031,242.98406 c 0,0 -0.0259,-0.001 0,0 0.60876,0.0385 0,0 1.05779,0.0134 0.51703,0 0,0 0,0 h 3.38131 v 3.48161 c 0,-0.62259 0,-0.38165 0,0 v 0 c 0.0141,0.9152 0.0526,0.30643 0.0141,0.9152 -0.0389,0.60877 -0.0138,0.84871 0,0 8.3e-4,-0.4504 0,0 -0.0138,0.84871 v 3.256 l -0.005,0.001 h -4.44536 c -3.58093,0 -3.94909,-0.30181 -3.94909,-3.23836 v -5.26457 h 0.0367 3.21797 c 0,0 -0.43874,0 0,0 v 0 c -0.95055,0 0.12648,8.5e-4 0.70538,-0.013 z"
-         id="path21860-4-1-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccsscccccc" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer4"
-       inkscape:label="Borders"
-       style="display:inline;opacity:1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 225.07269,43.999698 c 35.29673,0 39.09487,3.62603 38.92188,38.99414 v 2 c 0.17299,-35.36811 -3.62515,-38.99414 -38.92188,-38.99414 H 78.916454 c -35.29673,0 -38.92188,3.62561 -38.92188,38.99414 v -2 c 0,-35.36853 3.62515,-38.99414 38.92188,-38.99414 z"
-         id="path931"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 225.06729,267.9997 c 35.29673,0 39.09488,-3.62603 38.92189,-38.99414 v -2 c 0.17299,35.36811 -3.62516,38.99414 -38.92189,38.99414 H 78.911054 c -35.29673,0 -38.92188,-3.62561 -38.92188,-38.99414 v 2 c 0,35.36853 3.62515,38.99414 38.92188,38.99414 z"
-         id="path931-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 354.66378,61.500047 c 10.01116,0 11.88667,0.90635 11.83407,9.74838 V 84 96.75181 c 0.0527,8.84203 -1.82291,9.74838 -11.83407,9.74838 h -21.3308 c -10.00866,0 -11.83405,-0.90625 -11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 1.82539,-9.74838 11.83406,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 342.87283,133.5 c 6.45163,0 7.6603,0.58409 7.62639,6.28227 v 8.21765 8.21781 c 0.034,5.69818 -1.17476,6.28227 -7.62639,6.28227 h -13.74651 c -6.45003,0 -7.62639,-0.58403 -7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 1.17636,-6.28227 7.62639,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 326.02347,211.50015 c -4.67187,0 -5.5471,-0.42296 -5.52255,-4.54923 v -7.95037 -5.95084 c -0.0245,-4.12627 0.85068,-4.54923 5.52255,-4.54923 h 11.95364 c 4.67071,0 5.52256,0.42291 5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 -0.85185,4.54923 -5.52256,4.54923 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 324.44504,251.5 c -3.33705,0 -3.96221,-0.30212 -3.94468,-3.24946 v -4.2505 -4.25059 c -0.0175,-2.94734 0.60763,-3.24945 3.94468,-3.24945 h 7.11025 c 3.33622,0 3.94469,0.30208 3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 -0.60847,3.24946 -3.94469,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline;opacity:0.3">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 331.55467,237 c 1.65302,0 2.54604,0.12548 2.91601,0.41406 0.18499,0.14429 0.30479,0.33122 0.39649,0.70313 0.0917,0.37191 0.13281,0.91317 0.13281,1.63281 v 4.25 4.25 c 0,0.71964 -0.0411,1.26082 -0.13281,1.63281 -0.0917,0.37191 -0.2115,0.55884 -0.39649,0.70313 C 334.10071,250.87452 333.20769,251 331.55467,251 h -7.10938 c -1.65343,0 -2.55203,-0.12511 -2.92383,-0.41406 -0.18589,-0.14448 -0.30578,-0.33208 -0.39648,-0.70313 -0.0907,-0.37105 -0.129,-0.90979 -0.125,-1.6289 v -0.002 V 244 v -4.25195 -0.002 c -0.004,-0.71911 0.0343,-1.25785 0.125,-1.6289 0.0907,-0.37105 0.21059,-0.55865 0.39648,-0.70313 0.37179,-0.2889 1.2704,-0.41402 2.92383,-0.41402 z m -5.32813,1.04688 c -1.10767,-3.4e-4 -2.21363,0.008 -3.32031,0.0449 -0.26616,0.0599 -0.75737,-0.0208 -0.79297,0.3457 -0.13405,1.84438 -0.0662,3.68774 -0.10156,5.53906 0.0126,1.86745 -0.0543,3.67031 0.10351,5.49805 -0.0642,0.42314 0.43946,0.35577 0.70313,0.42187 3.43277,0.0703 6.87577,0.0589 10.29883,0.002 0.22288,-0.0398 0.55622,-3.2e-4 0.71093,-0.1875 0.19863,-1.12995 0.12696,-2.26946 0.16016,-3.41992 -0.0138,-2.55648 0.029,-5.10728 -0.0898,-7.65625 0.03,-0.2727 -0.10944,-0.49629 -0.40039,-0.48829 -1.30659,-0.161 -2.63265,-0.0636 -3.94727,-0.0976 -1.10718,0.006 -2.21655,-0.002 -3.32422,-0.002 z"
-         id="path918-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate"
-         d="m 337.97623,189.00048 c 2.32027,0 3.60941,0.15494 4.20703,0.62109 0.29882,0.23308 0.48964,0.54668 0.625,1.09571 0.13541,0.54902 0.19141,1.31765 0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 -0.056,1.783 -0.19141,2.33203 -0.13536,0.54903 -0.32618,0.86263 -0.625,1.09571 -0.59762,0.46615 -1.88676,0.62109 -4.20703,0.62109 h -11.9524 c -2.32085,0 -3.61652,-0.15457 -4.2168,-0.62109 -0.30014,-0.23327 -0.49095,-0.54754 -0.625,-1.09571 -0.13404,-0.54816 -0.18764,-1.31623 -0.18164,-2.33008 v -7.95279 -5.95312 c -0.006,-1.01386 0.0476,-1.78191 0.18164,-2.33008 0.13406,-0.54817 0.32486,-0.86244 0.625,-1.09571 0.60028,-0.46652 1.89595,-0.62109 4.2168,-0.62109 z m -4.95859,1.00977 c -1.5798,-0.002 -4.16014,-3.9e-4 -5.73991,0.0117 -1.50021,0.0511 -3.02236,-0.0712 -4.5,0.28321 -0.55111,0.0919 -0.61303,0.71807 -0.67773,1.16601 -0.1117,4.30832 -0.075,10.62608 -0.0508,14.94108 0.0716,0.99089 -0.13687,2.07606 0.30078,3.01366 0.34356,0.40964 0.9694,0.35958 1.45117,0.45509 3.95407,0.0823 9.92936,0.0499 13.89381,0.0371 1.16908,-0.0622 2.37292,0.11291 3.51758,-0.22266 0.57935,-0.098 0.6137,-0.75914 0.6875,-1.2207 0.1146,-4.11835 0.0751,-10.24472 0.0547,-14.36881 -0.0572,-1.06305 0.0797,-2.16734 -0.18164,-3.21485 -0.10495,-0.6386 -0.8614,-0.66043 -1.36719,-0.74023 -2.1305,-0.19658 -5.24071,-0.10662 -7.38828,-0.14062 z"
-         id="path914-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 342.87299,134 c 3.21072,0 5.03255,0.19514 5.9375,0.89844 0.45247,0.35165 0.74178,0.83286 0.93359,1.61718 0.19176,0.78433 0.26386,1.85686 0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c 0.008,1.40682 -0.0641,2.47935 -0.25586,3.26368 -0.1918,0.78431 -0.48112,1.26553 -0.93359,1.61718 -0.90496,0.7033 -2.72678,0.89844 -5.9375,0.89844 h -13.7461 c -3.20992,0 -5.02461,-0.19551 -5.92578,-0.89844 -0.45058,-0.35146 -0.73805,-0.83201 -0.93164,-1.61718 -0.19363,-0.7853 -0.26953,-1.86033 -0.26953,-3.26768 V 148 139.7832 c 0,-1.40735 0.0759,-2.48237 0.26953,-3.26758 0.19359,-0.78517 0.48106,-1.26572 0.93164,-1.61718 C 324.10228,134.19551 325.91697,134 329.12689,134 Z m -6.49805,1.04688 c -3.45647,0.0171 -6.9142,-0.0268 -10.36133,0.0918 -0.8211,0.13276 -1.80664,0.14835 -2.39062,0.82617 -0.67884,1.16473 -0.51296,2.58781 -0.56446,3.87305 -0.0431,6.02893 -0.0678,12.06719 0.0332,18.08789 0.0775,0.77792 0.12055,1.67263 0.67968,2.27539 0.70249,0.51038 1.61833,0.59683 2.45899,0.67383 4.04742,0.0864 8.16222,0.0456 12.24023,0.0606 2.45188,-0.0199 4.91402,0.0317 7.35352,-0.0606 0.87784,-0.12055 1.915,-0.14021 2.56055,-0.83398 0.64775,-1.02591 0.50264,-2.30525 0.56054,-3.46485 0.035,-5.65575 0.0351,-11.35518 0,-17.00976 -0.0632,-1.22153 0.10864,-2.57724 -0.59179,-3.65235 -0.6025,-0.62665 -1.55621,-0.63986 -2.35938,-0.77344 -2.73743,-0.10739 -5.48083,-0.0704 -8.22656,-0.0918 -0.46403,-2.9e-4 -0.92855,-0.002 -1.39258,-0.002 z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 354.66301,62 c 4.99049,0 7.87051,0.276282 9.38477,1.453125 0.75713,0.588421 1.23761,1.403518 1.54492,2.660156 0.3073,1.256638 0.4173,2.940031 0.4043,5.132813 V 84 96.753906 c 0.0131,2.19278 -0.097,3.876174 -0.4043,5.132814 -0.30731,1.25663 -0.78779,2.07172 -1.54492,2.66016 C 362.53351,105.72371 359.6535,106 354.66301,106 h -21.33008 c -4.98923,0 -7.85502,-0.27668 -9.36328,-1.45312 -0.75412,-0.58824 -1.23293,-1.40461 -1.54297,-2.66211 -0.31003,-1.2575 -0.42773,-2.939489 -0.42773,-5.132817 V 84 71.248047 c 0,-2.193329 0.1177,-3.875313 0.42773,-5.132813 0.31004,-1.257499 0.78884,-2.073874 1.54297,-2.662109 C 325.47791,62.276656 328.34369,62 333.33293,62 Z m -2.40234,1.097656 c -6.94737,8.3e-4 -13.91063,0.0034 -20.84961,0.05469 -2.14296,0.08293 -4.46431,-0.147701 -6.42383,0.93164 -1.29609,0.695228 -1.54862,2.250325 -1.76953,3.564454 -0.17551,2.202888 -0.0915,4.442228 -0.13867,6.669921 -0.0227,8.479532 -0.077,16.968993 0.0801,25.447266 0.16151,1.483233 0.38135,3.305793 1.79882,4.142573 1.6055,0.82871 3.47551,0.90643 5.24805,0.95313 9.49974,0.0678 19.0243,0.0843 28.52344,-0.0176 1.57816,-0.11413 3.27053,-0.24014 4.63281,-1.12109 1.22952,-0.99538 1.36082,-2.72739 1.50391,-4.193361 0.1272,-8.998585 0.0836,-18.004484 0.0527,-27.007813 -0.0997,-2.381275 0.24538,-4.900002 -0.70508,-7.160156 -0.67165,-1.50972 -2.46573,-1.859954 -3.93945,-2.05664 -2.66168,-0.316582 -5.34184,-0.147022 -8.01367,-0.207032 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
+         id="path618"
+         d="m 324.7046,245.4662 -1.19997,0.007 10e-4,0.33599 -0.64629,0.003 c -0.62304,0.004 -1.12706,0.51204 -1.12291,1.13507 l 0.0135,2.25595 c 0.004,0.62304 0.51068,1.12638 1.13372,1.12223 l 2.49459,-0.0135 c 0.62303,-0.004 1.1257,-0.51271 1.12155,-1.13575 l -0.0128,-2.25662 c -0.003,-0.62165 -0.51204,-1.12396 -1.13508,-1.12222 l -0.64764,0.004 z m 0.47187,1.32233 c 0.32295,-6.9e-4 0.58744,0.25877 0.58951,0.58275 0.002,0.32398 -0.25877,0.58743 -0.58275,0.58951 -0.32398,0.002 -0.58742,-0.25877 -0.5895,-0.58275 -10e-4,-0.32294 0.25876,-0.58708 0.58274,-0.58951 z m -1.99837,0.0128 c 0.32294,-0.003 0.58712,0.25913 0.58815,0.58207 0.003,0.32295 -0.25845,0.58712 -0.58139,0.58816 -0.32259,0.003 -0.58711,-0.2588 -0.58815,-0.58139 -0.003,-0.32295 0.25879,-0.5878 0.58139,-0.58884 z"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:0.346132" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/workspace-switcher-left-top.svg
+++ b/icons/src/fullcolor/default/apps/workspace-switcher-left-top.svg
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="workspace-switcher-left-top.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.70710678"
-     inkscape:cx="309.88352"
-     inkscape:cy="229.15631"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="2"
+     inkscape:cx="257"
+     inkscape:cy="188.5"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1301"
-     inkscape:window-height="744"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,153 +93,54 @@
   <defs
      id="defs3">
     <linearGradient
-       id="linearGradient906"
-       inkscape:collect="always">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(0,-33.6872,33.6872,0,616.83586,108.45575)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#e95420;stop-opacity:1"
+         stop-color="#006783"
          offset="0"
-         id="stop902" />
+         id="stop22" />
       <stop
-         style="stop-color:#f34f17;stop-opacity:1"
+         stop-color="#20ccff"
          offset="1"
-         id="stop904" />
+         id="stop24" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
+       xlink:href="#a"
+       id="linearGradient396"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-35.75806,35.75806,0,1131.7851,101.46144)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1686"
-       x1="319.99991"
-       y1="92.000153"
-       x2="367.99991"
-       y2="76.000153"
+       xlink:href="#a"
+       id="linearGradient404"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,343.99945,84.00065)" />
+       gradientTransform="matrix(0,-23.320475,23.320475,0,849.7729,159.3879)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1688"
-       x1="320.00003"
-       y1="152.00002"
-       x2="352.00003"
-       y2="144.00002"
+       xlink:href="#a"
+       id="linearGradient412"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,335.99997,148.00005)" />
+       gradientTransform="matrix(0,-17.879031,17.879031,0,725.89255,208.73072)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1690"
-       x1="319.9993"
-       y1="203.99928"
-       x2="343.9993"
-       y2="195.99928"
+       xlink:href="#a"
+       id="linearGradient420"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,332.00076,199.99998)" />
+       gradientTransform="matrix(0,-11.660237,11.660237,0,584.88645,249.69395)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1692"
-       x1="320.00031"
-       y1="246.00034"
-       x2="336.00031"
-       y2="242.00034"
+       xlink:href="#a"
+       id="linearGradient424"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,1,0,83.999654,-84.00031)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1692-6"
-       x1="321.00031"
-       y1="244.00034"
-       x2="335.00031"
-       y2="244.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-90,328.24997,244.25032)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1690-9"
-       x1="320.9993"
-       y1="199.99928"
-       x2="342.9993"
-       y2="199.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,1,0,132.00078,-131.9993)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1688-4"
-       x1="322"
-       y1="148.00002"
-       x2="350"
-       y2="148.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,1,0,187.99993,-188.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1686-0"
-       x1="321.99991"
-       y1="84.000153"
-       x2="365.99991"
-       y2="84.000153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,1,0,259.99879,-259.9999)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58449"
-       x="-0.047999425"
-       width="1.0959988"
-       y="-0.048000575"
-       height="1.0960012">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.4800539"
-         id="feGaussianBlur58451" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58492"
-       x="-0.011999856"
-       width="1.0239997"
-       y="-0.012000144"
-       height="1.0240003">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1200135"
-         id="feGaussianBlur58494" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient3155"
-       x1="109.29108"
-       y1="42.311958"
-       x2="187.63246"
-       y2="265.99969"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(-180,151.99728,155.99985)" />
+       gradientTransform="matrix(0,-174.12621,174.12621,0,3988.171,241.02965)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -250,13 +152,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -338,7 +240,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">workspace-switcher-left-top</tspan></text>
+           id="tspan924">workspace-switcher-left-top</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -373,239 +275,69 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(-1,0,0,1,303.99457,0)" />
+         d="M 231.80802,268 H 72.191981 C 54.421257,268 39.999989,253.57874 39.999989,235.80801 V 76.191993 c 0,-17.770724 14.421268,-32.191992 32.191992,-32.191992 H 231.80802 c 17.77072,0 32.19199,14.421268 32.19199,32.191992 V 235.80801 C 264.00001,253.57874 249.57874,268 231.80802,268 Z"
+         fill="url(#a)"
+         id="path27"
+         style="display:inline;fill:url(#linearGradient424);stroke-width:5.16891;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(-1,0,0,1,303.99457,0)" />
+         d="m 360.38915,107 h -32.7783 C 323.96151,107 321,104.03849 321,100.38914 V 67.610856 c 0,-3.649345 2.96151,-6.610855 6.61085,-6.610855 h 32.7783 c 3.64934,0 6.61085,2.96151 6.61085,6.610855 V 100.38914 C 367,104.03849 364.03849,107 360.38915,107 Z"
+         fill="url(#a)"
+         id="path390"
+         style="display:inline;fill:url(#linearGradient396);stroke-width:1.06147;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 331.8714,237.00001 c 3.74357,0 4.14638,0.30899 4.12803,3.32331 v 4.17669 4.17668 c 0.0183,3.01433 -0.38446,3.32332 -4.12803,3.32332 h -7.74335 c -3.7436,0 -4.12805,-0.30895 -4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 0.38446,-3.32331 4.12805,-3.32331 z"
-         id="path918-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 346.68857,163 H 325.31143 C 322.93142,163 321,161.06858 321,158.68857 V 137.31143 C 321,134.93142 322.93142,133 325.31143,133 h 21.37714 c 2.38001,0 4.31143,1.93142 4.31143,4.31143 v 21.37714 C 351,161.06858 349.06858,163 346.68857,163 Z"
+         fill="url(#a)"
+         id="path398"
+         style="display:inline;fill:url(#linearGradient404);stroke-width:0.692265;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 337.54731,189.00048 c 1.2321,0 2.21668,0.0221 3.06999,0.14144 0.85332,0.11937 1.62809,0.35533 2.21066,0.83967 0.58256,0.48436 0.86983,1.13381 1.01188,1.84587 0.14202,0.71207 0.16501,1.53239 0.15897,2.56202 v 7.61066 4.6143 c 0.006,1.02762 -0.0171,1.84735 -0.15897,2.55843 -0.14203,0.71208 -0.42931,1.36152 -1.01188,1.84587 -0.58258,0.48434 -1.35734,0.7203 -2.21066,0.83967 -0.85331,0.11936 -1.83789,0.14144 -3.06999,0.14144 h -11.09542 c -1.2321,0 -2.21381,-0.022 -3.0657,-0.14144 -0.85187,-0.11947 -1.62795,-0.35683 -2.2085,-0.84146 -0.58057,-0.48464 -0.86451,-1.13152 -1.00758,-1.84228 -0.14307,-0.71077 -0.16972,-1.5314 -0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 0.0266,-1.84946 0.16972,-2.56023 0.14307,-0.71076 0.42701,-1.35765 1.00758,-1.84228 0.58055,-0.48464 1.35661,-0.722 2.2085,-0.84147 0.8519,-0.11947 1.83359,-0.14144 3.0657,-0.14144 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         d="m 340.19457,211.5 h -16.38915 c -1.82467,0 -3.30542,-1.48076 -3.30542,-3.30543 v -16.38915 c 0,-1.82467 1.48075,-3.30542 3.30542,-3.30542 h 16.38915 c 1.82467,0 3.30543,1.48075 3.30543,3.30542 v 16.38915 c 0,1.82467 -1.48076,3.30543 -3.30543,3.30543 z"
+         fill="url(#a)"
+         id="path406"
+         style="display:inline;fill:url(#linearGradient412);stroke-width:0.530737;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 342.699,134 c 1.63949,0 2.94082,0.0308 4.04505,0.19141 1.10422,0.16064 2.06697,0.4726 2.78308,1.09179 0.71611,0.61919 1.0805,1.45612 1.26421,2.41407 0.18374,0.95795 0.21537,2.08705 0.20733,3.51171 V 149 v 7.79688 c 0.009,1.42131 -0.0239,2.5495 -0.20733,3.50585 -0.18371,0.95796 -0.5481,1.79488 -1.26421,2.41407 -0.71611,0.61919 -1.67886,0.93115 -2.78308,1.09179 C 345.63982,163.96924 344.33849,164 342.699,164 h -13.40164 c -1.63949,0 -2.93835,-0.0307 -4.04054,-0.19141 -1.10219,-0.16075 -2.06274,-0.47425 -2.77633,-1.09375 -0.71357,-0.6195 -1.07457,-1.45363 -1.25969,-2.41015 -0.18515,-0.95653 -0.22086,-2.08403 -0.22086,-3.50781 V 149 141.20312 c 0,-1.42378 0.0358,-2.55128 0.22086,-3.50781 0.18512,-0.95653 0.54612,-1.79065 1.25969,-2.41015 0.71359,-0.61951 1.67414,-0.933 2.77633,-1.09375 C 326.35901,134.03065 327.65787,134 329.29736,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 354.34119,62 c 2.6221,0 4.68675,0.05009 6.38561,0.286735 1.69887,0.236639 3.08904,0.680503 4.10735,1.523515 1.0183,0.843013 1.55577,1.996072 1.83828,3.406406 0.28252,1.410336 0.33767,3.127346 0.32482,5.308412 v 12.474816 12.480783 c 0.0127,2.177715 -0.0426,3.893853 -0.32482,5.302673 -0.28251,1.41034 -0.81998,2.5634 -1.83828,3.40641 -1.01831,0.84301 -2.40848,1.28688 -4.10735,1.52351 C 359.02792,107.94991 356.96329,108 354.34119,108 h -20.68618 c -2.62213,0 -4.68568,-0.05 -6.38104,-0.28674 -1.69534,-0.23674 -3.08126,-0.6821 -4.09581,-1.52542 -1.01457,-0.84331 -1.54885,-1.99555 -1.83367,-3.4045 -0.28483,-1.40893 -0.34554,-3.122462 -0.34554,-5.302673 V 84.999884 72.519333 c 0,-2.180211 0.0608,-3.893733 0.34554,-5.302677 0.28482,-1.408942 0.81911,-2.561177 1.83368,-3.404494 1.01455,-0.843317 2.40047,-1.288685 4.09582,-1.525427 C 328.96933,62.049992 331.0329,62 333.65501,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 354.66378,106.50014 c 10.01116,0 11.88667,-0.90635 11.83407,-9.748379 V 84.000191 71.248381 C 366.55055,62.40635 364.67494,61.5 354.66378,61.5 h -21.3308 c -10.00866,0 -11.83405,0.90625 -11.83405,9.748381 v 12.75181 12.75157 c 0,8.842129 1.82539,9.748379 11.83406,9.748379 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.921604,268 c -35.29673,0 -39.09461,-3.62542 -38.92162,-38.99353 V 156 82.993524 c -0.17299,-35.36812 3.62489,-38.99353 38.92162,-38.99353 H 225.07836 c 35.29671,0 38.92161,3.625 38.92161,38.99353 V 156 229.00647 C 263.99997,264.375 260.37507,268 225.07836,268 Z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 337.82318,211.502 c 5.14666,0 5.70043,-0.43262 5.67521,-4.65309 v -5.84793 -7.84761 c 0.0253,-4.22046 -0.52855,-4.65307 -5.67521,-4.65307 H 326.1775 c -5.14665,0 -5.67521,0.43255 -5.67521,4.65307 v 7.84761 5.84793 c 0,4.22051 0.52857,4.65309 5.67522,4.65309 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 331.59438,236.50001 c 3.47604,0 3.85006,0.30899 3.83302,3.32331 v 4.17669 4.17668 c 0.017,3.01433 -0.35698,3.32332 -3.83302,3.32332 h -7.18996 c -3.47605,0 -3.83303,-0.30895 -3.83303,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 0.35699,-3.32331 3.83303,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 342.87283,162.5 c 6.45163,0 7.6603,-0.58409 7.62639,-6.28227 v -8.21765 -8.21781 c 0.034,-5.69818 -1.17476,-6.28227 -7.62639,-6.28227 h -13.74651 c -6.45003,0 -7.62639,0.58403 -7.62639,6.28227 v 8.21781 8.21765 c 0,5.69824 1.17636,6.28227 7.62639,6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 333.34429,251.5 h -10.68858 c -1.19,0 -2.15571,-0.96571 -2.15571,-2.15571 v -10.68858 c 0,-1.19 0.96571,-2.15571 2.15571,-2.15571 h 10.68858 c 1.19,0 2.15571,0.96571 2.15571,2.15571 v 10.68858 c 0,1.19 -0.96571,2.15571 -2.15571,2.15571 z"
+         fill="url(#a)"
+         id="path414"
+         style="display:inline;fill:url(#linearGradient420);stroke-width:0.346133;enable-background:new" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms and folds"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         sodipodi:nodetypes="sssssssss"
-         inkscape:connector-curvature="0"
-         id="path983"
-         d="m 336.06784,62.499886 c -13.62163,0 -15.56836,1.94187 -15.56836,15.55078 v 11.89844 c 0,13.608864 1.94673,15.550784 15.56836,15.550784 h 15.86327 c 13.62162,0 15.56836,-1.94192 15.56836,-15.550784 v -11.89844 c 0,-13.60891 -1.94674,-15.55078 -15.56836,-15.55078 z"
-         style="display:inline;opacity:1;fill:url(#linearGradient986);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+         id="path362"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:5.16891"
+         d="m 100.62312,57.219337 -17.909506,0.100948 0.02067,5.017485 -9.661422,0.05066 c -9.304044,0.06203 -16.820626,7.631104 -16.758599,16.940306 l 0.191767,33.688794 c 0.05686,9.30403 7.636294,16.83071 16.940286,16.76868 l 37.252564,-0.21203 c 9.30399,-0.062 16.81049,-7.65646 16.74846,-16.96049 l -0.2021,-33.688796 c -0.0413,-9.288526 -7.6363,-16.799697 -16.94034,-16.768683 l -9.6715,0.06058 z m 7.05676,19.746866 c 4.82259,-0.01551 8.77232,3.864248 8.80333,8.702351 0.0362,4.838093 -3.86428,8.772297 -8.70238,8.8033 -4.83811,0.03618 -8.772269,-3.864253 -8.803283,-8.702346 -0.01551,-4.817417 3.864233,-8.772292 8.702333,-8.803305 z m -29.842412,0.201898 c 4.822596,-0.05169 8.767614,3.864744 8.783121,8.682161 0.05169,4.822586 -3.869656,8.767614 -8.692252,8.78311 -4.817427,0.05169 -8.757483,-3.869665 -8.772989,-8.692251 -0.05169,-4.817416 3.864744,-8.757514 8.68212,-8.77302 z" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 332.1597,84.026101 c 1.14882,0 0.94111,-0.0028 2.2455,-0.02591 1.44422,0 -1.18767,0.02173 0,0 h 2.28125 7.3125 v -9.701172 c 0,2.388672 0,1.17755 0,0 7.5e-4,-2.111408 7.5e-4,-0.962598 7.5e-4,-2.111408 0,-1.14881 0,0 0.005,-1.851021 -0.006,-0.635388 -0.006,-3.0239 -0.006,-0.635228 V 61.50019 h -10.66602 c -10.00866,0 -11.83398,0.90592 -11.83398,9.748047 V 84.00019 h 0.10742 5.70508 2.49609 c -1.72157,0 -1.15088,0 0,0 0.9566,0.01734 1.20335,0.02591 2.35216,0.02591 z"
-         id="path21860"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccscccsscccccs" />
+         id="path392"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:1.06147"
+         d="m 333.44939,63.714685 -3.67784,0.02073 0.004,1.030376 -1.98404,0.0104 c -1.91065,0.01274 -3.45423,1.567101 -3.4415,3.478812 l 0.0394,6.918235 c 0.0117,1.910649 1.56817,3.456306 3.47881,3.443569 l 7.65008,-0.04354 c 1.91064,-0.01274 3.45216,-1.572309 3.43942,-3.482959 l -0.0415,-6.918234 c -0.009,-1.907466 -1.56817,-3.449938 -3.47882,-3.443569 l -1.98611,0.01244 z m 1.44916,4.05516 c 0.99035,-0.0032 1.80146,0.793551 1.80782,1.78709 0.007,0.993537 -0.79355,1.801454 -1.78709,1.807821 -0.99354,0.0074 -1.80145,-0.793552 -1.80782,-1.787089 -0.003,-0.989291 0.79355,-1.801453 1.78709,-1.807822 z m -6.12835,0.04146 c 0.99035,-0.01061 1.80049,0.793653 1.80367,1.782944 0.0106,0.990353 -0.79466,1.800492 -1.78501,1.803675 -0.9893,0.01061 -1.79841,-0.794664 -1.8016,-1.785016 -0.0106,-0.989291 0.79365,-1.798418 1.78294,-1.801603 z" />
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 343.9982,96.026103 c 0,-1.14882 2e-5,-0.702038 7.5e-4,-2.432163 0,-1.550883 0,-2.28125 0,0 v -2.28125 -7.3125 h -9.59375 c 2.28125,10e-7 1.11481,-0.01995 0,10e-7 -1.27776,0.02287 -1.09669,0.02591 -2.2455,0.02591 -1.14881,0 -0.62235,-0.0011 -2.35216,-0.02591 -0.67088,0 -1.32157,0 0,0 h -8.20117 V 94.66621 c 0,10.00866 0.90592,11.83398 9.74805,11.83398 h 12.64453 v -0.10742 -5.70508 -2.49609 c 0,1.721567 0,1.310883 0,0 -7.5e-4,-2.165497 -7.5e-4,-1.016687 -7.5e-4,-2.165497 z"
-         id="path21860-7"
-         sodipodi:nodetypes="scccccsscccsscccccs" />
+         id="path400"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:0.692265"
+         d="m 329.11917,134.77045 -2.3986,0.0135 0.003,0.67198 -1.29394,0.007 c -1.24608,0.008 -2.25276,1.02202 -2.24445,2.26879 l 0.0257,4.51189 c 0.008,1.24607 1.02272,2.25411 2.26879,2.2458 l 4.98918,-0.0284 c 1.24607,-0.008 2.25141,-1.02542 2.2431,-2.2715 l -0.0271,-4.51189 c -0.006,-1.244 -1.02272,-2.24996 -2.26879,-2.24581 l -1.29529,0.008 z m 0.9451,2.64467 c 0.64588,-0.002 1.17486,0.51753 1.17902,1.16549 0.005,0.64796 -0.51754,1.17486 -1.1655,1.17901 -0.64796,0.005 -1.17486,-0.51753 -1.17901,-1.16549 -0.002,-0.64519 0.51753,-1.17486 1.16549,-1.17901 z m -3.99675,0.027 c 0.64588,-0.007 1.17423,0.5176 1.17631,1.16279 0.007,0.64588 -0.51826,1.17423 -1.16414,1.17631 -0.64519,0.007 -1.17288,-0.51826 -1.17496,-1.16415 -0.007,-0.64519 0.5176,-1.17288 1.16279,-1.17495 z" />
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 343.9997,72.18761 c 0,1.14882 -0.0588,0.807945 -7.5e-4,2.111408 0,1.364217 0,2.388672 0,0.107422 v 2.28125 7.3125 h 9.70117 c -0.8149,-1.67376 -1.11492,0.01188 0,0 2.43216,-0.02591 1.28335,-0.02591 2.43216,-0.02591 1.14881,0 0.80865,0.0016 2.1655,0.02591 1.68422,0 0.8149,-1.67376 0,0 h 8.20117 V 73.33417 c 0,-10.00866 -0.90592,-11.83398 -9.74805,-11.83398 h -12.75195 v 0.10742 5.70508 2.49609 c 0,-2.49609 0,-1.684217 0,0 0.022,1.916797 7.5e-4,1.23002 7.5e-4,2.37883 z"
-         id="path21860-7-4"
-         sodipodi:nodetypes="scccccsscccsscccccs" />
+         id="path408"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:0.530737"
+         d="m 326.72469,189.85734 -1.83892,0.0104 0.002,0.51519 -0.99202,0.005 c -0.95532,0.006 -1.72712,0.78355 -1.72075,1.73941 l 0.0197,3.45912 c 0.006,0.95532 0.78409,1.72815 1.73941,1.72178 l 3.82504,-0.0218 c 0.95532,-0.006 1.72608,-0.78615 1.71971,-1.74148 l -0.0208,-3.45912 c -0.004,-0.95373 -0.78409,-1.72497 -1.73941,-1.72178 l -0.99306,0.006 z m 0.72458,2.02758 c 0.49518,-0.002 0.90073,0.39677 0.90391,0.89354 0.004,0.49677 -0.39677,0.90073 -0.89354,0.90391 -0.49677,0.004 -0.90073,-0.39677 -0.90391,-0.89354 -0.002,-0.49465 0.39677,-0.90073 0.89354,-0.90391 z m -3.06417,0.0207 c 0.49517,-0.005 0.90024,0.39683 0.90183,0.89147 0.005,0.49518 -0.39733,0.90025 -0.8925,0.90184 -0.49465,0.005 -0.89921,-0.39733 -0.9008,-0.89251 -0.005,-0.49465 0.39682,-0.89921 0.89147,-0.9008 z" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.99994,162.5 v -0.0684 -3.67773 -2.15625 c 0.39707,0.2396 0,0 0,0 v 0 c 0.0689,-1.56883 -8.4e-4,-0.46566 0.0689,-1.56883 0.0706,-1.10318 -0.0689,-3.04078 -0.0689,-1.75171 V 153.40039 148 H 321.5683 v 6.87305 c 0,6.45002 0.58494,7.62695 6.2832,7.62695 z"
-         id="path21860-7-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccssc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 350.49994,148 v -6.87305 c 0,-6.45002 -0.58299,-7.62695 -6.28125,-7.62695 h -8.21875 v 0.0684 5.83203 0 c -0.0324,1.62844 -0.10302,0.52526 -0.0324,1.62844 0.0697,1.10317 0,0 0.0324,1.56879 v 0 c 0,0 -0.39705,0.23961 0,0 V 148 h 5.40039 c -0.28091,-0.4674 -1.078,0 0,0 v 0 c 1.11072,-0.0261 0.48948,-0.0667 1.59208,0.004 1.10317,0.0697 0,0 1.60519,-0.004 0,0 0.78535,0 0,0 z"
-         id="path21860-7-4-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csscccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.66997,148 c 4.32244,0 4.2756,0.003 4.32244,0 1.10317,-0.0697 0,0 1.60519,0 0,0 -1.60519,0 0,0 h 5.40234 v -5.40234 0 l -0.0324,-1.56879 c 0,0 0.0697,1.10317 0,0 -0.0706,-1.10318 0.0324,1.56879 0,0 0.0324,1.56879 0.0324,-1.62844 0.0324,-1.62848 V 133.5 h -6.87305 c -6.45002,0 -7.62695,0.58299 -7.62695,6.28125 V 148 h 0.0684 5.83203 c 0,0 1.59204,0 0,0 v 0 c -1.25436,0 0.54297,-0.0251 1.59204,0 z"
-         id="path21860-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccssccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 332.00006,211.50145 v -0.0547 -2.91601 -1.71094 c 0,0.461 0.0485,-0.74669 0,0 v 0 c 0,1.06355 -0.0724,-0.28481 -0.0171,-1.15974 0.056,-0.87494 0,0 0.0172,-1.37542 0,-0.58634 0,-0.6357 0,0 v -4.28319 h -11.44531 l -0.0527,0.19727 v 0.80273 5.84766 c 0,4.22051 0.52913,4.65234 5.67578,4.65234 z m 0,-11.5 h 4.2832 c -0.22279,-0.3707 -0.87021,0 0,0 v 0 c 1.28509,0.004 0.41061,-0.0517 1.28509,0.004 0.87493,0.0553 0,0 1.25007,-0.004 -0.64941,0.0127 0.59026,0 0,0 h 4.67969 v -6.84766 c 0.0253,-4.22046 -0.52912,-4.65429 -5.67578,-4.65429 h -5.81446 l -0.008,0.002 v 0.0547 4.625 c -5e-5,-0.60989 0,0 0,0 0.0301,1.27219 -0.0259,0.39726 0.0301,1.27219 -0.009,0.86203 -0.003,0.26196 -0.0301,1.26291 v 0 c 4e-5,0.7959 0.17546,-0.70023 5e-5,5e-5 z"
-         id="path21860-7-7-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccssccccccccccscccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 326.4287,200.00145 c 0.0372,9.6e-4 -2.6684,0 0,0 0.87493,-0.0553 0,0 1.28622,0 0.7704,-4e-5 -1.28622,0 -2e-5,-4e-5 h 4.28516 v -4.28516 c 0,0.57713 0.0286,-1.12293 0,0 v 0 c 0.0301,-1.26291 0.0854,-0.38798 0.0301,-1.26291 -0.056,-0.87494 -0.0301,-2.18232 -0.0301,-1.27219 0,0 0,-0.58415 -5e-5,-5e-5 v -4.67965 l -0.008,-0.002 h -5.81446 c -5.14665,0 -5.67578,0.43377 -5.67578,4.65429 v 6.84771 h 0.0527 4.625 c -0.85505,0 0,0 0,0 v 0 c 1.24923,0 0.41721,-0.0199 1.24923,0 z"
-         id="path21860-4-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccssccccccc" />
-      <path
-         style="display:inline;opacity:1;vector-effect:none;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 96.741184,155.84483 c 15.386716,0.0215 40.320056,0.15483 7.253386,0.15486 l 48,-5e-5 v -47.99995 c 0,0 0.15987,7.67972 0.15987,-8.320276 0,-16 -0.15987,-7.67972 -0.15987,-7.67972 v -48 H 78.922304 c -35.29673,0 -39.09486,3.62602 -38.92187,38.99414 v 73.005856 h 47.99414 c -30,0 -7.86667,-0.13333 8.74661,-0.15486 z"
-         id="rect1772-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccscccc" />
-      <path
-         style="display:inline;opacity:0.1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 151.98378,210.58664 c 0.0215,-15.38672 0.0215,-32.98672 0.0215,-6.58672 l -5e-5,-48 h -47.99995 c 29.86667,-2.6e-4 8.73586,-0.15509 -7.264126,-0.15509 -16,0 -35.66919,0.15486 -8.73586,0.15509 h -48 v 73.07227 c 0,35.29673 3.62602,39.09486 38.99414,38.92187 h 73.005846 v -47.99414 c 0,29.06667 0,7.2 -0.0215,-9.41328 z"
-         id="rect1772-7-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccscccc" />
-      <path
-         style="display:inline;opacity:0.1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 152.15444,99.679414 c -0.0215,15.386716 -0.0215,0.853376 -0.15486,8.320046 l 5e-5,48 h 47.99995 c -30.4,0 -7.86667,0.13333 8.13333,0.13333 16,0 36.66666,-0.13333 7.86666,-0.13333 h 48 V 82.927194 c 0,-35.29673 -3.62602,-39.09486 -38.99414,-38.92187 h -73.00585 v 47.99414 c 0,9.466666 0.13333,-8.93333 0.15486,7.67995 z"
-         id="rect1772-7-5-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccscccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.56031,245.51592 c 0,0 -0.0259,0.001 0,0 0.60876,-0.0385 0,0 1.05779,-0.0134 0.51703,0 0,0 0,0 h 3.38131 v -3.48161 c 0,0.62259 0,0.38165 0,0 v 0 c 0.0141,-0.9152 0.0526,-0.30643 0.0141,-0.9152 -0.0389,-0.60877 -0.0138,-0.84871 0,0 8.3e-4,0.4504 0,0 -0.0138,-0.84871 v -3.256 l -0.005,-0.001 h -4.44536 c -3.58093,0 -3.94909,0.30181 -3.94909,3.23836 v 5.26457 h 0.0367 3.21797 c 0,0 -0.43874,0 0,0 v 0 c -0.95055,0 0.12648,-8.5e-4 0.70538,0.013 z"
-         id="path21860-4-1-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccsscccccc" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer4"
-       inkscape:label="Borders"
-       style="display:inline;opacity:1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 225.07269,43.999698 c 35.29673,0 39.09487,3.62603 38.92188,38.99414 v 2 c 0.17299,-35.36811 -3.62515,-38.99414 -38.92188,-38.99414 H 78.916454 c -35.29673,0 -38.92188,3.62561 -38.92188,38.99414 v -2 c 0,-35.36853 3.62515,-38.99414 38.92188,-38.99414 z"
-         id="path931"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 225.06729,267.9997 c 35.29673,0 39.09488,-3.62603 38.92189,-38.99414 v -2 c 0.17299,35.36811 -3.62516,38.99414 -38.92189,38.99414 H 78.911054 c -35.29673,0 -38.92188,-3.62561 -38.92188,-38.99414 v 2 c 0,35.36853 3.62515,38.99414 38.92188,38.99414 z"
-         id="path931-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 354.66378,61.500047 c 10.01116,0 11.88667,0.90635 11.83407,9.74838 V 84 96.75181 c 0.0527,8.84203 -1.82291,9.74838 -11.83407,9.74838 h -21.3308 c -10.00866,0 -11.83405,-0.90625 -11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 1.82539,-9.74838 11.83406,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 342.87283,133.5 c 6.45163,0 7.6603,0.58409 7.62639,6.28227 v 8.21765 8.21781 c 0.034,5.69818 -1.17476,6.28227 -7.62639,6.28227 h -13.74651 c -6.45003,0 -7.62639,-0.58403 -7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 1.17636,-6.28227 7.62639,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 326.02347,211.50015 c -4.67187,0 -5.5471,-0.42296 -5.52255,-4.54923 v -7.95037 -5.95084 c -0.0245,-4.12627 0.85068,-4.54923 5.52255,-4.54923 h 11.95364 c 4.67071,0 5.52256,0.42291 5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 -0.85185,4.54923 -5.52256,4.54923 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 324.44504,251.5 c -3.33705,0 -3.96221,-0.30212 -3.94468,-3.24946 v -4.2505 -4.25059 c -0.0175,-2.94734 0.60763,-3.24945 3.94468,-3.24945 h 7.11025 c 3.33622,0 3.94469,0.30208 3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 -0.60847,3.24946 -3.94469,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline;opacity:0.3">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 331.55467,251.49998 c 1.65302,0 2.54604,-0.12548 2.91601,-0.41406 0.18499,-0.14429 0.30479,-0.33122 0.39649,-0.70313 0.0917,-0.37191 0.13281,-0.91317 0.13281,-1.63281 v -4.25 -4.25 c 0,-0.71964 -0.0411,-1.26082 -0.13281,-1.63281 -0.0917,-0.37191 -0.2115,-0.55884 -0.39649,-0.70313 -0.36997,-0.28858 -1.26299,-0.41406 -2.91601,-0.41406 h -7.10938 c -1.65343,0 -2.55203,0.12511 -2.92383,0.41406 -0.18589,0.14448 -0.30578,0.33208 -0.39648,0.70313 -0.0907,0.37105 -0.129,0.90979 -0.125,1.6289 v 0.002 4.25191 4.25195 0.002 c -0.004,0.71911 0.0343,1.25785 0.125,1.6289 0.0907,0.37105 0.21059,0.55865 0.39648,0.70313 0.37179,0.2889 1.2704,0.41402 2.92383,0.41402 z m -5.32813,-1.04688 c -1.10767,3.4e-4 -2.21363,-0.008 -3.32031,-0.0449 -0.26616,-0.0599 -0.75737,0.0208 -0.79297,-0.3457 -0.13405,-1.84438 -0.0662,-3.68774 -0.10156,-5.53906 0.0126,-1.86745 -0.0543,-3.67031 0.10351,-5.49805 -0.0642,-0.42314 0.43946,-0.35577 0.70313,-0.42187 3.43277,-0.0703 6.87577,-0.0589 10.29883,-0.002 0.22288,0.0398 0.55622,3.2e-4 0.71093,0.1875 0.19863,1.12995 0.12696,2.26946 0.16016,3.41992 -0.0138,2.55648 0.029,5.10728 -0.0898,7.65625 0.03,0.2727 -0.10944,0.49629 -0.40039,0.48829 -1.30659,0.161 -2.63265,0.0636 -3.94727,0.0976 -1.10718,-0.006 -2.21655,0.002 -3.32422,0.002 z"
-         id="path918-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate"
-         d="m 337.97623,189.00048 c 2.32027,0 3.60941,0.15494 4.20703,0.62109 0.29882,0.23308 0.48964,0.54668 0.625,1.09571 0.13541,0.54902 0.19141,1.31765 0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 -0.056,1.783 -0.19141,2.33203 -0.13536,0.54903 -0.32618,0.86263 -0.625,1.09571 -0.59762,0.46615 -1.88676,0.62109 -4.20703,0.62109 h -11.9524 c -2.32085,0 -3.61652,-0.15457 -4.2168,-0.62109 -0.30014,-0.23327 -0.49095,-0.54754 -0.625,-1.09571 -0.13404,-0.54816 -0.18764,-1.31623 -0.18164,-2.33008 v -7.95279 -5.95312 c -0.006,-1.01386 0.0476,-1.78191 0.18164,-2.33008 0.13406,-0.54817 0.32486,-0.86244 0.625,-1.09571 0.60028,-0.46652 1.89595,-0.62109 4.2168,-0.62109 z m -4.95859,1.00977 c -1.5798,-0.002 -4.16014,-3.9e-4 -5.73991,0.0117 -1.50021,0.0511 -3.02236,-0.0712 -4.5,0.28321 -0.55111,0.0919 -0.61303,0.71807 -0.67773,1.16601 -0.1117,4.30832 -0.075,10.62608 -0.0508,14.94108 0.0716,0.99089 -0.13687,2.07606 0.30078,3.01366 0.34356,0.40964 0.9694,0.35958 1.45117,0.45509 3.95407,0.0823 9.92936,0.0499 13.89381,0.0371 1.16908,-0.0622 2.37292,0.11291 3.51758,-0.22266 0.57935,-0.098 0.6137,-0.75914 0.6875,-1.2207 0.1146,-4.11835 0.0751,-10.24472 0.0547,-14.36881 -0.0572,-1.06305 0.0797,-2.16734 -0.18164,-3.21485 -0.10495,-0.6386 -0.8614,-0.66043 -1.36719,-0.74023 -2.1305,-0.19658 -5.24071,-0.10662 -7.38828,-0.14062 z"
-         id="path914-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 342.87299,134 c 3.21072,0 5.03255,0.19514 5.9375,0.89844 0.45247,0.35165 0.74178,0.83286 0.93359,1.61718 0.19176,0.78433 0.26386,1.85686 0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c 0.008,1.40682 -0.0641,2.47935 -0.25586,3.26368 -0.1918,0.78431 -0.48112,1.26553 -0.93359,1.61718 -0.90496,0.7033 -2.72678,0.89844 -5.9375,0.89844 h -13.7461 c -3.20992,0 -5.02461,-0.19551 -5.92578,-0.89844 -0.45058,-0.35146 -0.73805,-0.83201 -0.93164,-1.61718 -0.19363,-0.7853 -0.26953,-1.86033 -0.26953,-3.26768 V 148 139.7832 c 0,-1.40735 0.0759,-2.48237 0.26953,-3.26758 0.19359,-0.78517 0.48106,-1.26572 0.93164,-1.61718 C 324.10228,134.19551 325.91697,134 329.12689,134 Z m -6.49805,1.04688 c -3.45647,0.0171 -6.9142,-0.0268 -10.36133,0.0918 -0.8211,0.13276 -1.80664,0.14835 -2.39062,0.82617 -0.67884,1.16473 -0.51296,2.58781 -0.56446,3.87305 -0.0431,6.02893 -0.0678,12.06719 0.0332,18.08789 0.0775,0.77792 0.12055,1.67263 0.67968,2.27539 0.70249,0.51038 1.61833,0.59683 2.45899,0.67383 4.04742,0.0864 8.16222,0.0456 12.24023,0.0606 2.45188,-0.0199 4.91402,0.0317 7.35352,-0.0606 0.87784,-0.12055 1.915,-0.14021 2.56055,-0.83398 0.64775,-1.02591 0.50264,-2.30525 0.56054,-3.46485 0.035,-5.65575 0.0351,-11.35518 0,-17.00976 -0.0632,-1.22153 0.10864,-2.57724 -0.59179,-3.65235 -0.6025,-0.62665 -1.55621,-0.63986 -2.35938,-0.77344 -2.73743,-0.10739 -5.48083,-0.0704 -8.22656,-0.0918 -0.46403,-2.9e-4 -0.92855,-0.002 -1.39258,-0.002 z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 354.66301,62 c 4.99049,0 7.87051,0.276282 9.38477,1.453125 0.75713,0.588421 1.23761,1.403518 1.54492,2.660156 0.3073,1.256638 0.4173,2.940031 0.4043,5.132813 V 84 96.753906 c 0.0131,2.19278 -0.097,3.876174 -0.4043,5.132814 -0.30731,1.25663 -0.78779,2.07172 -1.54492,2.66016 C 362.53351,105.72371 359.6535,106 354.66301,106 h -21.33008 c -4.98923,0 -7.85502,-0.27668 -9.36328,-1.45312 -0.75412,-0.58824 -1.23293,-1.40461 -1.54297,-2.66211 -0.31003,-1.2575 -0.42773,-2.939489 -0.42773,-5.132817 V 84 71.248047 c 0,-2.193329 0.1177,-3.875313 0.42773,-5.132813 0.31004,-1.257499 0.78884,-2.073874 1.54297,-2.662109 C 325.47791,62.276656 328.34369,62 333.33293,62 Z m -2.40234,1.097656 c -6.94737,8.3e-4 -13.91063,0.0034 -20.84961,0.05469 -2.14296,0.08293 -4.46431,-0.147701 -6.42383,0.93164 -1.29609,0.695228 -1.54862,2.250325 -1.76953,3.564454 -0.17551,2.202888 -0.0915,4.442228 -0.13867,6.669921 -0.0227,8.479532 -0.077,16.968993 0.0801,25.447266 0.16151,1.483233 0.38135,3.305793 1.79882,4.142573 1.6055,0.82871 3.47551,0.90643 5.24805,0.95313 9.49974,0.0678 19.0243,0.0843 28.52344,-0.0176 1.57816,-0.11413 3.27053,-0.24014 4.63281,-1.12109 1.22952,-0.99538 1.36082,-2.72739 1.50391,-4.193361 0.1272,-8.998585 0.0836,-18.004484 0.0527,-27.007813 -0.0997,-2.381275 0.24538,-4.900002 -0.70508,-7.160156 -0.67165,-1.50972 -2.46573,-1.859954 -3.93945,-2.05664 -2.66168,-0.316582 -5.34184,-0.147022 -8.01367,-0.207032 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
+         id="path416"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:0.346133"
+         d="m 324.55958,237.38522 -1.19929,0.007 10e-4,0.33599 -0.64697,0.003 c -0.62304,0.004 -1.12638,0.51101 -1.12223,1.13439 l 0.0128,2.25595 c 0.004,0.62304 0.51136,1.12705 1.1344,1.1229 l 2.49459,-0.0142 c 0.62304,-0.004 1.1257,-0.51271 1.12155,-1.13574 l -0.0135,-2.25595 c -0.003,-0.622 -0.51136,-1.12498 -1.1344,-1.1229 l -0.64765,0.004 z m 0.47255,1.32234 c 0.32295,-0.001 0.58744,0.25876 0.58951,0.58274 0.002,0.32398 -0.25877,0.58743 -0.58275,0.58951 -0.32398,0.002 -0.58742,-0.25877 -0.5895,-0.58275 -10e-4,-0.32259 0.25876,-0.58743 0.58274,-0.5895 z m -1.99837,0.0135 c 0.32294,-0.003 0.58712,0.2588 0.58815,0.58139 0.003,0.32294 -0.25912,0.58712 -0.58207,0.58816 -0.32259,0.003 -0.58643,-0.25913 -0.58747,-0.58207 -0.003,-0.3226 0.2588,-0.58644 0.58139,-0.58748 z" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/workspace-switcher-right-bottom.svg
+++ b/icons/src/fullcolor/default/apps/workspace-switcher-right-bottom.svg
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="workspace-switcher-right-bottom.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.70710678"
-     inkscape:cx="345.10912"
-     inkscape:cy="225.12309"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="265.87215"
+     inkscape:cy="154.14928"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1301"
-     inkscape:window-height="744"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,152 +93,54 @@
   <defs
      id="defs3">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient927">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(0,-33.6872,33.6872,0,662.45776,172.4502)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         stop-color="#006783"
          offset="0"
-         id="stop923" />
+         id="stop2" />
       <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         stop-color="#20ccff"
          offset="1"
-         id="stop925" />
+         id="stop4" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1686"
-       x1="319.99991"
-       y1="92.000153"
-       x2="367.99991"
-       y2="76.000153"
+       xlink:href="#a"
+       id="linearGradient387"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000121)" />
+       gradientTransform="matrix(0,-35.758057,35.758057,0,1131.785,101.46144)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1688"
-       x1="320.00003"
-       y1="152.00002"
-       x2="352.00003"
-       y2="144.00002"
+       xlink:href="#a"
+       id="linearGradient395"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00002,148)" />
+       gradientTransform="matrix(0,-23.320473,23.320473,0,849.77284,159.3879)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1690"
-       x1="319.9993"
-       y1="203.99928"
-       x2="343.9993"
-       y2="195.99928"
+       xlink:href="#a"
+       id="linearGradient403"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
+       gradientTransform="matrix(0,-17.879029,17.879029,0,725.89251,208.73073)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1692"
-       x1="320.00031"
-       y1="246.00034"
-       x2="336.00031"
-       y2="242.00034"
+       xlink:href="#a"
+       id="linearGradient411"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
+       gradientTransform="matrix(0,-11.660236,11.660236,0,584.88642,249.69395)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1692-6"
-       x1="321.00031"
-       y1="244.00034"
-       x2="335.00031"
-       y2="244.00034"
+       xlink:href="#a"
+       id="linearGradient458"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1690-9"
-       x1="320.9993"
-       y1="199.99928"
-       x2="342.9993"
-       y2="199.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1688-4"
-       x1="322"
-       y1="148.00002"
-       x2="350"
-       y2="148.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00001,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1686-0"
-       x1="321.99991"
-       y1="84.000153"
-       x2="365.99991"
-       y2="84.000153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.000125)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58449"
-       x="-0.047999425"
-       width="1.0959988"
-       y="-0.048000575"
-       height="1.0960012">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.4800539"
-         id="feGaussianBlur58451" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58492"
-       x="-0.011999856"
-       width="1.0239997"
-       y="-0.012000144"
-       height="1.0240003">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1200135"
-         id="feGaussianBlur58494" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient3155"
-       x1="109.29108"
-       y1="42.311958"
-       x2="187.63246"
-       y2="265.99969"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient906"
-       inkscape:collect="always">
-      <stop
-         style="stop-color:#e95420;stop-opacity:1"
-         offset="0"
-         id="stop902" />
-      <stop
-         style="stop-color:#f34f17;stop-opacity:1"
-         offset="1"
-         id="stop904" />
-    </linearGradient>
+       gradientTransform="matrix(0,-174.1262,174.1262,0,3988.1706,241.02965)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -249,13 +152,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -337,7 +240,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">workspace-switcher-right-bottom</tspan></text>
+           id="tspan924">workspace-switcher-right-bottom</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -372,237 +275,69 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 231.80801,268 H 72.19199 C 54.421268,268 40.000001,253.57874 40.000001,235.80801 V 76.191989 c 0,-17.770722 14.421267,-32.191988 32.191989,-32.191988 H 231.80801 C 249.57874,44.000001 264,58.421267 264,76.191989 V 235.80801 C 264,253.57874 249.57874,268 231.80801,268 Z"
+         fill="url(#a)"
+         id="path7"
+         style="fill:url(#linearGradient458);stroke-width:5.16891" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 360.38915,107 H 327.61086 C 323.96151,107 321,104.03849 321,100.38914 V 67.610855 C 321,63.96151 323.96151,61 327.61086,61 h 32.77829 C 364.03849,61 367,63.96151 367,67.610855 V 100.38914 C 367,104.03849 364.03849,107 360.38915,107 Z"
+         fill="url(#a)"
+         id="path381"
+         style="fill:url(#linearGradient387);stroke-width:1.06147" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.12858,237.00001 c -3.74357,0 -4.14638,0.30899 -4.12803,3.32331 v 4.17669 4.17668 c -0.0183,3.01433 0.38446,3.32332 4.12803,3.32332 h 7.74335 c 3.7436,0 4.12805,-0.30895 4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 -0.38446,-3.32331 -4.12805,-3.32331 z"
-         id="path918-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 346.68857,163 H 325.31142 C 322.93142,163 321,161.06858 321,158.68857 V 137.31143 C 321,134.93142 322.93142,133 325.31142,133 h 21.37715 c 2.38001,0 4.31143,1.93142 4.31143,4.31143 v 21.37714 C 351,161.06858 349.06858,163 346.68857,163 Z"
+         fill="url(#a)"
+         id="path389"
+         style="fill:url(#linearGradient395);stroke-width:0.692265" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 326.45275,189.00048 c -1.2321,0 -2.21668,0.0221 -3.06999,0.14144 -0.85332,0.11937 -1.62809,0.35533 -2.21066,0.83967 -0.58256,0.48436 -0.86983,1.13381 -1.01188,1.84587 -0.14202,0.71207 -0.16501,1.53239 -0.15897,2.56202 v 7.61066 4.6143 c -0.006,1.02762 0.0171,1.84735 0.15897,2.55843 0.14203,0.71208 0.42931,1.36152 1.01188,1.84587 0.58258,0.48434 1.35734,0.7203 2.21066,0.83967 0.85331,0.11936 1.83789,0.14144 3.06999,0.14144 h 11.09542 c 1.2321,0 2.21381,-0.022 3.0657,-0.14144 0.85187,-0.11947 1.62795,-0.35683 2.2085,-0.84146 0.58057,-0.48464 0.86451,-1.13152 1.00758,-1.84228 0.14307,-0.71077 0.16972,-1.5314 0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 -0.0266,-1.84946 -0.16972,-2.56023 -0.14307,-0.71076 -0.42701,-1.35765 -1.00758,-1.84228 -0.58055,-0.48464 -1.35661,-0.722 -2.2085,-0.84147 -0.8519,-0.11947 -1.83359,-0.14144 -3.0657,-0.14144 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         d="m 340.19457,211.5 h -16.38915 c -1.82467,0 -3.30542,-1.48075 -3.30542,-3.30542 v -16.38915 c 0,-1.82467 1.48075,-3.30543 3.30542,-3.30543 h 16.38915 c 1.82467,0 3.30543,1.48076 3.30543,3.30543 v 16.38915 c 0,1.82467 -1.48076,3.30542 -3.30543,3.30542 z"
+         fill="url(#a)"
+         id="path397"
+         style="fill:url(#linearGradient403);stroke-width:0.530737" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 329.30094,134 c -1.63949,0 -2.94082,0.0308 -4.04505,0.19141 -1.10422,0.16064 -2.06697,0.4726 -2.78308,1.09179 -0.71611,0.61919 -1.0805,1.45612 -1.26421,2.41407 -0.18374,0.95795 -0.21537,2.08705 -0.20733,3.51171 V 149 v 7.79688 c -0.009,1.42131 0.0239,2.5495 0.20733,3.50585 0.18371,0.95796 0.5481,1.79488 1.26421,2.41407 0.71611,0.61919 1.67886,0.93115 2.78308,1.09179 1.10423,0.16065 2.40556,0.19141 4.04505,0.19141 h 13.40164 c 1.63949,0 2.93835,-0.0307 4.04054,-0.19141 1.10219,-0.16075 2.06274,-0.47425 2.77633,-1.09375 0.71357,-0.6195 1.07457,-1.45363 1.25969,-2.41015 C 350.96429,159.34816 351,158.22066 351,156.79688 V 149 141.20312 c 0,-1.42378 -0.0358,-2.55128 -0.22086,-3.50781 -0.18512,-0.95653 -0.54612,-1.79065 -1.25969,-2.41015 -0.71359,-0.61951 -1.67414,-0.933 -2.77633,-1.09375 C 345.64093,134.03065 344.34207,134 342.70258,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 333.65776,62 c -2.6221,0 -4.68675,0.05009 -6.38561,0.286735 -1.69887,0.236639 -3.08904,0.680503 -4.10735,1.523515 -1.0183,0.843013 -1.55577,1.996072 -1.83828,3.406406 -0.28252,1.410336 -0.33767,3.127346 -0.32482,5.308412 v 12.474816 12.480783 c -0.0127,2.177715 0.0426,3.893853 0.32482,5.302673 0.28251,1.41034 0.81998,2.5634 1.83828,3.40641 1.01831,0.84301 2.40848,1.28688 4.10735,1.52351 1.69888,0.23665 3.76351,0.28674 6.38561,0.28674 h 20.68618 c 2.62213,0 4.68568,-0.05 6.38104,-0.28674 1.69534,-0.23674 3.08126,-0.6821 4.09581,-1.52542 1.01457,-0.84331 1.54885,-1.99555 1.83367,-3.4045 C 366.93929,101.37441 367,99.660878 367,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0608,-3.893733 -0.34554,-5.302677 -0.28482,-1.408942 -0.81911,-2.561177 -1.83368,-3.404494 -1.01455,-0.843317 -2.40047,-1.288685 -4.09582,-1.525427 C 359.02962,62.049992 356.96605,62 354.34394,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500049 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 v 12.75157 12.75181 c -0.0527,8.842031 1.82291,9.748381 11.83407,9.748381 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.748381 v -12.75181 -12.75157 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3155);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 225.07297,43.999694 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.006466 73.00648 c 0.17299,35.36812 -3.62489,38.99353 -38.92162,38.99353 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 155.99969 82.993224 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 326.17688,188.49945 c -5.14666,0 -5.70043,0.43262 -5.67521,4.65309 v 5.84793 7.84761 c -0.0253,4.22046 0.52855,4.65307 5.67521,4.65307 h 11.64568 c 5.14665,0 5.67521,-0.43255 5.67521,-4.65307 v -7.84761 -5.84793 c 0,-4.22051 -0.52857,-4.65309 -5.67522,-4.65309 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.4056,236.50001 c -3.47604,0 -3.85006,0.30899 -3.83302,3.32331 v 4.17669 4.17668 c -0.017,3.01433 0.35698,3.32332 3.83302,3.32332 h 7.18996 c 3.47605,0 3.83303,-0.30895 3.83303,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.35699,-3.32331 -3.83303,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 333.34428,251.5 h -10.68857 c -1.19,0 -2.15571,-0.96571 -2.15571,-2.15572 v -10.68857 c 0,-1.19 0.96571,-2.15571 2.15571,-2.15571 h 10.68857 c 1.19001,0 2.15572,0.96571 2.15572,2.15571 v 10.68857 c 0,1.19001 -0.96571,2.15572 -2.15572,2.15572 z"
+         fill="url(#a)"
+         id="path405"
+         style="fill:url(#linearGradient411);stroke-width:0.346133" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms and folds"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         sodipodi:nodetypes="sssssssss"
-         inkscape:connector-curvature="0"
-         id="path983"
-         d="m 351.93111,62.499886 c 13.62163,0 15.56836,1.94187 15.56836,15.55078 v 11.89844 c 0,13.608864 -1.94673,15.550784 -15.56836,15.550784 h -15.86327 c -13.62162,0 -15.56836,-1.94192 -15.56836,-15.550784 v -11.89844 c 0,-13.60891 1.94674,-15.55078 15.56836,-15.55078 z"
-         style="display:inline;opacity:1;fill:url(#linearGradient986);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+         id="path373"
+         d="m 218.83344,175.43227 -17.91957,0.091 0.0305,5.01752 -9.66142,0.0517 c -9.30404,0.062 -16.83071,7.63629 -16.76868,16.94033 l 0.2019,33.68875 c 0.062,9.30405 7.63627,16.82554 16.9403,16.76873 l 37.25251,-0.21192 c 9.30404,-0.062 16.81052,-7.65646 16.74849,-16.9605 l -0.20189,-33.6888 c -0.0465,-9.28854 -7.63627,-16.79452 -16.9403,-16.76868 l -9.67153,0.0708 z m 7.05677,19.73672 c 4.81742,-0.0155 8.77229,3.87436 8.80331,8.71246 0.031,4.8381 -3.86426,8.77232 -8.70235,8.80333 -4.84326,0.031 -8.77722,-3.87436 -8.8134,-8.71246 -0.0155,-4.8226 3.87435,-8.77232 8.71244,-8.80333 z m -29.84239,0.19176 c 4.81742,-0.0465 8.7676,3.87488 8.78311,8.69231 0.0465,4.82249 -3.87483,8.76756 -8.69225,8.78306 -4.82258,0.0517 -8.76761,-3.85952 -8.78311,-8.68211 -0.0517,-4.81743 3.86967,-8.77775 8.69225,-8.79326 z"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:5.16891" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 355.83925,83.974089 c -1.14882,0 -0.94111,0.0028 -2.2455,0.02591 -1.44422,0 1.18767,-0.02173 0,0 H 351.3125 344 v 9.701172 c 0,-2.388672 0,-1.17755 0,0 -7.5e-4,2.111408 -7.5e-4,0.962598 -7.5e-4,2.111408 0,1.14881 0,0 -0.005,1.851021 C 344,98.298988 344,100.6875 344,98.298828 V 106.5 h 10.66602 C 364.67468,106.5 366.5,105.59408 366.5,96.751953 V 84 h -0.10742 -5.70508 -2.49609 c 1.72157,0 1.15088,0 0,0 -0.9566,-0.01734 -1.20335,-0.02591 -2.35216,-0.02591 z"
-         id="path21860"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccscccsscccccs" />
+         id="path383"
+         d="m 357.72473,87.990555 -3.67992,0.01868 0.006,1.030382 -1.98404,0.01062 c -1.91066,0.01274 -3.45631,1.568167 -3.44357,3.478819 l 0.0415,6.918225 c 0.0127,1.910649 1.56816,3.455239 3.47881,3.443579 l 7.65007,-0.0435 c 1.91065,-0.0127 3.45216,-1.57231 3.43942,-3.48296 l -0.0415,-6.918236 c -0.01,-1.907467 -1.56816,-3.448875 -3.47881,-3.443567 l -1.98612,0.01454 z m 1.44916,4.053075 c 0.98929,-0.0032 1.80145,0.795628 1.80782,1.789166 0.006,0.993539 -0.79356,1.801458 -1.78709,1.807827 -0.9946,0.0064 -1.80247,-0.795627 -1.8099,-1.789166 -0.003,-0.990354 0.79563,-1.801458 1.78917,-1.807827 z m -6.12835,0.03938 c 0.98929,-0.0096 1.80049,0.795733 1.80367,1.785026 0.01,0.990334 -0.79572,1.800482 -1.78501,1.803666 -0.99036,0.01062 -1.80049,-0.792581 -1.80368,-1.782935 -0.0106,-0.989293 0.79467,-1.802572 1.78502,-1.805757 z"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:1.06147" />
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 344.00075,71.974087 c 0,1.14882 -2e-5,0.702038 -7.5e-4,2.432163 0,1.550883 0,2.28125 0,0 V 76.6875 84 h 9.59375 c -2.28125,-10e-7 -1.11481,0.01995 0,-10e-7 1.27776,-0.02287 1.09669,-0.02591 2.2455,-0.02591 1.14881,0 0.62235,0.0011 2.35216,0.02591 0.67088,0 1.32157,0 0,0 h 8.20117 V 73.33398 C 366.39258,63.32532 365.48666,61.5 356.64453,61.5 H 344 v 0.10742 5.70508 2.49609 c 0,-1.721567 0,-1.310883 0,0 7.5e-4,2.165497 7.5e-4,1.016687 7.5e-4,2.165497 z"
-         id="path21860-7"
-         sodipodi:nodetypes="scccccsscccsscccccs" />
+         id="path391"
+         d="m 344.9509,150.60254 -2.39994,0.0122 0.004,0.67199 -1.29394,0.007 c -1.24608,0.008 -2.25412,1.02272 -2.24581,2.2688 l 0.027,4.51188 c 0.008,1.24608 1.02271,2.25342 2.26879,2.24581 l 4.98918,-0.0284 c 1.24607,-0.008 2.2514,-1.02542 2.2431,-2.27149 l -0.027,-4.5119 c -0.006,-1.244 -1.02272,-2.24926 -2.26879,-2.2458 l -1.2953,0.009 z m 0.94511,2.64331 c 0.64519,-0.002 1.17486,0.51888 1.17901,1.16684 0.004,0.64796 -0.51753,1.17487 -1.16549,1.17902 -0.64865,0.004 -1.17552,-0.51889 -1.18037,-1.16685 -0.002,-0.64588 0.51889,-1.17486 1.16685,-1.17901 z m -3.99675,0.0257 c 0.64519,-0.006 1.17423,0.51896 1.17631,1.16415 0.006,0.64587 -0.51895,1.17422 -1.16414,1.1763 -0.64588,0.007 -1.17424,-0.5169 -1.17631,-1.16278 -0.007,-0.64519 0.51826,-1.17559 1.16414,-1.17767 z"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:0.692265" />
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 343.99925,95.81258 c 0,-1.14882 0.0588,-0.807945 7.5e-4,-2.111408 0,-1.364217 0,-2.388672 0,-0.107422 V 91.3125 84 h -9.70117 c 0.8149,1.67376 1.11492,-0.01188 0,0 -2.43216,0.02591 -1.28335,0.02591 -2.43216,0.02591 -1.14881,0 -0.80865,-0.0016 -2.1655,-0.02591 -1.68422,0 -0.8149,1.67376 0,0 H 321.5 v 10.66602 c 0,10.00866 0.90592,11.83398 9.74805,11.83398 H 344 v -0.10742 -5.70508 -2.49609 c 0,2.49609 0,1.684217 0,0 -0.022,-1.916797 -7.5e-4,-1.23002 -7.5e-4,-2.37883 z"
-         id="path21860-7-4"
-         sodipodi:nodetypes="scccccsscccsscccccs" />
+         id="path399"
+         d="m 338.86236,201.99528 -1.83996,0.009 0.003,0.51519 -0.99202,0.005 c -0.95532,0.006 -1.72815,0.78409 -1.72178,1.73941 l 0.0207,3.45911 c 0.006,0.95533 0.78408,1.72763 1.7394,1.72179 l 3.82504,-0.0218 c 0.95532,-0.006 1.72608,-0.78615 1.71971,-1.74148 l -0.0207,-3.45911 c -0.005,-0.95374 -0.78408,-1.72444 -1.73941,-1.72179 l -0.99305,0.007 z m 0.72458,2.02654 c 0.49464,-0.002 0.90072,0.39781 0.90391,0.89458 0.003,0.49677 -0.39678,0.90073 -0.89355,0.90392 -0.4973,0.003 -0.90123,-0.39782 -0.90495,-0.89459 -0.002,-0.49517 0.39782,-0.90073 0.89459,-0.90391 z m -3.06418,0.0197 c 0.49465,-0.005 0.90025,0.39787 0.90184,0.89251 0.005,0.49517 -0.39786,0.90024 -0.89251,0.90184 -0.49517,0.005 -0.90024,-0.39629 -0.90184,-0.89147 -0.005,-0.49465 0.39734,-0.90129 0.89251,-0.90288 z"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:0.530737" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 336,133.5 v 0.0684 3.67773 2.15625 c -0.39707,-0.2396 0,0 0,0 v 0 c -0.0689,1.56883 8.4e-4,0.46566 -0.0689,1.56883 -0.0706,1.10318 0.0689,3.04078 0.0689,1.75171 l 0,-0.12331 V 148 h 14.43164 v -6.87305 c 0,-6.45002 -0.58494,-7.62695 -6.2832,-7.62695 z"
-         id="path21860-7-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccssc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 321.5,148 v 6.87305 c 0,6.45002 0.58299,7.62695 6.28125,7.62695 H 336 v -0.0684 -5.83203 0 c 0.0324,-1.62844 0.10302,-0.52526 0.0324,-1.62844 -0.0697,-1.10317 0,0 -0.0324,-1.56879 v 0 c 0,0 0.39705,-0.23961 0,0 V 148 h -5.40039 c 0.28091,0.4674 1.078,0 0,0 v 0 c -1.11072,0.0261 -0.48948,0.0667 -1.59208,-0.004 -1.10317,-0.0697 0,0 -1.60519,0.004 0,0 -0.78535,0 0,0 z"
-         id="path21860-7-4-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csscccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 347.32997,148 c -4.32244,0 -4.2756,-0.003 -4.32244,0 -1.10317,0.0697 0,0 -1.60519,0 0,0 1.60519,0 0,0 H 336 v 5.40234 0 l 0.0324,1.56879 c 0,0 -0.0697,-1.10317 0,0 0.0706,1.10318 -0.0324,-1.56879 0,0 C 336,153.40234 336,156.59957 336,156.59961 V 162.5 h 6.87305 c 6.45002,0 7.62695,-0.58299 7.62695,-6.28125 V 148 h -0.0684 -5.83203 c 0,0 -1.59204,0 0,0 v 0 c 1.25436,0 -0.54297,0.0251 -1.59204,0 z"
-         id="path21860-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccssccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 332,188.5 v 0.0547 2.91601 1.71094 c 0,-0.461 -0.0485,0.74669 0,0 v 0 c 0,-1.06355 0.0724,0.28481 0.0171,1.15974 -0.056,0.87494 0,0 -0.0172,1.37542 0,0.58634 0,0.6357 0,0 V 200 h 11.44531 l 0.0527,-0.19727 V 199 193.15234 c 0,-4.22051 -0.52913,-4.65234 -5.67578,-4.65234 z m 0,11.5 h -4.2832 c 0.22279,0.3707 0.87021,0 0,0 v 0 c -1.28509,-0.004 -0.41061,0.0517 -1.28509,-0.004 -0.87493,-0.0553 0,0 -1.25007,0.004 0.64941,-0.0127 -0.59026,0 0,0 h -4.67969 v 6.84766 c -0.0253,4.22046 0.52912,4.65429 5.67578,4.65429 h 5.81446 L 332,211.5 v -0.0547 -4.625 c 5e-5,0.60989 0,0 0,0 -0.0301,-1.27219 0.0259,-0.39726 -0.0301,-1.27219 0.009,-0.86203 0.003,-0.26196 0.0301,-1.26291 v 0 c -4e-5,-0.7959 -0.17546,0.70023 -5e-5,-5e-5 z"
-         id="path21860-7-7-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccssccccccccccscccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 337.57136,200 c -0.0372,-9.6e-4 2.6684,0 0,0 -0.87493,0.0553 0,0 -1.28622,0 -0.7704,4e-5 1.28622,0 2e-5,4e-5 H 332 v 4.28516 c 0,-0.57713 -0.0286,1.12293 0,0 v 0 c -0.0301,1.26291 -0.0854,0.38798 -0.0301,1.26291 0.056,0.87494 0.0301,2.18232 0.0301,1.27219 0,0 0,0.58415 5e-5,5e-5 V 211.5 l 0.008,0.002 h 5.81446 c 5.14665,0 5.67578,-0.43377 5.67578,-4.65429 V 200 h -0.0527 -4.625 c 0.85505,0 0,0 0,0 v 0 c -1.24923,0 -0.41721,0.0199 -1.24923,0 z"
-         id="path21860-4-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccssccccccc" />
-      <path
-         style="display:inline;opacity:1;vector-effect:none;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="M 207.25339,156.15486 C 191.86667,156.13333 166.93333,156.00003 200,156 l -48,5e-5 V 204 c 0,0 -0.15987,-7.67972 -0.15987,8.32028 0,16 0.15987,7.67972 0.15987,7.67972 v 48 h 73.07227 c 35.29673,0 39.09486,-3.62602 38.92187,-38.99414 V 156 H 216 c 30,0 7.86667,0.13333 -8.74661,0.15486 z"
-         id="rect1772-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccscccc" />
-      <path
-         style="display:inline;opacity:0.1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 152.01079,101.41305 c -0.0215,15.38672 -0.0215,32.98672 -0.0215,6.58672 l 5e-5,48 h 47.99995 c -29.86667,2.6e-4 -8.73586,0.15509 7.26413,0.15509 16,0 35.66919,-0.15486 8.73586,-0.15509 h 48 V 82.927499 c 0,-35.29673 -3.62602,-39.09486 -38.99414,-38.92187 h -73.00585 v 47.99414 c 0,-29.066667 0,-7.2 0.0215,9.413281 z"
-         id="rect1772-7-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccscccc" />
-      <path
-         style="display:inline;opacity:0.1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 151.84013,212.32028 c 0.0215,-15.38672 0.0215,-0.85338 0.15486,-8.32005 l -5e-5,-48 h -47.99995 c 30.4,0 7.86667,-0.13333 -8.133323,-0.13333 -16,0 -36.666667,0.13333 -7.866667,0.13333 h -48 v 73.07227 c 0,35.29673 3.62602,39.09486 38.99414,38.92187 h 73.00585 v -47.99414 c 0,-9.46667 -0.13333,8.93333 -0.15486,-7.67995 z"
-         id="rect1772-7-5-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccscccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 331.43967,242.98406 c 0,0 0.0259,-0.001 0,0 -0.60876,0.0385 0,0 -1.05779,0.0134 -0.51703,0 0,0 0,0 h -3.38131 v 3.48161 c 0,-0.62259 0,-0.38165 0,0 v 0 c -0.0141,0.9152 -0.0526,0.30643 -0.0141,0.9152 0.0389,0.60877 0.0138,0.84871 0,0 -8.3e-4,-0.4504 0,0 0.0138,0.84871 v 3.256 l 0.005,0.001 h 4.44536 c 3.58093,0 3.94909,-0.30181 3.94909,-3.23836 v -5.26457 h -0.0367 -3.21797 c 0,0 0.43874,0 0,0 v 0 c 0.95055,0 -0.12648,8.5e-4 -0.70538,-0.013 z"
-         id="path21860-4-1-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccsscccccc" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer4"
-       inkscape:label="Borders"
-       style="display:inline;opacity:1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92188,43.999698 c -35.296728,0 -39.09487,3.62603 -38.92188,38.99414 v 2 c -0.17299,-35.36811 3.625152,-38.99414 38.92188,-38.99414 h 146.15624 c 35.29673,0 38.92188,3.62561 38.92188,38.99414 v -2 c 0,-35.36853 -3.62515,-38.99414 -38.92188,-38.99414 z"
-         id="path931"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92728,267.9997 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 c -0.17299,35.36811 3.625154,38.99414 38.921885,38.99414 h 146.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 c 0,35.36853 -3.62515,38.99414 -38.92188,38.99414 z"
-         id="path931-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500047 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 V 84 96.75181 c -0.0527,8.84203 1.82291,9.74838 11.83407,9.74838 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 337.97659,211.50015 c 4.67187,0 5.5471,-0.42296 5.52255,-4.54923 v -7.95037 -5.95084 c 0.0245,-4.12627 -0.85068,-4.54923 -5.52255,-4.54923 h -11.95364 c -4.67071,0 -5.52256,0.42291 -5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 0.85185,4.54923 5.52256,4.54923 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.55494,251.5 c 3.33705,0 3.96221,-0.30212 3.94468,-3.24946 v -4.2505 -4.25059 c 0.0175,-2.94734 -0.60763,-3.24945 -3.94468,-3.24945 h -7.11025 c -3.33622,0 -3.94469,0.30208 -3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 0.60847,3.24946 3.94469,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline;opacity:0.3">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.44531,237 c -1.65302,0 -2.54604,0.12548 -2.91601,0.41406 -0.18499,0.14429 -0.30479,0.33122 -0.39649,0.70313 C 321.0411,238.4891 321,239.03036 321,239.75 v 4.25 4.25 c 0,0.71964 0.0411,1.26082 0.13281,1.63281 0.0917,0.37191 0.2115,0.55884 0.39649,0.70313 0.36997,0.28858 1.26299,0.41406 2.91601,0.41406 h 7.10938 c 1.65343,0 2.55203,-0.12511 2.92383,-0.41406 0.18589,-0.14448 0.30578,-0.33208 0.39648,-0.70313 0.0907,-0.37105 0.129,-0.90979 0.125,-1.6289 v -0.002 V 244 v -4.25195 -0.002 c 0.004,-0.71911 -0.0343,-1.25785 -0.125,-1.6289 -0.0907,-0.37105 -0.21059,-0.55865 -0.39648,-0.70313 C 334.10673,237.12512 333.20812,237 331.55469,237 Z m 5.32813,1.04688 c 1.10767,-3.4e-4 2.21363,0.008 3.32031,0.0449 0.26616,0.0599 0.75737,-0.0208 0.79297,0.3457 0.13405,1.84438 0.0662,3.68774 0.10156,5.53906 -0.0126,1.86745 0.0543,3.67031 -0.10351,5.49805 0.0642,0.42314 -0.43946,0.35577 -0.70313,0.42187 -3.43277,0.0703 -6.87577,0.0589 -10.29883,0.002 -0.22288,-0.0398 -0.55622,-3.2e-4 -0.71093,-0.1875 -0.19863,-1.12995 -0.12696,-2.26946 -0.16016,-3.41992 0.0138,-2.55648 -0.029,-5.10728 0.0898,-7.65625 -0.03,-0.2727 0.10944,-0.49629 0.40039,-0.48829 1.30659,-0.161 2.63265,-0.0636 3.94727,-0.0976 1.10718,0.006 2.21655,-0.002 3.32422,-0.002 z"
-         id="path918-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate"
-         d="m 326.02383,189.00048 c -2.32027,0 -3.60941,0.15494 -4.20703,0.62109 -0.29882,0.23308 -0.48964,0.54668 -0.625,1.09571 -0.13541,0.54902 -0.19141,1.31765 -0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 0.056,1.783 0.19141,2.33203 0.13536,0.54903 0.32618,0.86263 0.625,1.09571 0.59762,0.46615 1.88676,0.62109 4.20703,0.62109 h 11.9524 c 2.32085,0 3.61652,-0.15457 4.2168,-0.62109 0.30014,-0.23327 0.49095,-0.54754 0.625,-1.09571 0.13404,-0.54816 0.18764,-1.31623 0.18164,-2.33008 v -7.95279 -5.95312 c 0.006,-1.01386 -0.0476,-1.78191 -0.18164,-2.33008 -0.13406,-0.54817 -0.32486,-0.86244 -0.625,-1.09571 -0.60028,-0.46652 -1.89595,-0.62109 -4.2168,-0.62109 z m 4.95859,1.00977 c 1.5798,-0.002 4.16014,-3.9e-4 5.73991,0.0117 1.50021,0.0511 3.02236,-0.0712 4.5,0.28321 0.55111,0.0919 0.61303,0.71807 0.67773,1.16601 0.1117,4.30832 0.075,10.62608 0.0508,14.94108 -0.0716,0.99089 0.13687,2.07606 -0.30078,3.01366 -0.34356,0.40964 -0.9694,0.35958 -1.45117,0.45509 -3.95407,0.0823 -9.92936,0.0499 -13.89381,0.0371 -1.16908,-0.0622 -2.37292,0.11291 -3.51758,-0.22266 -0.57935,-0.098 -0.6137,-0.75914 -0.6875,-1.2207 -0.1146,-4.11835 -0.0751,-10.24472 -0.0547,-14.36881 0.0572,-1.06305 -0.0797,-2.16734 0.18164,-3.21485 0.10495,-0.6386 0.8614,-0.66043 1.36719,-0.74023 2.1305,-0.19658 5.24071,-0.10662 7.38828,-0.14062 z"
-         id="path914-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12695,134 c -3.21072,0 -5.03255,0.19514 -5.9375,0.89844 -0.45247,0.35165 -0.74178,0.83286 -0.93359,1.61718 -0.19176,0.78433 -0.26386,1.85686 -0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c -0.008,1.40682 0.0641,2.47935 0.25586,3.26368 0.1918,0.78431 0.48112,1.26553 0.93359,1.61718 0.90496,0.7033 2.72678,0.89844 5.9375,0.89844 h 13.7461 c 3.20992,0 5.02461,-0.19551 5.92578,-0.89844 0.45058,-0.35146 0.73805,-0.83201 0.93164,-1.61718 C 349.9241,158.69918 350,157.62415 350,156.2168 V 148 139.7832 c 0,-1.40735 -0.0759,-2.48237 -0.26953,-3.26758 -0.19359,-0.78517 -0.48106,-1.26572 -0.93164,-1.61718 C 347.89766,134.19551 346.08297,134 342.87305,134 Z m 6.49805,1.04688 c 3.45647,0.0171 6.9142,-0.0268 10.36133,0.0918 0.8211,0.13276 1.80664,0.14835 2.39062,0.82617 0.67884,1.16473 0.51296,2.58781 0.56446,3.87305 0.0431,6.02893 0.0678,12.06719 -0.0332,18.08789 -0.0775,0.77792 -0.12055,1.67263 -0.67968,2.27539 -0.70249,0.51038 -1.61833,0.59683 -2.45899,0.67383 -4.04742,0.0864 -8.16222,0.0456 -12.24023,0.0606 -2.45188,-0.0199 -4.91402,0.0317 -7.35352,-0.0606 -0.87784,-0.12055 -1.915,-0.14021 -2.56055,-0.83398 -0.64775,-1.02591 -0.50264,-2.30525 -0.56054,-3.46485 -0.035,-5.65575 -0.0351,-11.35518 0,-17.00976 0.0632,-1.22153 -0.10864,-2.57724 0.59179,-3.65235 0.6025,-0.62665 1.55621,-0.63986 2.35938,-0.77344 2.73743,-0.10739 5.48083,-0.0704 8.22656,-0.0918 0.46403,-2.9e-4 0.92855,-0.002 1.39258,-0.002 z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33594,62 c -4.99049,0 -7.87051,0.276282 -9.38477,1.453125 -0.75713,0.588421 -1.23761,1.403518 -1.54492,2.660156 -0.3073,1.256638 -0.4173,2.940031 -0.4043,5.132813 V 84 96.753906 c -0.0131,2.19278 0.097,3.876174 0.4043,5.132814 0.30731,1.25663 0.78779,2.07172 1.54492,2.66016 1.51427,1.17683 4.39428,1.45312 9.38477,1.45312 h 21.33008 c 4.98923,0 7.85502,-0.27668 9.36328,-1.45312 0.75412,-0.58824 1.23293,-1.40461 1.54297,-2.66211 C 365.8823,100.62727 366,98.945281 366,96.751953 V 84 71.248047 c 0,-2.193329 -0.1177,-3.875313 -0.42773,-5.132813 -0.31004,-1.257499 -0.78884,-2.073874 -1.54297,-2.662109 C 362.52104,62.276656 359.65526,62 354.66602,62 Z m 2.40234,1.097656 c 6.94737,8.3e-4 13.91063,0.0034 20.84961,0.05469 2.14296,0.08293 4.46431,-0.147701 6.42383,0.93164 1.29609,0.695228 1.54862,2.250325 1.76953,3.564454 0.17551,2.202888 0.0915,4.442228 0.13867,6.669921 0.0227,8.479532 0.077,16.968993 -0.0801,25.447266 -0.16151,1.483233 -0.38135,3.305793 -1.79882,4.142573 -1.6055,0.82871 -3.47551,0.90643 -5.24805,0.95313 -9.49974,0.0678 -19.0243,0.0843 -28.52344,-0.0176 -1.57816,-0.11413 -3.27053,-0.24014 -4.63281,-1.12109 -1.22952,-0.99538 -1.36082,-2.72739 -1.50391,-4.193361 -0.1272,-8.998585 -0.0836,-18.004484 -0.0527,-27.007813 0.0997,-2.381275 -0.24538,-4.900002 0.70508,-7.160156 0.67165,-1.50972 2.46573,-1.859954 3.93945,-2.05664 2.66168,-0.316582 5.34184,-0.147022 8.01367,-0.207032 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
+         id="path407"
+         d="m 332.47545,245.30127 -1.19997,0.006 0.002,0.33599 -0.64697,0.003 c -0.62304,0.004 -1.12705,0.51136 -1.1229,1.1344 l 0.0135,2.25594 c 0.004,0.62304 0.51136,1.12671 1.13439,1.12291 l 2.49459,-0.0142 c 0.62304,-0.004 1.12571,-0.51271 1.12155,-1.13575 l -0.0135,-2.25595 c -0.003,-0.622 -0.51135,-1.12463 -1.13439,-1.1229 l -0.64765,0.005 z m 0.47255,1.32165 c 0.3226,-0.001 0.58743,0.25944 0.58951,0.58342 0.002,0.32398 -0.25877,0.58744 -0.58275,0.58951 -0.32432,0.002 -0.58776,-0.25944 -0.59018,-0.58342 -10e-4,-0.32294 0.25944,-0.58743 0.58342,-0.58951 z m -1.99837,0.0128 c 0.32259,-0.003 0.58712,0.25948 0.58815,0.58208 0.003,0.32293 -0.25947,0.58711 -0.58207,0.58815 -0.32294,0.003 -0.58711,-0.25845 -0.58815,-0.58139 -0.003,-0.3226 0.25913,-0.5878 0.58207,-0.58884 z"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:0.346133" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/default/apps/workspace-switcher-right-top.svg
+++ b/icons/src/fullcolor/default/apps/workspace-switcher-right-top.svg
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:export-ydpi="96"
-   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="workspace-switcher-right-top.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
-     id="title3004">Yaru Icon Theme Template</title>
+     id="title3004">Suru Icon Theme Template</title>
   <sodipodi:namedview
      stroke="#ef2929"
      fill="#f57900"
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="11.313708"
-     inkscape:cx="348.27579"
-     inkscape:cy="227.7618"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="2"
+     inkscape:cx="469.5"
+     inkscape:cy="160.5"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1301"
-     inkscape:window-height="744"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -92,153 +93,54 @@
   <defs
      id="defs3">
     <linearGradient
-       id="linearGradient906"
-       inkscape:collect="always">
+       id="a"
+       x2="1"
+       gradientTransform="matrix(0,-174.1262,174.1262,0,3988.1708,241.02965)"
+       gradientUnits="userSpaceOnUse">
       <stop
-         style="stop-color:#e95420;stop-opacity:1"
+         stop-color="#006783"
          offset="0"
-         id="stop902" />
+         id="stop22" />
       <stop
-         style="stop-color:#f34f17;stop-opacity:1"
+         stop-color="#20ccff"
          offset="1"
-         id="stop904" />
+         id="stop24" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient927">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop923" />
-      <stop
-         id="stop933"
-         offset="0.125"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
-         offset="1"
-         id="stop925" />
-    </linearGradient>
+       xlink:href="#a"
+       id="linearGradient378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-35.758058,35.758058,0,1131.7851,101.46145)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1686"
-       x1="319.99991"
-       y1="92.000153"
-       x2="367.99991"
-       y2="76.000153"
+       xlink:href="#a"
+       id="linearGradient386"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,428.00015,428.0001)" />
+       gradientTransform="matrix(0,-23.320473,23.320473,0,849.77287,159.3879)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1688"
-       x1="320.00003"
-       y1="152.00002"
-       x2="352.00003"
-       y2="144.00002"
+       xlink:href="#a"
+       id="linearGradient394"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,484.00002,484.00002)" />
+       gradientTransform="matrix(0,-17.879029,17.879029,0,725.89253,208.73072)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1690"
-       x1="319.9993"
-       y1="203.99928"
-       x2="343.9993"
-       y2="195.99928"
+       xlink:href="#a"
+       id="linearGradient402"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,531.99928,532.00074)" />
+       gradientTransform="matrix(0,-11.660237,11.660237,0,584.88646,249.69395)"
+       x2="1" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient1692"
-       x1="320.00031"
-       y1="246.00034"
-       x2="336.00031"
-       y2="242.00034"
+       xlink:href="#a"
+       id="linearGradient404"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,328.00032,244.00001)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1692-6"
-       x1="321.00031"
-       y1="244.00034"
-       x2="335.00031"
-       y2="244.00034"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,-1,0,572.00033,572.50029)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1690-9"
-       x1="320.9993"
-       y1="199.99928"
-       x2="342.9993"
-       y2="199.99928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,331.99929,199.99999)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1688-4"
-       x1="322"
-       y1="148.00002"
-       x2="350"
-       y2="148.00002"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,336.00001,148)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient1686-0"
-       x1="321.99991"
-       y1="84.000153"
-       x2="365.99991"
-       y2="84.000153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="rotate(90,344.00003,84.00013)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58449"
-       x="-0.047999425"
-       width="1.0959988"
-       y="-0.048000575"
-       height="1.0960012">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.4800539"
-         id="feGaussianBlur58451" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter58492"
-       x="-0.011999856"
-       width="1.0239997"
-       y="-0.012000144"
-       height="1.0240003">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.1200135"
-         id="feGaussianBlur58494" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient906"
-       id="linearGradient3155"
-       x1="109.29108"
-       y1="42.311958"
-       x2="187.63246"
-       y2="265.99969"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,-1,6.2569805e-6,311.9997)" />
+       gradientTransform="matrix(0,-174.1262,174.1262,0,3988.1708,241.02965)"
+       x2="1" />
   </defs>
   <metadata
      id="metadata4">
@@ -250,13 +152,13 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>Yaru Team, based on the Suru template by Sam Hewitt and original Suru designs by Matthieu James</dc:title>
+            <dc:title>Sam Hewitt</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source />
         <cc:license
            rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
-        <dc:title>Yaru Icon Theme Template</dc:title>
+        <dc:title>Suru Icon Theme Template</dc:title>
         <dc:subject>
           <rdf:Bag />
         </dc:subject>
@@ -338,7 +240,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">workspace-switcher-right-top</tspan></text>
+           id="tspan924">workspace-switcher-right-top</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"
@@ -373,237 +275,69 @@
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
-         id="rect3951"
+         id="rect256x256"
          width="256"
          height="256"
          x="24"
          y="28"
-         inkscape:label="48x48" />
+         inkscape:label="256x256" />
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
+       id="layer2"
+       inkscape:label="Background"
        style="display:inline">
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916214 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 231.80802,268 H 72.191985 c -17.77072,0 -32.19199,-14.42127 -32.19199,-32.19199 V 76.191989 c 0,-17.770721 14.42127,-32.191988 32.19199,-32.191988 H 231.80802 c 17.77072,0 32.19199,14.421267 32.19199,32.191988 V 235.80801 C 264.00001,253.57873 249.57874,268 231.80802,268 Z"
+         fill="url(#a)"
+         id="path27"
+         style="display:inline;fill:url(#linearGradient404);stroke-width:5.16891;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916214 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 360.38914,107 h -32.77829 c -3.64934,0 -6.61086,-2.96151 -6.61086,-6.61086 V 67.610855 C 320.99999,63.961511 323.96151,61 327.61085,61 h 32.77829 C 364.03849,61 367,63.961511 367,67.610855 V 100.38914 C 367,104.03849 364.03849,107 360.38914,107 Z"
+         fill="url(#a)"
+         id="path372"
+         style="display:inline;fill:url(#linearGradient378);stroke-width:1.06147;enable-background:new" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.12858,237.00001 c -3.74357,0 -4.14638,0.30899 -4.12803,3.32331 v 4.17669 4.17668 c -0.0183,3.01433 0.38446,3.32332 4.12803,3.32332 h 7.74335 c 3.7436,0 4.12805,-0.30895 4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 -0.38446,-3.32331 -4.12805,-3.32331 z"
-         id="path918-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="M 346.68858,163 H 325.31143 C 322.93142,163 321,161.06858 321,158.68857 v -21.37715 c 0,-2.38 1.93142,-4.31142 4.31143,-4.31142 h 21.37715 c 2.38,0 4.31142,1.93142 4.31142,4.31142 v 21.37715 C 351,161.06858 349.06858,163 346.68858,163 Z"
+         fill="url(#a)"
+         id="path380"
+         style="display:inline;fill:url(#linearGradient386);stroke-width:0.692265;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 326.45275,189.00048 c -1.2321,0 -2.21668,0.0221 -3.06999,0.14144 -0.85332,0.11937 -1.62809,0.35533 -2.21066,0.83967 -0.58256,0.48436 -0.86983,1.13381 -1.01188,1.84587 -0.14202,0.71207 -0.16501,1.53239 -0.15897,2.56202 v 7.61066 4.6143 c -0.006,1.02762 0.0171,1.84735 0.15897,2.55843 0.14203,0.71208 0.42931,1.36152 1.01188,1.84587 0.58258,0.48434 1.35734,0.7203 2.21066,0.83967 0.85331,0.11936 1.83789,0.14144 3.06999,0.14144 h 11.09542 c 1.2321,0 2.21381,-0.022 3.0657,-0.14144 0.85187,-0.11947 1.62795,-0.35683 2.2085,-0.84146 0.58057,-0.48464 0.86451,-1.13152 1.00758,-1.84228 0.14307,-0.71077 0.16972,-1.5314 0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 -0.0266,-1.84946 -0.16972,-2.56023 -0.14307,-0.71076 -0.42701,-1.35765 -1.00758,-1.84228 -0.58055,-0.48464 -1.35661,-0.722 -2.2085,-0.84147 -0.8519,-0.11947 -1.83359,-0.14144 -3.0657,-0.14144 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
+         d="m 340.19458,211.5 h -16.38915 c -1.82467,0 -3.30543,-1.48076 -3.30543,-3.30543 v -16.38915 c 0,-1.82467 1.48076,-3.30542 3.30543,-3.30542 h 16.38915 c 1.82467,0 3.30542,1.48075 3.30542,3.30542 v 16.38915 c 0,1.82467 -1.48075,3.30543 -3.30542,3.30543 z"
+         fill="url(#a)"
+         id="path388"
+         style="display:inline;fill:url(#linearGradient394);stroke-width:0.530736;enable-background:new" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 329.30094,134 c -1.63949,0 -2.94082,0.0308 -4.04505,0.19141 -1.10422,0.16064 -2.06697,0.4726 -2.78308,1.09179 -0.71611,0.61919 -1.0805,1.45612 -1.26421,2.41407 -0.18374,0.95795 -0.21537,2.08705 -0.20733,3.51171 V 149 v 7.79688 c -0.009,1.42131 0.0239,2.5495 0.20733,3.50585 0.18371,0.95796 0.5481,1.79488 1.26421,2.41407 0.71611,0.61919 1.67886,0.93115 2.78308,1.09179 1.10423,0.16065 2.40556,0.19141 4.04505,0.19141 h 13.40164 c 1.63949,0 2.93835,-0.0307 4.04054,-0.19141 1.10219,-0.16075 2.06274,-0.47425 2.77633,-1.09375 0.71357,-0.6195 1.07457,-1.45363 1.25969,-2.41015 C 350.96429,159.34816 351,158.22066 351,156.79688 V 149 141.20312 c 0,-1.42378 -0.0358,-2.55128 -0.22086,-3.50781 -0.18512,-0.95653 -0.54612,-1.79065 -1.25969,-2.41015 -0.71359,-0.61951 -1.67414,-0.933 -2.77633,-1.09375 C 345.64093,134.03065 344.34207,134 342.70258,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 333.65776,62 c -2.6221,0 -4.68675,0.05009 -6.38561,0.286735 -1.69887,0.236639 -3.08904,0.680503 -4.10735,1.523515 -1.0183,0.843013 -1.55577,1.996072 -1.83828,3.406406 -0.28252,1.410336 -0.33767,3.127346 -0.32482,5.308412 v 12.474816 12.480783 c -0.0127,2.177715 0.0426,3.893853 0.32482,5.302673 0.28251,1.41034 0.81998,2.5634 1.83828,3.40641 1.01831,0.84301 2.40848,1.28688 4.10735,1.52351 1.69888,0.23665 3.76351,0.28674 6.38561,0.28674 h 20.68618 c 2.62213,0 4.68568,-0.05 6.38104,-0.28674 1.69534,-0.23674 3.08126,-0.6821 4.09581,-1.52542 1.01457,-0.84331 1.54885,-1.99555 1.83367,-3.4045 C 366.93929,101.37441 367,99.660878 367,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0608,-3.893733 -0.34554,-5.302677 -0.28482,-1.408942 -0.81911,-2.561177 -1.83368,-3.404494 -1.01455,-0.843317 -2.40047,-1.288685 -4.09582,-1.525427 C 359.02962,62.049992 356.96605,62 354.34394,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,106.50014 c -10.01116,0 -11.88667,-0.90635 -11.83407,-9.748379 V 84.000191 71.248381 C 321.4484,62.40635 323.32401,61.5 333.33517,61.5 h 21.3308 c 10.00866,0 11.83405,0.90625 11.83405,9.748381 v 12.75181 12.75157 c 0,8.842129 -1.82539,9.748379 -11.83406,9.748379 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3155);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 225.07296,268 c 35.29673,0 39.09461,-3.62542 38.92162,-38.99353 V 156 82.993524 c 0.17299,-35.36812 -3.62489,-38.99353 -38.92162,-38.99353 H 78.916206 c -35.29671,0 -38.92161,3.625 -38.92161,38.99353 V 156 229.00647 c 0,35.36853 3.6249,38.99353 38.92161,38.99353 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 326.17688,211.502 c -5.14666,0 -5.70043,-0.43262 -5.67521,-4.65309 v -5.84793 -7.84761 c -0.0253,-4.22046 0.52855,-4.65307 5.67521,-4.65307 h 11.64568 c 5.14665,0 5.67521,0.43255 5.67521,4.65307 v 7.84761 5.84793 c 0,4.22051 -0.52857,4.65309 -5.67522,4.65309 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.4056,236.50001 c -3.47604,0 -3.85006,0.30899 -3.83302,3.32331 v 4.17669 4.17668 c -0.017,3.01433 0.35698,3.32332 3.83302,3.32332 h 7.18996 c 3.47605,0 3.83303,-0.30895 3.83303,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.35699,-3.32331 -3.83303,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,162.5 c -6.45163,0 -7.6603,-0.58409 -7.62639,-6.28227 v -8.21765 -8.21781 c -0.034,-5.69818 1.17476,-6.28227 7.62639,-6.28227 h 13.74651 c 6.45003,0 7.62639,0.58403 7.62639,6.28227 v 8.21781 8.21765 c 0,5.69824 -1.17636,6.28227 -7.62639,6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+         d="m 333.34429,251.5 h -10.68857 c -1.19001,0 -2.15572,-0.96571 -2.15572,-2.15571 v -10.68858 c 0,-1.19 0.96571,-2.15571 2.15572,-2.15571 h 10.68857 c 1.19,0 2.15571,0.96571 2.15571,2.15571 v 10.68858 c 0,1.19 -0.96571,2.15571 -2.15571,2.15571 z"
+         fill="url(#a)"
+         id="path396"
+         style="display:inline;fill:url(#linearGradient402);stroke-width:0.346132;enable-background:new" />
     </g>
     <g
        inkscape:groupmode="layer"
        id="layer6"
-       inkscape:label="Pictograms and folds"
+       inkscape:label="Pictogram"
        style="display:inline">
       <path
-         sodipodi:nodetypes="sssssssss"
-         inkscape:connector-curvature="0"
-         id="path983"
-         d="m 351.93111,62.499886 c 13.62163,0 15.56836,1.94187 15.56836,15.55078 v 11.89844 c 0,13.608864 -1.94673,15.550784 -15.56836,15.550784 h -15.86327 c -13.62162,0 -15.56836,-1.94192 -15.56836,-15.550784 v -11.89844 c 0,-13.60891 1.94674,-15.55078 15.56836,-15.55078 z"
-         style="display:inline;opacity:1;fill:url(#linearGradient986);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+         id="path362"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:5.16891"
+         d="m 224.67952,58.764722 -17.91959,0.09087 0.0207,5.017479 -9.65134,0.05066 c -9.30922,0.06203 -16.83071,7.631098 -16.76868,16.940298 l 0.19176,33.688801 c 0.062,9.30403 7.64633,16.8307 16.95037,16.76867 l 37.25251,-0.21203 c 9.30404,-0.062 16.81055,-7.65645 16.74852,-16.96049 l -0.20211,-33.688791 c -0.0465,-9.28852 -7.63629,-16.79969 -16.94033,-16.768677 l -9.68158,0.07066 z m 7.05675,19.736767 c 4.81743,-0.0155 8.77237,3.87435 8.80328,8.71244 0.031,4.8381 -3.87431,8.7622 -8.71241,8.79321 -4.8381,0.0362 -8.77232,-3.86426 -8.80333,-8.70235 -0.0155,-4.81741 3.87436,-8.77229 8.71246,-8.8033 z m -29.85249,0.2019 c 4.8226,-0.0517 8.7777,3.86473 8.7932,8.68215 0.0517,4.82259 -3.86965,8.76761 -8.69225,8.78312 -4.82259,0.0517 -8.76761,-3.85958 -8.78312,-8.68216 -0.0465,-4.81742 3.86475,-8.76761 8.68217,-8.78311 z" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 355.83925,84.026101 c -1.14882,0 -0.94111,-0.0028 -2.2455,-0.02591 -1.44422,0 1.18767,0.02173 0,0 H 351.3125 344 v -9.701172 c 0,2.388672 0,1.17755 0,0 -7.5e-4,-2.111408 -7.5e-4,-0.962598 -7.5e-4,-2.111408 0,-1.14881 0,0 -0.005,-1.851021 0.006,-0.635388 0.006,-3.0239 0.006,-0.635228 V 61.50019 h 10.66602 c 10.00866,0 11.83398,0.90592 11.83398,9.748047 V 84.00019 h -0.10742 -5.70508 -2.49609 c 1.72157,0 1.15088,0 0,0 -0.9566,0.01734 -1.20335,0.02591 -2.35216,0.02591 z"
-         id="path21860"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccscccsscccccs" />
+         id="path374"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:1.06147"
+         d="m 358.92525,64.032041 -3.67991,0.01866 0.004,1.030375 -1.98197,0.0104 c -1.91172,0.01274 -3.45631,1.5671 -3.44357,3.478811 l 0.0394,6.918236 c 0.0127,1.910649 1.57023,3.456304 3.48088,3.443566 l 7.65007,-0.04354 c 1.91065,-0.01273 3.45216,-1.572307 3.43942,-3.482958 l -0.0415,-6.918234 c -0.01,-1.907464 -1.56817,-3.449936 -3.47882,-3.443567 l -1.98818,0.01451 z m 1.44916,4.053086 c 0.98929,-0.0032 1.80147,0.795626 1.80781,1.789162 0.006,0.993538 -0.79561,1.79938 -1.78915,1.805748 -0.99354,0.0074 -1.80146,-0.793553 -1.80783,-1.787089 -0.003,-0.98929 0.79563,-1.801453 1.78917,-1.807821 z m -6.13042,0.04146 c 0.99035,-0.01062 1.80256,0.79365 1.80574,1.782941 0.0106,0.990354 -0.79466,1.800492 -1.78501,1.803677 -0.99036,0.01062 -1.80049,-0.792593 -1.80368,-1.782944 -0.01,-0.989291 0.79365,-1.800491 1.78295,-1.803674 z" />
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 344.00075,96.026103 c 0,-1.14882 -2e-5,-0.702038 -7.5e-4,-2.432163 0,-1.550883 0,-2.28125 0,0 v -2.28125 -7.3125 h 9.59375 c -2.28125,10e-7 -1.11481,-0.01995 0,10e-7 1.27776,0.02287 1.09669,0.02591 2.2455,0.02591 1.14881,0 0.62235,-0.0011 2.35216,-0.02591 0.67088,0 1.32157,0 0,0 h 8.20117 V 94.66621 c 0,10.00866 -0.90592,11.83398 -9.74805,11.83398 H 344 v -0.10742 -5.70508 -2.49609 c 0,1.721567 0,1.310883 0,0 7.5e-4,-2.165497 7.5e-4,-1.016687 7.5e-4,-2.165497 z"
-         id="path21860-7"
-         sodipodi:nodetypes="scccccsscccsscccccs" />
+         id="path382"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:0.692265"
+         d="m 345.73387,134.97742 -2.39995,0.0122 0.003,0.67198 -1.29259,0.007 c -1.24677,0.008 -2.25411,1.02203 -2.2458,2.26879 l 0.0257,4.5119 c 0.008,1.24607 1.02406,2.25411 2.27014,2.2458 l 4.98917,-0.0284 c 1.24608,-0.008 2.25142,-1.02541 2.24311,-2.27149 l -0.0271,-4.51189 c -0.006,-1.244 -1.02272,-2.24996 -2.26879,-2.24581 l -1.29664,0.009 z m 0.9451,2.64331 c 0.64519,-0.002 1.17487,0.51889 1.17901,1.16685 0.004,0.64796 -0.51888,1.17351 -1.16684,1.17766 -0.64796,0.005 -1.17487,-0.51754 -1.17902,-1.16549 -0.002,-0.64519 0.51889,-1.17486 1.16685,-1.17902 z m -3.9981,0.027 c 0.64588,-0.007 1.17558,0.5176 1.17766,1.16279 0.007,0.64588 -0.51826,1.17423 -1.16414,1.17631 -0.64589,0.007 -1.17424,-0.51691 -1.17631,-1.16279 -0.006,-0.64519 0.5176,-1.17423 1.16279,-1.17631 z" />
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 343.99925,72.18761 c 0,1.14882 0.0588,0.807945 7.5e-4,2.111408 0,1.364217 0,2.388672 0,0.107422 v 2.28125 7.3125 h -9.70117 c 0.8149,-1.67376 1.11492,0.01188 0,0 -2.43216,-0.02591 -1.28335,-0.02591 -2.43216,-0.02591 -1.14881,0 -0.80865,0.0016 -2.1655,0.02591 -1.68422,0 -0.8149,-1.67376 0,0 H 321.5 V 73.33417 c 0,-10.00866 0.90592,-11.83398 9.74805,-11.83398 H 344 v 0.10742 5.70508 2.49609 c 0,-2.49609 0,-1.684217 0,0 -0.022,1.916797 -7.5e-4,1.23002 -7.5e-4,2.37883 z"
-         id="path21860-7-4"
-         sodipodi:nodetypes="scccccsscccsscccccs" />
+         id="path390"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:0.530736"
+         d="m 339.46263,190.01602 -1.83996,0.009 0.002,0.51519 -0.99099,0.005 c -0.95585,0.006 -1.72815,0.78355 -1.72178,1.7394 l 0.0197,3.45912 c 0.006,0.95533 0.78511,1.72815 1.74044,1.72178 l 3.82503,-0.0218 c 0.95533,-0.006 1.72609,-0.78615 1.71972,-1.74148 l -0.0207,-3.45911 c -0.005,-0.95373 -0.78409,-1.72497 -1.73941,-1.72179 l -0.99409,0.007 z m 0.72458,2.02654 c 0.49465,-0.002 0.90073,0.39781 0.90391,0.89458 0.003,0.49677 -0.39781,0.89969 -0.89458,0.90288 -0.49677,0.004 -0.90073,-0.39678 -0.90391,-0.89355 -0.002,-0.49464 0.39781,-0.90073 0.89458,-0.90391 z m -3.06521,0.0207 c 0.49518,-0.005 0.90128,0.39683 0.90287,0.89147 0.005,0.49518 -0.39733,0.90025 -0.89251,0.90184 -0.49517,0.005 -0.90024,-0.3963 -0.90183,-0.89147 -0.005,-0.49465 0.39682,-0.90025 0.89147,-0.90184 z" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 336,162.5 v -0.0684 -3.67773 -2.15625 c -0.39707,0.2396 0,0 0,0 v 0 c -0.0689,-1.56883 8.4e-4,-0.46566 -0.0689,-1.56883 C 335.8605,153.92561 336,151.98801 336,153.27708 V 153.40039 148 h 14.43164 v 6.87305 c 0,6.45002 -0.58494,7.62695 -6.2832,7.62695 z"
-         id="path21860-7-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccssc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 321.5,148 v -6.87305 c 0,-6.45002 0.58299,-7.62695 6.28125,-7.62695 H 336 v 0.0684 5.83203 0 c 0.0324,1.62844 0.10302,0.52526 0.0324,1.62844 -0.0697,1.10317 0,0 -0.0324,1.56879 v 0 c 0,0 0.39705,0.23961 0,0 V 148 h -5.40039 c 0.28091,-0.4674 1.078,0 0,0 v 0 c -1.11072,-0.0261 -0.48948,-0.0667 -1.59208,0.004 -1.10317,0.0697 0,0 -1.60519,-0.004 0,0 -0.78535,0 0,0 z"
-         id="path21860-7-4-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csscccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 347.32997,148 c -4.32244,0 -4.2756,0.003 -4.32244,0 -1.10317,-0.0697 0,0 -1.60519,0 0,0 1.60519,0 0,0 H 336 v -5.40234 0 l 0.0324,-1.56879 c 0,0 -0.0697,1.10317 0,0 0.0706,-1.10318 -0.0324,1.56879 0,0 C 336,142.59766 336,139.40043 336,139.40039 V 133.5 h 6.87305 c 6.45002,0 7.62695,0.58299 7.62695,6.28125 V 148 h -0.0684 -5.83203 c 0,0 -1.59204,0 0,0 v 0 c 1.25436,0 -0.54297,-0.0251 -1.59204,0 z"
-         id="path21860-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccssccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 332,211.50145 v -0.0547 -2.91601 -1.71094 c 0,0.461 -0.0485,-0.74669 0,0 v 0 c 0,1.06355 0.0724,-0.28481 0.0171,-1.15974 -0.056,-0.87494 0,0 -0.0172,-1.37542 0,-0.58634 0,-0.6357 0,0 v -4.28319 h 11.44531 l 0.0527,0.19727 v 0.80273 5.84766 c 0,4.22051 -0.52913,4.65234 -5.67578,4.65234 z m 0,-11.5 h -4.2832 c 0.22279,-0.3707 0.87021,0 0,0 v 0 c -1.28509,0.004 -0.41061,-0.0517 -1.28509,0.004 -0.87493,0.0553 0,0 -1.25007,-0.004 0.64941,0.0127 -0.59026,0 0,0 h -4.67969 v -6.84766 c -0.0253,-4.22046 0.52912,-4.65429 5.67578,-4.65429 h 5.81446 l 0.008,0.002 v 0.0547 4.625 c 5e-5,-0.60989 0,0 0,0 -0.0301,1.27219 0.0259,0.39726 -0.0301,1.27219 0.009,0.86203 0.003,0.26196 0.0301,1.26291 v 0 c -4e-5,0.7959 -0.17546,-0.70023 -5e-5,5e-5 z"
-         id="path21860-7-7-4"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccssccccccccccscccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 337.57136,200.00145 c -0.0372,9.6e-4 2.6684,0 0,0 -0.87493,-0.0553 0,0 -1.28622,0 -0.7704,-4e-5 1.28622,0 2e-5,-4e-5 H 332 v -4.28516 c 0,0.57713 -0.0286,-1.12293 0,0 v 0 c -0.0301,-1.26291 -0.0854,-0.38798 -0.0301,-1.26291 0.056,-0.87494 0.0301,-2.18232 0.0301,-1.27219 0,0 0,-0.58415 5e-5,-5e-5 v -4.67965 l 0.008,-0.002 h 5.81446 c 5.14665,0 5.67578,0.43377 5.67578,4.65429 v 6.84771 h -0.0527 -4.625 c 0.85505,0 0,0 0,0 v 0 c -1.24923,0 -0.41721,-0.0199 -1.24923,0 z"
-         id="path21860-4-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccssccccccc" />
-      <path
-         style="display:inline;opacity:1;vector-effect:none;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 207.25338,155.84483 c -15.38671,0.0215 -40.32005,0.15483 -7.25338,0.15486 l -48,-5e-5 v -47.99995 c 0,0 -0.15987,7.67972 -0.15987,-8.320276 0,-16 0.15987,-7.67972 0.15987,-7.67972 v -48 h 73.07226 c 35.29673,0 39.09486,3.62602 38.92187,38.99414 v 73.005856 h -47.99414 c 30,0 7.86667,-0.13333 -8.74661,-0.15486 z"
-         id="rect1772-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccscccc" />
-      <path
-         style="display:inline;opacity:0.1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 152.01079,210.58664 c -0.0215,-15.38672 -0.0215,-32.98672 -0.0215,-6.58672 l 5e-5,-48 h 47.99995 c -29.86667,-2.6e-4 -8.73586,-0.15509 7.26412,-0.15509 16,0 35.66919,0.15486 8.73586,0.15509 h 48 v 73.07227 c 0,35.29673 -3.62602,39.09486 -38.99414,38.92187 h -73.00584 v -47.99414 c 0,29.06667 0,7.2 0.0215,-9.41328 z"
-         id="rect1772-7-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccscccc" />
-      <path
-         style="display:inline;opacity:0.1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 151.84013,99.679414 c 0.0215,15.386716 0.0215,0.853376 0.15486,8.320046 l -5e-5,48 h -47.99995 c 30.4,0 7.86667,0.13333 -8.133334,0.13333 -16,0 -36.66666,-0.13333 -7.86666,-0.13333 h -48 V 82.927194 c 0,-35.29673 3.62602,-39.09486 38.99414,-38.92187 h 73.005854 v 47.99414 c 0,9.466666 -0.13333,-8.93333 -0.15486,7.67995 z"
-         id="rect1772-7-5-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccscccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 331.43967,245.51592 c 0,0 0.0259,0.001 0,0 -0.60876,-0.0385 0,0 -1.05779,-0.0134 -0.51703,0 0,0 0,0 h -3.38131 v -3.48161 c 0,0.62259 0,0.38165 0,0 v 0 c -0.0141,-0.9152 -0.0526,-0.30643 -0.0141,-0.9152 0.0389,-0.60877 0.0138,-0.84871 0,0 -8.3e-4,0.4504 0,0 0.0138,-0.84871 v -3.256 l 0.005,-0.001 h 4.44536 c 3.58093,0 3.94909,0.30181 3.94909,3.23836 v 5.26457 h -0.0367 -3.21797 c 0,0 0.43874,0 0,0 v 0 c 0.95055,0 -0.12648,-8.5e-4 -0.70538,0.013 z"
-         id="path21860-4-1-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccsscccccc" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer4"
-       inkscape:label="Borders"
-       style="display:inline;opacity:1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.921876,43.999698 c -35.29673,0 -39.09487,3.62603 -38.92188,38.99414 v 2 c -0.17299,-35.36811 3.62515,-38.99414 38.92188,-38.99414 H 225.07811 c 35.29673,0 38.92188,3.62561 38.92188,38.99414 v -2 c 0,-35.36853 -3.62515,-38.99414 -38.92188,-38.99414 z"
-         id="path931"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.927276,267.9997 c -35.29673,0 -39.09488,-3.62603 -38.92189,-38.99414 v -2 c -0.17299,35.36811 3.62516,38.99414 38.92189,38.99414 H 225.08351 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 c 0,35.36853 -3.62515,38.99414 -38.92188,38.99414 z"
-         id="path931-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500047 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 V 84 96.75181 c -0.0527,8.84203 1.82291,9.74838 11.83407,9.74838 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 337.97659,211.50015 c 4.67187,0 5.5471,-0.42296 5.52255,-4.54923 v -7.95037 -5.95084 c 0.0245,-4.12627 -0.85068,-4.54923 -5.52255,-4.54923 h -11.95364 c -4.67071,0 -5.52256,0.42291 -5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 0.85185,4.54923 5.52256,4.54923 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.55494,251.5 c 3.33705,0 3.96221,-0.30212 3.94468,-3.24946 v -4.2505 -4.25059 c 0.0175,-2.94734 -0.60763,-3.24945 -3.94468,-3.24945 h -7.11025 c -3.33622,0 -3.94469,0.30208 -3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 0.60847,3.24946 3.94469,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </g>
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline;opacity:0.3">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.44531,251.49998 c -1.65302,0 -2.54604,-0.12548 -2.91601,-0.41406 -0.18499,-0.14429 -0.30479,-0.33122 -0.39649,-0.70313 C 321.04111,250.01088 321,249.46962 321,248.74998 v -4.25 -4.25 c 0,-0.71964 0.0411,-1.26082 0.13281,-1.63281 0.0917,-0.37191 0.2115,-0.55884 0.39649,-0.70313 0.36997,-0.28858 1.26299,-0.41406 2.91601,-0.41406 h 7.10938 c 1.65343,0 2.55203,0.12511 2.92383,0.41406 0.18589,0.14448 0.30578,0.33208 0.39648,0.70313 0.0907,0.37105 0.129,0.90979 0.125,1.6289 v 0.002 4.25191 4.25195 0.002 c 0.004,0.71911 -0.0343,1.25785 -0.125,1.6289 -0.0907,0.37105 -0.21059,0.55865 -0.39648,0.70313 -0.37179,0.2889 -1.2704,0.41402 -2.92383,0.41402 z m 5.32813,-1.04688 c 1.10767,3.4e-4 2.21363,-0.008 3.32031,-0.0449 0.26616,-0.0599 0.75737,0.0208 0.79297,-0.3457 0.13405,-1.84438 0.0662,-3.68774 0.10156,-5.53906 -0.0126,-1.86745 0.0543,-3.67031 -0.10351,-5.49805 0.0642,-0.42314 -0.43946,-0.35577 -0.70313,-0.42187 -3.43277,-0.0703 -6.87577,-0.0589 -10.29883,-0.002 -0.22288,0.0398 -0.55622,3.2e-4 -0.71093,0.1875 -0.19863,1.12995 -0.12696,2.26946 -0.16016,3.41992 0.0138,2.55648 -0.029,5.10728 0.0898,7.65625 -0.03,0.2727 0.10944,0.49629 0.40039,0.48829 1.30659,0.161 2.63265,0.0636 3.94727,0.0976 1.10718,-0.006 2.21655,0.002 3.32422,0.002 z"
-         id="path918-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate"
-         d="m 326.02383,189.00048 c -2.32027,0 -3.60941,0.15494 -4.20703,0.62109 -0.29882,0.23308 -0.48964,0.54668 -0.625,1.09571 -0.13541,0.54902 -0.19141,1.31765 -0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 0.056,1.783 0.19141,2.33203 0.13536,0.54903 0.32618,0.86263 0.625,1.09571 0.59762,0.46615 1.88676,0.62109 4.20703,0.62109 h 11.9524 c 2.32085,0 3.61652,-0.15457 4.2168,-0.62109 0.30014,-0.23327 0.49095,-0.54754 0.625,-1.09571 0.13404,-0.54816 0.18764,-1.31623 0.18164,-2.33008 v -7.95279 -5.95312 c 0.006,-1.01386 -0.0476,-1.78191 -0.18164,-2.33008 -0.13406,-0.54817 -0.32486,-0.86244 -0.625,-1.09571 -0.60028,-0.46652 -1.89595,-0.62109 -4.2168,-0.62109 z m 4.95859,1.00977 c 1.5798,-0.002 4.16014,-3.9e-4 5.73991,0.0117 1.50021,0.0511 3.02236,-0.0712 4.5,0.28321 0.55111,0.0919 0.61303,0.71807 0.67773,1.16601 0.1117,4.30832 0.075,10.62608 0.0508,14.94108 -0.0716,0.99089 0.13687,2.07606 -0.30078,3.01366 -0.34356,0.40964 -0.9694,0.35958 -1.45117,0.45509 -3.95407,0.0823 -9.92936,0.0499 -13.89381,0.0371 -1.16908,-0.0622 -2.37292,0.11291 -3.51758,-0.22266 -0.57935,-0.098 -0.6137,-0.75914 -0.6875,-1.2207 -0.1146,-4.11835 -0.0751,-10.24472 -0.0547,-14.36881 0.0572,-1.06305 -0.0797,-2.16734 0.18164,-3.21485 0.10495,-0.6386 0.8614,-0.66043 1.36719,-0.74023 2.1305,-0.19658 5.24071,-0.10662 7.38828,-0.14062 z"
-         id="path914-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12695,134 c -3.21072,0 -5.03255,0.19514 -5.9375,0.89844 -0.45247,0.35165 -0.74178,0.83286 -0.93359,1.61718 -0.19176,0.78433 -0.26386,1.85686 -0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c -0.008,1.40682 0.0641,2.47935 0.25586,3.26368 0.1918,0.78431 0.48112,1.26553 0.93359,1.61718 0.90496,0.7033 2.72678,0.89844 5.9375,0.89844 h 13.7461 c 3.20992,0 5.02461,-0.19551 5.92578,-0.89844 0.45058,-0.35146 0.73805,-0.83201 0.93164,-1.61718 C 349.9241,158.69918 350,157.62415 350,156.2168 V 148 139.7832 c 0,-1.40735 -0.0759,-2.48237 -0.26953,-3.26758 -0.19359,-0.78517 -0.48106,-1.26572 -0.93164,-1.61718 C 347.89766,134.19551 346.08297,134 342.87305,134 Z m 6.49805,1.04688 c 3.45647,0.0171 6.9142,-0.0268 10.36133,0.0918 0.8211,0.13276 1.80664,0.14835 2.39062,0.82617 0.67884,1.16473 0.51296,2.58781 0.56446,3.87305 0.0431,6.02893 0.0678,12.06719 -0.0332,18.08789 -0.0775,0.77792 -0.12055,1.67263 -0.67968,2.27539 -0.70249,0.51038 -1.61833,0.59683 -2.45899,0.67383 -4.04742,0.0864 -8.16222,0.0456 -12.24023,0.0606 -2.45188,-0.0199 -4.91402,0.0317 -7.35352,-0.0606 -0.87784,-0.12055 -1.915,-0.14021 -2.56055,-0.83398 -0.64775,-1.02591 -0.50264,-2.30525 -0.56054,-3.46485 -0.035,-5.65575 -0.0351,-11.35518 0,-17.00976 0.0632,-1.22153 -0.10864,-2.57724 0.59179,-3.65235 0.6025,-0.62665 1.55621,-0.63986 2.35938,-0.77344 2.73743,-0.10739 5.48083,-0.0704 8.22656,-0.0918 0.46403,-2.9e-4 0.92855,-0.002 1.39258,-0.002 z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33594,62 c -4.99049,0 -7.87051,0.276282 -9.38477,1.453125 -0.75713,0.588421 -1.23761,1.403518 -1.54492,2.660156 -0.3073,1.256638 -0.4173,2.940031 -0.4043,5.132813 V 84 96.753906 c -0.0131,2.19278 0.097,3.876174 0.4043,5.132814 0.30731,1.25663 0.78779,2.07172 1.54492,2.66016 1.51427,1.17683 4.39428,1.45312 9.38477,1.45312 h 21.33008 c 4.98923,0 7.85502,-0.27668 9.36328,-1.45312 0.75412,-0.58824 1.23293,-1.40461 1.54297,-2.66211 C 365.8823,100.62727 366,98.945281 366,96.751953 V 84 71.248047 c 0,-2.193329 -0.1177,-3.875313 -0.42773,-5.132813 -0.31004,-1.257499 -0.78884,-2.073874 -1.54297,-2.662109 C 362.52104,62.276656 359.65526,62 354.66602,62 Z m 2.40234,1.097656 c 6.94737,8.3e-4 13.91063,0.0034 20.84961,0.05469 2.14296,0.08293 4.46431,-0.147701 6.42383,0.93164 1.29609,0.695228 1.54862,2.250325 1.76953,3.564454 0.17551,2.202888 0.0915,4.442228 0.13867,6.669921 0.0227,8.479532 0.077,16.968993 -0.0801,25.447266 -0.16151,1.483233 -0.38135,3.305793 -1.79882,4.142573 -1.6055,0.82871 -3.47551,0.90643 -5.24805,0.95313 -9.49974,0.0678 -19.0243,0.0843 -28.52344,-0.0176 -1.57816,-0.11413 -3.27053,-0.24014 -4.63281,-1.12109 -1.22952,-0.99538 -1.36082,-2.72739 -1.50391,-4.193361 -0.1272,-8.998585 -0.0836,-18.004484 -0.0527,-27.007813 0.0997,-2.381275 -0.24538,-4.900002 0.70508,-7.160156 0.67165,-1.50972 2.46573,-1.859954 3.93945,-2.05664 2.66168,-0.316582 5.34184,-0.147022 8.01367,-0.207032 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
+         id="path398"
+         style="display:inline;enable-background:new;fill:#ffffff;stroke-width:0.346132"
+         d="m 332.86693,237.48871 -1.19997,0.006 10e-4,0.33599 -0.6463,0.003 c -0.62338,0.004 -1.12705,0.51101 -1.1229,1.13439 l 0.0128,2.25595 c 0.004,0.62304 0.51203,1.12705 1.13507,1.1229 l 2.49459,-0.0142 c 0.62304,-0.004 1.12571,-0.51271 1.12155,-1.13574 l -0.0135,-2.25595 c -0.003,-0.622 -0.51136,-1.12498 -1.1344,-1.1229 l -0.64832,0.005 z m 0.47255,1.32166 c 0.3226,-0.001 0.58744,0.25944 0.58951,0.58342 0.002,0.32398 -0.25944,0.58675 -0.58342,0.58883 -0.32398,0.002 -0.58743,-0.25877 -0.58951,-0.58275 -10e-4,-0.32259 0.25944,-0.58743 0.58342,-0.5895 z m -1.99905,0.0135 c 0.32295,-0.003 0.5878,0.2588 0.58883,0.58139 0.003,0.32294 -0.25912,0.58712 -0.58207,0.58816 -0.32294,0.003 -0.58711,-0.25846 -0.58815,-0.5814 -0.003,-0.32259 0.2588,-0.58712 0.58139,-0.58815 z" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
- calendar-app
- calls-app
- clock-app
- configurator-app
- disk-usage-app
- disk-utility-app
- evince
- file-roller
- gallery-app
- games-app
- gparted
- image-viewer
- libreoffice-base
- libreoffice-calc
- libreoffice-draw
- libreoffice-impress
- libreoffice-main
- libreoffice-math
- libreoffice-startcenter
- libreoffice-writer
- log-viewer-app
- maps-app
- mediaplayer-app
- scanner
- screenshot-app
- session-properties
- software-store
- wine
- winetricks
- workspace-switcher-left-bottom
- workspace-switcher-left-top
- workspace-switcher-right-bottom
- workspace-switcher-right-top