### PR TITLE
Fix meson build script

### DIFF
--- a/icons/meson.build
+++ b/icons/meson.build
@@ -356,7 +356,7 @@ foreach flavour: icon_flavors
         '-mindepth', '2',
         '-maxdepth', '2',
         '-printf', '%P\\n',
-        check: true
+        check: false
       ).stdout().strip()
       dark_categories = dark_categories != '' ? dark_categories.split('\n') : []
 


### PR DESCRIPTION
- Update meson build script to fix build failure for dark icons. Since there is no dark icons, meson build was failing while checking for dark icons.